### PR TITLE
trainスキーマの各パラメータにデフォルト値を追加

### DIFF
--- a/VanillaSchema/train.yml
+++ b/VanillaSchema/train.yml
@@ -80,31 +80,42 @@ properties:
   properties:
   - key: weight
     type: integer
+    default: 40
 - key: fluidContainer
   type: object
   properties:
   - key: weight
     type: integer
+    default: 40
 - key: motionParameters
   type: object
   properties:
   # Divided by 10000000
   - key: friction
     type: integer
+    default: 35300
   # Divided by 10000000
   - key: airResistance
     type: integer
+    default: 117
   - key: speedWeight
     type: number
+    default: 0.09
   - key: autoRunMaxSpeedDistanceCoefficient
     type: number
+    default: 10000.0
   - key: autoRunMaxSpeedOffset
     type: number
+    default: 10.0
   - key: autoRunSpeedBufferMargin
     type: number
+    default: 0.02
   - key: tractionForceAccelerationRate
     type: number
+    default: 0.1
   - key: manualControlDecelerationFactor
     type: number
+    default: 1.0
   - key: masconLevelMaximum
     type: integer
+    default: 16777216

--- a/moorestech_server/Assets/Scripts/Core.Master/_CompileRequester.cs
+++ b/moorestech_server/Assets/Scripts/Core.Master/_CompileRequester.cs
@@ -5,5 +5,5 @@ public class CompileRequester
 {
 // スキーマを更新したら、こちらの更新もコミットしてください。
 // If you update the schema, please also commit this update.
-    private const string dummyText = "2026/04/05 18:34:17";
+    private const string dummyText = "2026/04/11 train-default-values";
 }


### PR DESCRIPTION
## Summary
- trainスキーマ（`VanillaSchema/train.yml`）のitemContainer, fluidContainer, motionParametersの各プロパティにデフォルト値を追加
- weight, friction, airResistance, speedWeight, autoRunMaxSpeedDistanceCoefficient, autoRunMaxSpeedOffset, autoRunSpeedBufferMargin, tractionForceAccelerationRate, manualControlDecelerationFactor, masconLevelMaximum にそれぞれデフォルト値を設定
- `_CompileRequester.cs` のダミーテキストを更新してソース生成をトリガー

## Test plan
- [ ] サーバーコンパイルが成功することを確認
- [ ] ソースジェネレータが正しくデフォルト値を含むコードを生成することを確認
- [ ] デフォルト値が未設定のマスターJSONでもパラメータが正しくロードされることを確認

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build timestamp reference.

**Note:** This release contains no user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->