### PR TITLE
ワールドセーブをアトミック書き込み化してクラッシュ破損を防ぐ

### DIFF
--- a/moorestech_server/Assets/Scripts/Game.SaveLoad/Json/WorldSaverForJson.cs
+++ b/moorestech_server/Assets/Scripts/Game.SaveLoad/Json/WorldSaverForJson.cs
@@ -16,7 +16,26 @@ namespace Game.SaveLoad.Json
         
         public void Save()
         {
-            File.WriteAllText(_filePath.Path, _assembleSaveJsonText.AssembleSaveJson());
+            // 書き込み途中のクラッシュでセーブが破損しないようアトミックに書き込む
+            // Write atomically so a mid-write crash cannot corrupt the save file
+            var targetPath = _filePath.Path;
+            var tmpPath = targetPath + ".tmp";
+            var backupPath = targetPath + ".bak";
+
+            // まず一時ファイルへ全内容を書き切る
+            // First write the full contents to a temporary file
+            File.WriteAllText(tmpPath, _assembleSaveJsonText.AssembleSaveJson());
+
+            // 既存ファイルがあれば直前バックアップ付きで置換、無ければ単純に移動
+            // Replace existing file with a prior-version backup, or move directly on first save
+            if (File.Exists(targetPath))
+            {
+                File.Replace(tmpPath, targetPath, backupPath);
+            }
+            else
+            {
+                File.Move(tmpPath, targetPath);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- `WorldSaverForJson.Save` を一時ファイル + `File.Replace` によるアトミック置換に変更
- 既存セーブは `.bak` として直前バックアップを残し、書き込み途中のクラッシュでも破損しないようにした
- 初回保存時は `File.Move` で単純リネーム

## Test plan
- [ ] 既存ワールドで通常セーブが問題なく行えること
- [ ] 新規ワールド作成から初回セーブが成功すること
- [ ] セーブ後に `.bak` が直前状態として保持されていること
- [ ] `.tmp` が残留しないこと

Generated with [Claude Code](https://claude.com/claude-code)