### PR TITLE
ビルドの最大並列数を2に変更

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       fail-fast: false
-      max-parallel: 1
+      max-parallel: 2
       matrix:
         platform:
           # ==========================================
@@ -119,7 +119,7 @@ jobs:
 
     strategy:
       fail-fast: false
-      max-parallel: 1
+      max-parallel: 2
       matrix:
         platform:
           # ==========================================


### PR DESCRIPTION
## Summary
- サーバービルド・クライアントビルドともに `max-parallel` を 1 → 2 に変更
- CI全体の実行時間を短縮（82分 → 推定50分程度）

## 変更点
- `server-build` ジョブ: `max-parallel: 1` → `max-parallel: 2`
- `client-build` ジョブ: `max-parallel: 1` → `max-parallel: 2`

## Test plan
- [ ] CIが正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)