### PR TITLE
ブロック回転処理のSerializeReference化とプレハブ/シーン更新

### DIFF
--- a/.claude/skills/unity-runtime-bug-hunt/SKILL.md
+++ b/.claude/skills/unity-runtime-bug-hunt/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: unity-runtime-bug-hunt
+description: Unity Editor PlayMode 中のランタイム挙動不具合・例外・応答不能の原因特定スキル。uloop execute-dynamic-code でランタイム状態を広く浅くダンプし、JetBrains Rider debugger で狭く深く変数/BPヒットを観測する。TRIGGER when: (1) ユーザーのメッセージに PlayMode 実行時のランタイム例外スタックトレースが貼られている（NullReferenceException / TimeoutException / IndexOutOfRangeException 等）(2) 「〇〇するとエラー/例外が出る」「破壊/生成したら固まった」などプレイ操作と異常の因果が絡む (3) クライアント-サーバー通信のタイムアウト・応答 null・"Receive null"・パケット未返信・サーバー固まり (4) 「動かない」「反応しない」「呼ばれない」「途中で止まる」「期待した動きにならない」「なぜ〇〇にならない？」といった実行フロー系 (5) 「ランタイム状態/実行中のインスタンスを見て」「実行中のコンポーネント状態を確認」 (6) null の直接源は分かるが、なぜその値が null かがランタイム状態依存（別スレッド/サーバー側/非同期/他インスタンス）。ユーザーが "debug" / "breakpoint" を明示しなくても上記いずれかに該当すれば起動する。SKIP when: (a) コンパイルエラーや型エラー（静的バグ） (b) null の原因が静的初期化漏れと即特定できる（フィールド未初期化がソース読むだけで自明等） (c) テスト入力値の誤りなどコード読解だけで完結するケース。迷ったら起動する（起動コスト低、起動漏れコスト高）。
+---
+
+# unity-runtime-bug-hunt
+
+## 前提条件
+
+- Unity Editor がPlayModeで起動中、かつJetBrains RiderがUnityプロセスにアタッチ済み（`mcp__rider-debugger__list_debug_sessions` で `state: running` のセッションが見えること）
+- `uloop` CLI が install 済み（`uloop --version` で確認、無ければ対象プロジェクトの README に従って install）、対象プロジェクトに `--project-path` でアクセス可能
+- 対象コードのクラス名・namespace・フィールド名を `Grep` / `Read` で直接確認できる前提（= Debugger の実行時型情報だけに頼らない）
+
+## 基本原則
+
+**ツールの役割を混同しない。** 混同すると Unity が busy 化したり、存在しないバグを追って時間を溶かす。
+
+| 問い | 使うツール | 理由 |
+|---|---|---|
+| 今どんなインスタンスがどこに存在するか？ | `execute-dynamic-code` | コレクション全走査が1コールで済む |
+| 各インスタンスのフィールド値・インベントリ・参照関係は？ | `execute-dynamic-code` | property getter / LINQ / 拡張メソッドが全部使える |
+| このメソッドは呼ばれているか？ | Rider BP | `hitCount` が決定的証拠 |
+| この時点での引数・ローカル変数は何？ | Rider `get_variables` / `evaluate_expression` | そのフレーム内の値のみ |
+| 期待したスレッド（更新ループ・ワーカー等）は生きているか？ | Rider `list_threads` | スレッド名で存在確認 |
+| 例外は出ていないか？ | `uloop get-logs --log-type Error/Exception` | ログを先に見ると近道 |
+
+**黄金律:** 動的コードでランタイム状態の真実を先に取り、**その後で** debugger を「ピンポイント観測」として使う。逆は時間の無駄。
+
+## 手順
+
+### Step 1. 症状と期待動作を一文化する
+
+「〇〇がXXするはずなのにYYする」の形で書き出す。この一文がそのまま Step 3 の dynamic code で確認する項目リストになる。あいまいだと以降の Step が全部ブレるので、ここで精度を出す。
+
+### Step 2. uloop get-logs で既出エラーを回収する
+
+```bash
+uloop get-logs --project-path ./{project} --log-type Error --max-count 30
+uloop get-logs --project-path ./{project} --log-type Exception --max-count 30
+```
+
+ランタイム例外が出ていれば90%ここで原因がわかる。`DynamicCommand_*.dll` のコンパイルエラーは自分の過去の動的コードの残骸なので無視してよい。
+
+### Step 3. 動的コードでランタイム状態をスナップショット
+
+**これが本スキルの中核。** Step 1 で書いた一文の全名詞（対象オブジェクト・状態・関係性）を dynamic code で列挙・ダンプして、**「何が存在していて、どうなっているか」を文字列一発で把握する**。
+
+最小テンプレート（プロジェクト非依存の汎用パターン）:
+
+```csharp
+using System.Linq;
+using System.Text;
+
+var sb = new StringBuilder();
+
+// 1. エントリーポイントから対象コレクションを取得
+var items = SomeStaticContext.GetAll();   // ← 対象PJT固有の呼び出しに置換
+
+// 2. 各インスタンスのID・位置・疑わしいフィールドをダンプ
+foreach (var x in items)
+{
+    sb.AppendLine($"[Id={x.Id}] state={x.State} connectedCount={x.Connected.Count}");
+
+    // 3. 内部状態を条件付きで詳細ダンプ
+    if (x.State == TargetState)
+        foreach (var c in x.Connected)
+            sb.AppendLine($"  -> {c.GetType().Name}");
+}
+
+sb.AppendLine($"Total={items.Count}");
+return sb.ToString();
+```
+
+**ポイント:**
+- 1回のコールで **全対象** を列挙する。個別クエリを何度も叩かない
+- ID・位置・疑わしいフィールドをまとめて1行で出す（`$"[Id=... pos=... count=..."`）
+- 条件分岐で詳細情報を追加（空インスタンスはスキップ、非空のみ内部ダンプ等）
+
+プロジェクト固有の**エントリーポイント**（どの static から世界を取るか）、**主要コレクション名**、**ありがちな名前ミス**、よく使うコンポーネント取得API は、実運用時に使うプロジェクトごとに [references/project-api-cheatsheet.md](references/project-api-cheatsheet.md) に追記して使い回す。moorestech 系の例（`ServerContext.WorldBlockDatastore` 起点、`block.ComponentManager.TryGetComponent<T>`、`BlockPositionInfo.OriginalPos` 等）は既に記載済み。
+
+**Step 3 完了判定:** 取得した状態が Step 1 の期待と**どこで食い違っているか**を特定する。多くの場合はここで原因が判明する（例: 「状態は入っているが参照先のコレクションが空」）。状態に異常がなければ Step 4 へ。
+
+### Step 4. Debugger BP で「呼ばれているか」を確認する
+
+状態は正しいのに挙動が間違っている場合は、コードパスが本当に走っているかを確認する。状態が正しい=bug は **実行フロー側** にある。
+
+1. 疑わしいメソッドの先頭行に BP を設置
+2. `wait_for_pause` でタイムアウト（例: 15秒）を指定して待つ
+3. ヒットすれば実行中 → Step 5。ヒットしなければ上流（初期化、イベント購読、スレッド起動）を疑う
+
+**「BPが当たらない = そこに辿り着いていない」は強い証拠。** 逆にBP hitCount=0が数十秒続くなら、上流で呼び出し自体が止まっている。
+
+BP運用の詳細・コツ・失敗パターンは [references/debugger-gotchas.md](references/debugger-gotchas.md) 参照。
+
+### Step 5. Debugger で変数を観測する
+
+BP が当たったら `get_variables` でローカル変数一覧を取得。個別値は `evaluate_expression` で見る。
+
+**重要な制約: Riderの soft debugger は "Implicit evaluation is disabled" がデフォルト。** property getter と method call は動かない。フィールド直アクセスが必要:
+
+```csharp
+// 動かない例
+someList.Count                     // property getter
+someDict[key]                      // indexer（property）
+obj.ComputeSomething()             // method call
+
+// 動く例
+someList._size                     // List<T>.Count の実体
+someList._items[i]                 // List<T> の内部配列
+obj._privateField                  // 直接フィールドアクセス
+```
+
+`List<T>` は `_items` (T[]) と `_size` (int) がランタイムフィールド。property `Count` は使えない。配列インデクサ `[i]` はフィールド経由 (`_items[i]`) なら効く。
+
+型判定で `is` を使うときは **fully qualified name** が必須:
+
+```csharp
+// NG: The type or namespace name 'XXX' does not exist
+_items[i] is ItemStack
+
+// OK
+_items[i] is Core.Item.Implementation.ItemStack
+```
+
+**internal クラスでも namespace.Class まで書けば参照できる。** エラーメッセージが出たら `Grep` で namespace を確認して付け直す。
+
+### Step 6. 毎回必ず後片付けする
+
+以下を **必ず** 実行する。残すと次回セッションで誤ヒット・誤診断・Unity freeze を引き起こす。
+
+1. `mcp__rider-debugger__list_breakpoints` で自分が張った line BP を列挙
+2. `remove_breakpoint` で全削除（exception BP は残してOK）
+3. セッションが `paused`（特に `pausedReason: step`）で止まっていたら `resume_execution`
+4. 作業完了を宣言
+
+## Gotchas
+
+### G1: Unity が busy になったら即 Rider debugger セッションを停止する
+
+**症状:** `uloop execute-dynamic-code` が 180秒タイムアウトでエラー、Unity Editor が応答しない、`get-logs` も返ってこない。
+
+**原因:** Rider debugger が paused/step 状態で止まったまま離脱されると、Unity のスクリプトスレッドが debugger のコマンド待ちで固まる。特に tracepoint/logpoint で複雑な `{this}` 式を評価させると頻発する。
+
+**対処:** **Rider側でdebugger停止ボタンを押す** (Shift+F5) → Unity が即座に復活する。MCP経由で`stop_debug_session`を呼んでもよい。
+
+**予防:**
+- tracepoint/logpoint には複雑な式（`{this}` やフィールド連鎖）を入れない。`i={i}` 程度にする
+- 長時間 Unity に触れない時は BP を外しておく
+- 作業が終わったら Step 6 のクリーンアップを忠実に実行
+
+### G2: 「Implicit evaluation is disabled」は debugger 側の制限。dynamic code では全機能使える
+
+Debugger の `evaluate_expression` / 条件付きBP では property getter やメソッドが呼べないが、`uloop execute-dynamic-code` は通常のC#実行環境なので **LINQ・property・拡張メソッド・await すべて使える**。複雑な集計は debugger でがんばらず動的コードに移すと速い。
+
+### G3: 静的state は PlayMode 停止後も残ることがある
+
+Unity Editor の Domain Reload を無効にしている場合、静的フィールド（例: シングルトン、サービスプロバイダ、UniRx Subject）は PlayMode 停止→再開後も前回の状態を引きずる。「さっき見たインスタンスが再開後にも見える」のは新しくロードされたのではなく残骸の可能性がある。
+
+**確認法:** PlayMode 再開後に `list_threads` で期待するバックグラウンドスレッドが**新しく**存在しているか、プロジェクト特有の初期化ログが出ているかを見る。
+
+### G4: BPのhitCount=0は「通っていない」の強い証拠
+
+`list_breakpoints` は各line BPのhitCountを返す。数十秒PlayMode継続後にhitCount=0なら、そのコードは実行されていない。**「BPの設定漏れ？」と疑う前にhitCountを信じる。** 逆に、hitCountが増えているのにwait_for_pauseがタイムアウトするなら、suspend policyが`none`（tracepoint）になっているか、別スレッドでヒットしている。
+
+### G5: 複数インスタンスへのBPは「全ヒット」する
+
+同じクラスのインスタンスが N 個ある場合、そのクラスのメソッドに張った BP は N 個全部でヒットする。「対象のインスタンスだけ見たい」時は Step 3 の動的コードダンプでインスタンスID（`BlockInstanceId` や `GetInstanceID()` 等）を先に特定し、BPの条件に `this._instanceId == ...` を入れる。
+
+### G6: for ループで empty 要素を早期 skip する条件があると BP body は発火しない
+
+例: 「全スロット舐めるループだが、空アイテムは `continue` / ループ条件で skip」というパターン。外側のループ先頭BPは当たるが、内部処理のBPは永久に当たらない。「呼ばれているはず」なのに当たらない時は **外側ループの条件** を読んで早期 skip がないか確認する。
+
+### G7: 条件付きBP の式は最初に `i == 0` 等で syntax 検証する
+
+いきなり複雑な条件（`_items[i] is My.Ns.Class`）を書くと、式エラーで **silent に BP が無効化** されることがある（Rider の場合ダイアログで "ブレークポイントで停止しますか？" が出る）。まず確実に true になる条件（`i == 0` 等）で一度ヒットさせ、その後にステップで `evaluate_expression` しながら本条件を組み立てると確実。
+
+### G8: field 名や型名からアーキテクチャ構成を推論するな。必ず probe で確定
+
+**症状:** `_localServerProcess (Process)` のような field を見て「サーバーは別OSプロセスだから見えない」と判断し、動的コードを試さずに「届かない」と結論。実際には PlayMode 中は同一プロセスで `ServerContext.*` が普通に引ける構成だった。
+
+**原因:** field 名・型名は**デプロイモードごとに意味が変わる**。`Process` 型の field があっても「製品ビルドでサブプロセス起動する時専用で、PlayMode では未使用」というケースがある。名前だけ見て結論すると、実測が1コールで済むはずのアクセス可能性を誤判定する。
+
+**対処:** 「この状態は見えない / この API は届かない」と言う前に、**uloop execute-dynamic-code で該当エントリーポイントを1回叩く**。返ったなら見える、throw / null なら見えない。1コールで確定する。
+
+```csharp
+// アクセス可能性の probe テンプレ
+var ctx = Game.Context.ServerContext.WorldBlockDatastore;
+return ctx == null ? "null" : $"OK count={ctx.BlockMasterDictionary.Count}";
+```
+
+`ServerContext` / `ClientContext` / 静的 singleton など、「見えるかどうか」が構成依存の対象は **プロジェクトごとに [references/project-api-cheatsheet.md](references/project-api-cheatsheet.md) に in-process 可否を記載する**。未登録なら probe してから追記する。
+
+**黄金律の再掲:** 「見えない」は推論でなく probe の結果として宣言する。推論で諦めると、余計なインストゥルメント提案や別 Unity 起動提案で時間を溶かす。
+
+## 典型的な調査フロー例
+
+**症状:** 「プレイヤーが拾えるはずのアイテムが表示されない」
+
+1. **Step 2 ログ確認:** runtime Exception なし → コード例外ではない
+2. **Step 3 動的コード:** ワールドの全 Item インスタンスを ID / pos / owner でダンプ
+   - 発見: Item は存在するが `pos` がプレイヤーの遥か遠くにあった
+   - → **原因: spawn ロジックの座標計算ミス**（ここで判明、Step 4 不要）
+
+**症状:** 「オブジェクトの Update() が一切呼ばれない」
+
+1. **Step 2:** Exception なし
+2. **Step 3:** 対象オブジェクトはコレクションに存在する（= 生成自体は成功）
+3. **Step 4:** 該当 `Update` に BP → **hitCount=0**
+4. 上流へ: 購読元（`GameUpdater.Update` 等）に BP → **hitCount=0**
+5. さらに上流: 更新スレッドのエントリに BP → **hitCount=0**
+6. `list_threads` → 期待する更新スレッドが存在しない
+7. → **原因: initialization pipeline が更新ループを起動していない** (コードを Read で確認)
+
+両方とも **Step 3 の動的コードスナップショット→ BP hitCount を上流へ追う** のパターンで特定している。

--- a/.claude/skills/unity-runtime-bug-hunt/references/debugger-gotchas.md
+++ b/.claude/skills/unity-runtime-bug-hunt/references/debugger-gotchas.md
@@ -1,0 +1,117 @@
+# Rider Debugger 運用の詰まりどころ集
+
+SKILL.md の Step 4 / 5 で BP を使うときに参照する、実運用で踏んだ罠の詳細。SKILL.md のサマリで足りない時だけ読む。
+
+## 1. BP設置の順序
+
+1. 疑わしいメソッドの**先頭行**に `set_breakpoint`（サスペンドポリシーは `all` デフォルト）
+2. 必要なら `wait_for_pause(timeout=15)` でブロック。resume → wait の繰り返しで hitCount を進める
+3. 調査が終わったら `list_breakpoints` → `remove_breakpoint` で自分が張ったline BPを全削除
+
+**先にBP、後でPlayMode操作**。PlayModeが走ってから set_breakpoint してもその後の呼び出しで普通に発火する。
+
+## 2. hitCount=0 は「実行されていない」の決定的証拠
+
+`list_breakpoints` は各line BPの `hitCount` フィールドを返す。数十秒〜数分 PlayMode を動かしても hitCount=0 なら、そのコードパスは**物理的に通っていない**。
+
+「設定ミスかも」より先に hitCount を信じる。上流へ遡って次の BP を張る:
+
+1. このメソッドの呼び出し元は何か (`Grep` で呼び出し箇所検索)
+2. 呼び出し元の先頭行にBP → hitCount=0 ならさらに上流へ
+3. 最終的に「どこまでは動いているか」の境界が見える
+
+**このhitCount追跡が本スキルの最大の威力**。推論より経験的に正確。
+
+## 3. wait_for_pause の運用
+
+- `timeout` は秒単位で必須
+- breakpoint ヒットで解除される時は、返却値に breakpointHit・stackSummary・variables がすべて入る
+- タイムアウトで解除される時は `waitResult: "timeout"`。これ自体はバグではなく「何も起きなかった」情報
+- タイムアウト後もセッションは running のまま。改めて set_breakpoint するなり `pause_execution` するなり好きにできる
+
+## 4. ローカル変数とフィールドの見方
+
+paused した時の変数観測は 2 通り:
+
+| ツール | 用途 |
+|---|---|
+| `get_variables` | 現フレームの this + 引数 + ローカル変数を一括取得。最初の一手 |
+| `evaluate_expression` | 特定のフィールドチェーンやインデクサを狙い撃ち |
+
+**Implicit evaluation is disabled 問題**:
+
+Rider soft debugger は property getter と method 呼び出しをデフォルトで評価しない。これを知らないと property で死ぬ。
+
+- NG: `list.Count`, `dict[key]`, `obj.GetName()`, `array.Length`（これは何故か通ることもある）
+- OK: `list._size`, `list._items[i]`, `obj._privateField`
+
+コレクションの内部フィールド早見表:
+
+| 型 | Count 相当 | インデクサ相当 |
+|---|---|---|
+| `List<T>` | `_size` | `_items[i]` |
+| `T[]` | `Length` (通る時がある) | `[i]` 直接 |
+| `Dictionary<K,V>` | `_count` | `_entries[slot].value` (複雑) |
+| `HashSet<T>` | `_count` | 実用的にはほぼ無理 |
+
+Dictionary と HashSet は debugger で中身を読むのが難しいので、そういう時は **素直に動的コードに逃げる**。
+
+## 5. 条件付きBP
+
+`set_breakpoint --condition "..."` の式は実行時に評価される。ただし同じ「Implicit evaluation is disabled」の制約を受ける。
+
+**検証のコツ**: いきなり複雑な条件を書かない。段階を踏む。
+
+1. まず条件なしで BP を張って一度ヒットさせる
+2. `evaluate_expression` で本番の条件式を評価して、エラー無く true/false が返ることを確認
+3. その式をそのまま `condition` に載せて set_breakpoint し直す
+
+型判定の `is` は **fully qualified name** が必須。`is ItemStack` では `CS0246: The type or namespace name 'ItemStack' does not exist` になる。`Grep` でクラス定義のファイルを開いて `namespace` を読み、`is Core.Item.Implementation.ItemStack` と書く。internal クラスでも可。
+
+## 6. tracepoint (logpoint) は地雷
+
+`suspend_policy: "none"` + `log_message` で非停止ログ出力が作れるが、次の 3 点で Unity を簡単にフリーズさせる:
+
+1. **複雑な式の評価**: `{this}` や `{_inventory._items[0]}` のような深いチェーンを毎tick評価するとオーバーヘッドが膨大
+2. **内部で例外が出ると消失**: 評価で例外が出ると log が出ないまま hit 数は進む（デバッグ不能）
+3. **log が stdout ではなく Rider の Debug Output に出る**: `uloop get-logs` では拾えない
+
+**基本的に tracepoint は避ける**。どうしても使うなら `i={i}` 程度の超シンプルな式に絞る。
+
+## 7. Unity が busy 化した時の復旧手順
+
+**症状**: `uloop execute-dynamic-code` が 180秒タイムアウトでエラー、Unity Editor GUI が無反応、`get-logs` も返ってこない。
+
+**原因**: debugger が内部的に paused/step 状態のまま、Unity のスクリプトスレッドが debugger のコマンド待ちで固まっている。
+
+**復旧手順** (優先順):
+
+1. **Rider の Debug ツールウィンドウから赤い停止ボタンを押す** (Shift+F5) → Unity 即復活。最速
+2. もしくは `mcp__rider-debugger__stop_debug_session` → `start_debug_session` で再アタッチ
+3. それでもダメなら Unity を一度閉じて uloop launch で再起動
+
+**予防**: Step 6 のクリーンアップを毎回忠実に実行する。paused のまま離席しない。
+
+## 8. スレッド一覧の読み方
+
+`list_threads` は Unity プロセスの全スレッドを返す。moorestech 系なら以下に注目:
+
+| 名前 | 意味 |
+|---|---|
+| `(main)` / id="main" | Unity main thread。MonoBehaviour.Update とかここ |
+| `[moorestech]ゲームアップデートスレッド` | ServerGameUpdater スレッド。ブロックロジックのtick源 |
+| `<Thread Pool>` x N | `Task.Run` 等のワーカー |
+| `Burst-CompilerThread-*` | Unity Burst コンパイラ内部 |
+| `ServerSocket-UnityServer-*` | RemoteConfig / IDE連携 |
+
+期待するバックグラウンドスレッドが**名前で存在するか**を最初に見る。名前が無ければそのスレッドは起動していない。
+
+## 9. ステップ実行系 (step_over / step_into / run_to_line)
+
+- `step_into` は this のメソッド呼び出しに深く入れる。ただしフレームワーク内部（UniRx とか）に吸い込まれると戻ってこられないので注意
+- `run_to_line` は BP を張る代わりの一時的な進め方。対象行に到達しなくてもタイムアウトしたら手動で resume する
+- `step_over` は property getter の呼び出しも1ステップでスキップするので、内部で複雑なことが起きていても追えない。疑わしい時は step_into に切り替え
+
+## 10. Exception breakpoint
+
+`list_breakpoints` の返却には `type: "exception"` の要素が複数並んでいる (`DotNet_Exception_Breakpoints` 等)。これらはデフォルトで disabled。自分で張った line BP とは区別すること。**削除不要**で、残しても害は無い。

--- a/.claude/skills/unity-runtime-bug-hunt/references/project-api-cheatsheet.md
+++ b/.claude/skills/unity-runtime-bug-hunt/references/project-api-cheatsheet.md
@@ -1,0 +1,75 @@
+# Project API Cheatsheet
+
+Step 3 で動的コードを書くときに参照する、プロジェクト固有のエントリーポイント集。対象プロジェクトで検証済みの API・名前・典型パターンを追記していく。未登録のプロジェクトで作業するときは最初にここへエントリを追加する。
+
+## moorestech (client-server統合版)
+
+### プロセス構成: PlayMode では同一プロセス
+
+**重要:** moorestech は client/server が別 Unity プロジェクトだが、**PlayMode 実行中は同一プロセス上で両方動く**。client の Unity Editor に uloop を繋いだ状態で `Game.Context.ServerContext.*` を普通に参照できる。
+
+- `VanillaApi` の field に `_localServerProcess (Process)` があるが、これは製品ビルド時の外部サーバー起動用の仕組みで、**PlayMode では未使用**。名前に惑わされない
+- サーバー側の状態（`WorldBlockDatastore`, `GearNetworkDatastore` 等）を client の uloop から直接ダンプできる。別 Unity 起動やサーバーコード改変は不要
+- 疑わしいときは probe: `return Game.Context.ServerContext.WorldBlockDatastore.BlockMasterDictionary.Count;` を 1 コール打つ。返れば in-process
+
+### エントリーポイント（ここから World を辿る）
+
+| 用途 | コード |
+|---|---|
+| ワールド内の全ブロック | `Game.Context.ServerContext.WorldBlockDatastore.BlockMasterDictionary.Values` |
+| ブロック→コンポーネント | `block.ComponentManager.TryGetComponent<T>(out var c)`（**`block.TryGetComponent` は存在しない**, Unity の GameObject 混同注意） |
+| ブロック座標 | `bwp.BlockPositionInfo.OriginalPos`（**`OriginPos` ではない**, `CS1061` になる） |
+| マスターデータ | `Core.Master.MasterHolder.ItemMaster` / `BlockMaster` / `CraftRecipeMaster` 等 |
+| サービスプロバイダ | `ServerContext.MainServiceProvider` → `.GetService<IWorldSaveDataLoader>()` 等 |
+| プレイヤーインベントリ | `serviceProvider.GetService<IPlayerInventoryDataStore>()` |
+
+### よく使うコンポーネント（ブロック系）
+
+| コンポーネント | namespace | 主フィールド |
+|---|---|---|
+| `VanillaChestComponent` | `Game.Block.Blocks.Chest` | `InventoryItems`（= `_itemDataStoreService._inventory`） |
+| `VanillaBeltConveyorComponent` | `Game.Block.Blocks.BeltConveyor` | `BeltConveyorItems`, `_inventoryItems` |
+| `BlockConnectorComponent<IBlockInventory>` | `Game.Block.Component` | `ConnectedTargets` (`IReadOnlyDictionary<IBlockInventory, ConnectedInfo>`) |
+
+### インベントリ中身のダンプパターン
+
+```csharp
+var nonEmpty = chest.InventoryItems
+    .Select((it, idx) => new { idx, it })
+    .Where(x => x.it.Count > 0)
+    .Select(x => $"slot={x.idx} id={x.it.Id.AsPrimitive()} cnt={x.it.Count}");
+```
+
+`IItemStack.Id` は `ItemId` 構造体。文字列比較には `.AsPrimitive()` を使う。
+
+### 接続先の存在チェック
+
+```csharp
+if (mgr.TryGetComponent<BlockConnectorComponent<IBlockInventory>>(out var conn))
+{
+    sb.AppendLine($"ConnectedTargets.Count={conn.ConnectedTargets.Count}");
+    foreach (var t in conn.ConnectedTargets)
+        sb.AppendLine($"  -> {t.Key.GetType().Name} self={t.Value.SelfConnector != null} target={t.Value.TargetConnector != null}");
+}
+```
+
+`ConnectedTargets.Count == 0` は **「このブロックは誰にも接続されていない」** という決定的証拠。アイテム搬出系の不具合ではまずこれを見る。
+
+### バックグラウンドスレッドの存在確認
+
+moorestech では `ServerGameUpdater.StartUpdate` が別スレッドで `GameUpdater.Update()` を 50ms ごとに叩く。このスレッドが死ぬと `BlockSystem.Update()` が一切呼ばれなくなる。
+
+`mcp__rider-debugger__list_threads` → 返却される threads[] 内に `"[moorestech]ゲームアップデートスレッド"` が存在するか確認。無ければ initialization pipeline が更新ループを起動していない。
+
+### よくある名前ミス
+
+| 間違い | 正しい | 理由 |
+|---|---|---|
+| `BlockPositionInfo.OriginPos` | `OriginalPos` | プロパティ名 |
+| `block.TryGetComponent<T>` | `block.ComponentManager.TryGetComponent<T>` | IBlock は Unity の GameObject ではない |
+| `itemStack is ItemStack` (BP条件内) | `is Core.Item.Implementation.ItemStack` | internal クラスは FQN 必須 |
+| `chest.InventoryItems.Count`（debugger内） | `_itemDataStoreService._inventory._size` | property getter は debugger で評価不可 |
+
+### PlayMode 起動を伴うテストユーティリティ
+
+`Client.Tests.EditModeInPlayingTest.Util.EditModeInPlayingTestUtil` にはPlayModeでのブロック配置・アイテム投入のヘルパーがある。動的コード相当のことを再現テストで書きたい時に参考になる。

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,20 +1,8 @@
 {
   "mcpServers": {
-    "serena": {
-      "type": "stdio",
-      "command": "uvx",
-      "args": [
-        "--from",
-        "git+https://github.com/oraios/serena",
-        "serena-mcp-server",
-        "--context",
-        "ide-assistant",
-        "--project",
-        "/Users/sato-katsumi/moorestech",
-        "--enable-web-dashboard",
-        "False"
-      ],
-      "env": {}
+    "rider-debugger": {
+      "type": "http",
+      "url": "http://127.0.0.1:29202/debugger-mcp/streamable-http"
     }
   }
 }

--- a/VanillaSchema/blocks.yml
+++ b/VanillaSchema/blocks.yml
@@ -491,7 +491,7 @@ properties:
           default: 2
         - key: requireTorquePerRpm
           type: number
-          default: 2
+          default: 0.002
         - key: slopeType
           type: enum
           options:

--- a/moorestech_client/.uloop/tools.json
+++ b/moorestech_client/.uloop/tools.json
@@ -1,7 +1,7 @@
 {
-  "version": "1.6.3",
-  "serverVersion": "0.69.6",
-  "updatedAt": "2026-04-03T07:30:56.030Z",
+  "version": "1.7.3",
+  "serverVersion": "1.6.3",
+  "updatedAt": "2026-04-19T06:08:49.102Z",
   "tools": [
     {
       "name": "clear-console",
@@ -255,35 +255,74 @@
       }
     },
     {
-      "name": "get-menu-items",
-      "description": "Retrieve Unity MenuItems with detailed metadata for programmatic execution. Unlike Unity Search menu provider, this provides implementation details (method names, assemblies, execution compatibility) needed for automation and debugging.",
+      "name": "record-input",
+      "description": "Record keyboard and mouse input during PlayMode. Captures key presses, mouse movement, clicks, and scroll events frame-by-frame into a JSON file for later replay.",
       "inputSchema": {
         "type": "object",
         "properties": {
-          "FilterText": {
+          "Action": {
             "type": "string",
-            "description": "Text to filter MenuItem paths (empty for all items)",
-            "default": ""
-          },
-          "FilterType": {
-            "type": "string",
-            "description": "Type of filter to apply (contains(0), exact(1), startswith(2))",
+            "description": "Recording action: Start(0) - begin recording input, Stop(1) - stop recording and save to file",
             "default": 0,
             "enum": [
-              "contains",
-              "exact",
-              "startswith"
+              "Start",
+              "Stop"
             ]
           },
-          "IncludeValidation": {
-            "type": "boolean",
-            "description": "Include validation functions in the results",
-            "default": false
+          "OutputPath": {
+            "type": "string",
+            "description": "Output file path for the recording JSON. If empty, auto-generates under .uloop/outputs/InputRecordings/",
+            "default": ""
           },
-          "MaxCount": {
+          "Keys": {
+            "type": "string",
+            "description": "Comma-separated key filter. Only record specified keys (e.g. 'W,A,S,D,Space'). Empty means record all common game keys.",
+            "default": ""
+          },
+          "DelaySeconds": {
             "type": "number",
-            "description": "Maximum number of menu items to retrieve",
-            "default": 200
+            "description": "Countdown delay in seconds before recording starts (0-10). Gives time to switch focus to Game View.",
+            "default": 3
+          },
+          "ShowOverlay": {
+            "type": "boolean",
+            "description": "Show recording overlay (countdown + REC indicator)",
+            "default": true
+          }
+        },
+        "required": []
+      }
+    },
+    {
+      "name": "replay-input",
+      "description": "Replay recorded input during PlayMode. Loads a JSON recording and injects keyboard/mouse input frame-by-frame with zero CLI overhead.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "Action": {
+            "type": "string",
+            "description": "Replay action: Start(0) - begin replaying, Stop(1) - stop mid-way, Status(2) - check progress",
+            "default": 0,
+            "enum": [
+              "Start",
+              "Stop",
+              "Status"
+            ]
+          },
+          "InputPath": {
+            "type": "string",
+            "description": "Path to recording JSON file. If empty, auto-detects the latest recording in .uloop/outputs/InputRecordings/",
+            "default": ""
+          },
+          "ShowOverlay": {
+            "type": "boolean",
+            "description": "Show visualization overlay during replay",
+            "default": true
+          },
+          "Loop": {
+            "type": "boolean",
+            "description": "Loop replay continuously",
+            "default": false
           }
         },
         "required": []
@@ -332,7 +371,7 @@
         "properties": {
           "WindowName": {
             "type": "string",
-            "description": "Window name to capture (e.g., 'Game', 'Scene', 'Console', 'Inspector', 'Project', 'Hierarchy', or any EditorWindow title)",
+            "description": "Window name to capture (e.g., 'Game', 'Scene', 'Console', 'Inspector', 'Project', 'Hierarchy', or any EditorWindow title). Ignored when CaptureMode is rendering.",
             "default": "Game"
           },
           "ResolutionScale": {
@@ -342,7 +381,7 @@
           },
           "MatchMode": {
             "type": "string",
-            "description": "Window name matching mode: exact(0)=exact match, prefix(1)=starts with, contains(2)=partial match. All modes are case-insensitive.",
+            "description": "Window name matching mode: exact(0)=exact match, prefix(1)=starts with, contains(2)=partial match. All modes are case-insensitive. Ignored when CaptureMode is rendering.",
             "default": 0,
             "enum": [
               "exact",
@@ -354,118 +393,185 @@
             "type": "string",
             "description": "Output directory path for saving screenshots. When empty, uses default path (.uloop/outputs/Screenshots/). Accepts absolute paths.",
             "default": ""
+          },
+          "CaptureMode": {
+            "type": "string",
+            "description": "Capture mode: window(0)=capture EditorWindow including toolbar, rendering(1)=capture game rendering only (PlayMode required, coordinates match simulate-mouse)",
+            "default": 0,
+            "enum": [
+              "window",
+              "rendering"
+            ]
+          },
+          "AnnotateElements": {
+            "type": "boolean",
+            "description": "Annotate interactive UI elements with names and simulate-mouse coordinates on the screenshot. Only works with CaptureMode=rendering in PlayMode.",
+            "default": false
+          },
+          "ElementsOnly": {
+            "type": "boolean",
+            "description": "Return only annotated element JSON without capturing a screenshot image. Requires AnnotateElements=true and CaptureMode=rendering in PlayMode.",
+            "default": false
           }
         },
         "required": []
       }
     },
     {
-      "name": "unity-search",
-      "description": "Search Unity project using Unity Search API with comprehensive filtering and export options",
+      "name": "simulate-keyboard",
+      "description": "Simulate keyboard key input in PlayMode via Input System. Supports one-shot press, key-down hold, and key-up release for game controls (WASD, Space, etc.). Requires the Input System package (com.unity.inputsystem).",
       "inputSchema": {
         "type": "object",
         "properties": {
-          "SearchQuery": {
+          "Action": {
             "type": "string",
-            "description": "Search query string (supports Unity Search syntax). Examples: '*.cs', 't:Texture2D', 'ref:MyScript', 'p:MyPackage'. For detailed Unity Search documentation see: https://docs.unity3d.com/6000.1/Documentation/Manual/search-expressions.html and https://docs.unity3d.com/6000.0/Documentation/Manual/search-query-operators.html. Common queries: '*.cs' (all C# files), 't:Texture2D' (Texture2D assets), 'ref:MyScript' (assets referencing MyScript), 'p:MyPackage' (search in package), 't:MonoScript *.cs' (C# scripts only), 'Assets/Scripts/*.cs' (C# files in specific folder). Japanese guide: https://light11.hatenadiary.com/entry/2022/12/12/193119",
-            "default": ""
-          },
-          "Providers": {
-            "type": "array",
-            "description": "(Optional) Specific search providers to use (empty = all active providers). Common providers: 'asset', 'scene', 'menu', 'settings', 'packages'",
-            "default": []
-          },
-          "MaxResults": {
-            "type": "number",
-            "description": "(Optional) Maximum number of search results to return (default: 50)",
-            "default": 50
-          },
-          "IncludeDescription": {
-            "type": "boolean",
-            "description": "(Optional) Whether to include detailed descriptions in results (default: true)",
-            "default": true
-          },
-          "IncludeMetadata": {
-            "type": "boolean",
-            "description": "(Optional) Whether to include file metadata like file size and last modified date (default: false)",
-            "default": false
-          },
-          "SearchFlags": {
-            "type": "string",
-            "description": "(Optional) Search flags for controlling Unity Search behavior (default: Default(0), Synchronous(1), WantsMore(2), Packages(4), Sorted(8))",
+            "description": "Keyboard action: Press(0) - one-shot key tap (Down then Up), KeyDown(1) - hold key down, KeyUp(2) - release held key",
             "default": 0,
             "enum": [
-              "Default",
-              "Synchronous",
-              "WantsMore",
-              "Packages",
-              "Sorted"
+              "Press",
+              "KeyDown",
+              "KeyUp"
             ]
           },
-          "SaveToFile": {
-            "type": "boolean",
-            "description": "(Optional) Whether to save search results to external file to avoid massive token consumption when dealing with large result sets. Results are saved as JSON/CSV files for external reading (default: false)",
-            "default": false
-          },
-          "OutputFormat": {
+          "Key": {
             "type": "string",
-            "description": "(Optional) Output file format when SaveToFile is enabled (default: JSON(0), CSV(1), TSV(2))",
-            "default": 0,
-            "enum": [
-              "JSON",
-              "CSV",
-              "TSV"
-            ]
-          },
-          "AutoSaveThreshold": {
-            "type": "number",
-            "description": "(Optional) Threshold for automatic file saving (if result count exceeds this, automatically save to file). Set to 0 to disable automatic file saving (default: 100)",
-            "default": 100
-          },
-          "FileExtensions": {
-            "type": "array",
-            "description": "(Optional) Filter results by file extension (e.g., 'cs', 'prefab', 'mat')",
-            "default": []
-          },
-          "AssetTypes": {
-            "type": "array",
-            "description": "(Optional) Filter results by asset type (e.g., 'Texture2D', 'GameObject', 'MonoScript')",
-            "default": []
-          },
-          "PathFilter": {
-            "type": "string",
-            "description": "(Optional) Filter results by path pattern (supports wildcards)",
+            "description": "Key name matching the Input System Key enum (e.g. \"W\", \"Space\", \"LeftShift\", \"A\", \"Enter\"). Case-insensitive.",
             "default": ""
+          },
+          "Duration": {
+            "type": "number",
+            "description": "Hold duration in seconds for Press action (default: 0 = one-shot tap). Ignored by KeyDown/KeyUp.",
+            "default": 0
           }
         },
         "required": []
       }
     },
     {
-      "name": "get-unity-search-providers",
-      "description": "Get detailed information about Unity Search providers including display names, descriptions, active status, and capabilities",
+      "name": "simulate-mouse-input",
+      "description": "Simulate mouse input in PlayMode via Input System. Injects button clicks, mouse delta, and scroll wheel directly into Mouse.current for game logic that reads Input System (e.g. WasPressedThisFrame). Requires the Input System package.",
       "inputSchema": {
         "type": "object",
         "properties": {
-          "ProviderId": {
+          "Action": {
             "type": "string",
-            "description": "Specific provider ID to get details for (empty = all providers). Examples: 'asset', 'scene', 'menu', 'settings'",
-            "default": ""
+            "description": "Mouse input action: Click(0) - inject left/right/middle button press+release, LongPress(1) - inject button hold for Duration seconds, MoveDelta(2) - inject mouse delta for camera/look (one-shot), Scroll(3) - inject scroll wheel, SmoothDelta(4) - inject mouse delta smoothly over Duration seconds",
+            "default": 0,
+            "enum": [
+              "Click",
+              "LongPress",
+              "MoveDelta",
+              "Scroll",
+              "SmoothDelta"
+            ]
           },
-          "ActiveOnly": {
-            "type": "boolean",
-            "description": "Whether to include only active providers",
-            "default": false
+          "X": {
+            "type": "number",
+            "description": "Target X position in screen pixels (origin: top-left). Used by Click and LongPress to set Mouse.current.position.",
+            "default": 0
           },
-          "SortByPriority": {
-            "type": "boolean",
-            "description": "Sort providers by priority (lower number = higher priority)",
-            "default": true
+          "Y": {
+            "type": "number",
+            "description": "Target Y position in screen pixels (origin: top-left). Used by Click and LongPress to set Mouse.current.position.",
+            "default": 0
           },
-          "IncludeDescriptions": {
-            "type": "boolean",
-            "description": "Include detailed descriptions for each provider",
-            "default": true
+          "Button": {
+            "type": "string",
+            "description": "Mouse button: Left(0, default), Right(1), Middle(2). Used by Click and LongPress.",
+            "default": 0,
+            "enum": [
+              "Left",
+              "Right",
+              "Middle"
+            ]
+          },
+          "Duration": {
+            "type": "number",
+            "description": "Hold duration in seconds for LongPress, or minimum hold time for Click (0 = one-shot tap). Also used as total duration for SmoothDelta.",
+            "default": 0
+          },
+          "DeltaX": {
+            "type": "number",
+            "description": "Delta X in pixels for MoveDelta/SmoothDelta action. Positive = right.",
+            "default": 0
+          },
+          "DeltaY": {
+            "type": "number",
+            "description": "Delta Y in pixels for MoveDelta/SmoothDelta action. Positive = up (Unity screen space).",
+            "default": 0
+          },
+          "ScrollX": {
+            "type": "number",
+            "description": "Horizontal scroll delta for Scroll action (default: 0).",
+            "default": 0
+          },
+          "ScrollY": {
+            "type": "number",
+            "description": "Vertical scroll delta for Scroll action. Positive = up, negative = down. Typically 120 per notch.",
+            "default": 0
+          }
+        },
+        "required": []
+      }
+    },
+    {
+      "name": "simulate-mouse-ui",
+      "description": "Simulate mouse click, long-press, and drag on PlayMode UI elements via EventSystem screen coordinates",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "Action": {
+            "type": "string",
+            "description": "Mouse action: Click(0) - click with selected Button, Drag(1) - one-shot drag, DragStart(2) - begin drag and hold, DragMove(3) - move while holding drag, DragEnd(4) - release drag, LongPress(5) - press and hold for Duration seconds",
+            "default": 0,
+            "enum": [
+              "Click",
+              "Drag",
+              "DragStart",
+              "DragMove",
+              "DragEnd",
+              "LongPress"
+            ]
+          },
+          "X": {
+            "type": "number",
+            "description": "Target X position in screen pixels (origin: top-left). For Drag action, this is the destination.",
+            "default": 0
+          },
+          "Y": {
+            "type": "number",
+            "description": "Target Y position in screen pixels (origin: top-left). For Drag action, this is the destination.",
+            "default": 0
+          },
+          "FromX": {
+            "type": "number",
+            "description": "Start X position in screen pixels for Drag action (origin: top-left). Drag starts here and moves to X,Y.",
+            "default": 0
+          },
+          "FromY": {
+            "type": "number",
+            "description": "Start Y position in screen pixels for Drag action (origin: top-left). Drag starts here and moves to X,Y.",
+            "default": 0
+          },
+          "DragSpeed": {
+            "type": "number",
+            "description": "Drag speed in pixels per second (0 for instant). Applies to Drag, DragMove, and DragEnd actions.",
+            "default": 2000
+          },
+          "Duration": {
+            "type": "number",
+            "description": "Hold duration in seconds for LongPress action (default: 0.5).",
+            "default": 0.5
+          },
+          "Button": {
+            "type": "string",
+            "description": "Mouse button: Left(0, default), Right(1), Middle(2).",
+            "default": 0,
+            "enum": [
+              "Left",
+              "Right",
+              "Middle"
+            ]
           }
         },
         "required": []

--- a/moorestech_client/Assets/AddressableResources/Block/Automatic_loom.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/Automatic_loom.prefab
@@ -89,6 +89,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &5546303415493633367
 BoxCollider:
@@ -199,6 +200,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &1142985264030112830
 GameObject:
@@ -288,6 +290,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &1462928483321019174
 GameObject:
@@ -378,6 +381,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &2986518112350196981
 BoxCollider:
@@ -489,6 +493,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &3539226310113827785
 BoxCollider:
@@ -600,6 +605,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &635358536984230746
 BoxCollider:
@@ -711,6 +717,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &8670134019340065158
 BoxCollider:
@@ -855,6 +862,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &4067415329992146776
 BoxCollider:
@@ -965,6 +973,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &4454558837963271978
 GameObject:
@@ -1088,6 +1097,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &3361649960993183662
 BoxCollider:
@@ -1120,6 +1130,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2563693994293955104}
   - component: {fileID: 4117102931534652962}
+  - component: {fileID: 7756702631296846981}
   m_Layer: 7
   m_Name: Automatic_loom
   m_TagString: Untagged
@@ -1170,20 +1181,41 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.StateProcessor.GearStateChangeProcessor
   rotationInfos:
-  - rotationMode: 0
-    rotationAxis: 0
-    rotationTransform: {fileID: 2160269865489261940}
-    animator: {fileID: 0}
-    rpm60Speed: 0
-    isReverse: 0
-    rotationSpeed: 1
-  - rotationMode: 0
-    rotationAxis: 0
-    rotationTransform: {fileID: 4090871014590697041}
-    animator: {fileID: 0}
-    rpm60Speed: 0
-    isReverse: 1
-    rotationSpeed: 1
+  - rid: 3331677946101629061
+  - rid: 3331677946101629062
+  references:
+    version: 2
+    RefIds:
+    - rid: 3331677946101629061
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 0
+        rotationTransform: {fileID: 2160269865489261940}
+        rotationSpeed: 1
+    - rid: 3331677946101629062
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 1
+        rotationAxis: 0
+        rotationTransform: {fileID: 4090871014590697041}
+        rotationSpeed: 1
+--- !u!114 &7756702631296846981
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4874315026191316956}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4bb7f8f1958ea4c37b753af86394eb8a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.StateProcessor.GearStateChangeProcessorSimulator
+  targetProcessor: {fileID: 4117102931534652962}
+  isSimulating: 0
+  simulateRpm: 60
+  simulateIsClockwise: 1
 --- !u!1 &5896368500484640645
 GameObject:
   m_ObjectHideFlags: 0
@@ -1273,6 +1305,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &2432618817358263352
 BoxCollider:
@@ -1384,6 +1417,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &1520905283671736916
 BoxCollider:
@@ -1495,6 +1529,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &4074268446523849736
 BoxCollider:
@@ -1606,6 +1641,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &4851706637265958983
 BoxCollider:
@@ -1716,6 +1752,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1001 &900457482418849201
 PrefabInstance:

--- a/moorestech_client/Assets/AddressableResources/Block/BigGear.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/BigGear.prefab
@@ -88,6 +88,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &3275088556043162121
 GameObject:
@@ -178,6 +179,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &1035331463896775981
 BoxCollider:
@@ -324,6 +326,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!64 &4345664292913582027
 MeshCollider:
@@ -435,6 +438,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &4731844410245127559
 GameObject:
@@ -525,6 +529,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &8732426611606426485
 BoxCollider:
@@ -635,6 +640,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &4855568091405056994
 GameObject:
@@ -725,6 +731,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &9168141015220704615
 BoxCollider:
@@ -835,6 +842,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &6362663631200503991
 GameObject:
@@ -925,6 +933,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!64 &8660761407999225088
 MeshCollider:
@@ -1037,6 +1046,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &7764996366102711762
 BoxCollider:
@@ -1126,13 +1136,17 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   rotationInfos:
-  - rotationMode: 0
-    rotationAxis: 2
-    rotationTransform: {fileID: 3253118763272804755}
-    isReverse: 0
-    rotationSpeed: 1
-    animator: {fileID: 0}
-    rpm60Speed: 1
+  - rid: 3331677946101629063
+  references:
+    version: 2
+    RefIds:
+    - rid: 3331677946101629063
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 2
+        rotationTransform: {fileID: 3253118763272804755}
+        rotationSpeed: 1
 --- !u!1 &7397736660562999078
 GameObject:
   m_ObjectHideFlags: 0

--- a/moorestech_client/Assets/AddressableResources/Block/Fuel_powered_windmill.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/Fuel_powered_windmill.prefab
@@ -89,6 +89,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!64 &2593102954513089642
 MeshCollider:
@@ -310,6 +311,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &2608808872943570715
 BoxCollider:
@@ -421,6 +423,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &8051666484586834875
 BoxCollider:
@@ -571,6 +574,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &4006169528934327245
 BoxCollider:
@@ -682,6 +686,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &8485574458686482519
 BoxCollider:
@@ -793,6 +798,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &9096223091528611759
 BoxCollider:
@@ -936,6 +942,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &7594734582770096691
 BoxCollider:
@@ -1047,6 +1054,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &4674646495388232180
 BoxCollider:
@@ -1158,6 +1166,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &9197067064779355537
 BoxCollider:
@@ -1269,6 +1278,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &8458734770107318021
 BoxCollider:
@@ -1380,6 +1390,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!136 &2663839899441657879
 CapsuleCollider:
@@ -1493,6 +1504,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &8505912992045525516
 BoxCollider:
@@ -1604,6 +1616,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &3975361315459647193
 BoxCollider:
@@ -1715,6 +1728,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &6794595897617526393
 BoxCollider:
@@ -1826,6 +1840,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &1246140750752571428
 BoxCollider:
@@ -1937,6 +1952,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &5204211243270523674
 BoxCollider:
@@ -2048,6 +2064,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &3204567122418257728
 BoxCollider:
@@ -2223,6 +2240,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &2945200413031091400
 BoxCollider:
@@ -2366,6 +2384,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &5445758718548429902
 BoxCollider:
@@ -2542,6 +2561,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &3575201440562518858
 BoxCollider:
@@ -2685,6 +2705,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &7816731390773294008
 BoxCollider:
@@ -2863,6 +2884,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &4259059001889254646
 BoxCollider:
@@ -3038,6 +3060,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &1788479039863501611
 BoxCollider:
@@ -3149,6 +3172,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!136 &17117678525913272
 CapsuleCollider:
@@ -3294,6 +3318,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &5916677394740213449
 BoxCollider:
@@ -3405,6 +3430,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!136 &8445015738249197541
 CapsuleCollider:
@@ -3518,6 +3544,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!136 &355148795666710591
 CapsuleCollider:
@@ -3595,34 +3622,41 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.StateProcessor.GearStateChangeProcessor
   rotationInfos:
-  - rotationMode: 0
-    rotationAxis: 0
-    rotationTransform: {fileID: 7581798578376413590}
-    isReverse: 0
-    rotationSpeed: 1
-    animator: {fileID: 0}
-    rpm60Speed: 0
-  - rotationMode: 0
-    rotationAxis: 1
-    rotationTransform: {fileID: 7781852951989586431}
-    isReverse: 0
-    rotationSpeed: 1
-    animator: {fileID: 0}
-    rpm60Speed: 0
-  - rotationMode: 0
-    rotationAxis: 1
-    rotationTransform: {fileID: 5741778233370143903}
-    isReverse: 0
-    rotationSpeed: 1
-    animator: {fileID: 0}
-    rpm60Speed: 0
-  - rotationMode: 0
-    rotationAxis: 1
-    rotationTransform: {fileID: 6792714997188756603}
-    isReverse: 0
-    rotationSpeed: 1
-    animator: {fileID: 0}
-    rpm60Speed: 0
+  - rid: 3331677946101629068
+  - rid: 3331677946101629069
+  - rid: 3331677946101629070
+  - rid: 3331677946101629071
+  references:
+    version: 2
+    RefIds:
+    - rid: 3331677946101629068
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 0
+        rotationTransform: {fileID: 7581798578376413590}
+        rotationSpeed: 1
+    - rid: 3331677946101629069
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 1
+        rotationTransform: {fileID: 7781852951989586431}
+        rotationSpeed: 1
+    - rid: 3331677946101629070
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 1
+        rotationTransform: {fileID: 5741778233370143903}
+        rotationSpeed: 1
+    - rid: 3331677946101629071
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 1
+        rotationTransform: {fileID: 6792714997188756603}
+        rotationSpeed: 1
 --- !u!114 &2537138480116240339
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3925,6 +3959,22 @@ PrefabInstance:
     - target: {fileID: 1069051896562662691, guid: a22f794443335e74c82387a9f622ffcd, type: 3}
       propertyPath: m_Name
       value: gear belt conveyor
+      objectReference: {fileID: 0}
+    - target: {fileID: 1920843585219452797, guid: a22f794443335e74c82387a9f622ffcd, type: 3}
+      propertyPath: 'managedReferences[-2]'
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1920843585219452797, guid: a22f794443335e74c82387a9f622ffcd, type: 3}
+      propertyPath: 'rotationInfos.Array.data[0]'
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1920843585219452797, guid: a22f794443335e74c82387a9f622ffcd, type: 3}
+      propertyPath: 'rotationInfos.Array.data[1]'
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1920843585219452797, guid: a22f794443335e74c82387a9f622ffcd, type: 3}
+      propertyPath: 'rotationInfos.Array.data[2]'
+      value: -2
       objectReference: {fileID: 0}
     - target: {fileID: 2750780202867129520, guid: a22f794443335e74c82387a9f622ffcd, type: 3}
       propertyPath: m_LocalPosition.x

--- a/moorestech_client/Assets/AddressableResources/Block/GearBeltConveyor Shaft.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/GearBeltConveyor Shaft.prefab
@@ -59,6 +59,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -80,9 +85,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!64 &1260705963578528311
 MeshCollider:
@@ -198,6 +205,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -219,9 +231,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &3007691065750262067
 BoxCollider:
@@ -303,6 +317,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -324,9 +343,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &879539770335653589
 BoxCollider:
@@ -408,6 +429,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -429,9 +455,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &8490051068003264726
 BoxCollider:
@@ -464,6 +492,7 @@ GameObject:
   m_Component:
   - component: {fileID: 6362561513966057089}
   - component: {fileID: 3337085609983907916}
+  - component: {fileID: 455414102666533038}
   m_Layer: 7
   m_Name: GearBeltConveyor Shaft
   m_TagString: Untagged
@@ -506,18 +535,49 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   rotationInfos:
-  - rotationAxis: 2
-    rotationTransform: {fileID: 2388746715498632052}
-    isReverse: 0
-    rotationSpeed: 1
-  - rotationAxis: 1
-    rotationTransform: {fileID: 6198614747264177215}
-    isReverse: 1
-    rotationSpeed: 1
-  - rotationAxis: 2
-    rotationTransform: {fileID: 8444679472851781093}
-    isReverse: 0
-    rotationSpeed: 1
+  - rid: 3331677946101629081
+  - rid: 3331677946101629082
+  - rid: 3331677946101629083
+  references:
+    version: 2
+    RefIds:
+    - rid: 3331677946101629081
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 2
+        rotationTransform: {fileID: 2388746715498632052}
+        rotationSpeed: 1
+    - rid: 3331677946101629082
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 1
+        rotationAxis: 1
+        rotationTransform: {fileID: 6198614747264177215}
+        rotationSpeed: 1
+    - rid: 3331677946101629083
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 2
+        rotationTransform: {fileID: 8444679472851781093}
+        rotationSpeed: 1
+--- !u!114 &455414102666533038
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5188025818332770762}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4bb7f8f1958ea4c37b753af86394eb8a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.StateProcessor.GearStateChangeProcessorSimulator
+  targetProcessor: {fileID: 3337085609983907916}
+  isSimulating: 0
+  simulateRpm: 60
+  simulateIsClockwise: 1
 --- !u!1 &5645395868698417386
 GameObject:
   m_ObjectHideFlags: 0
@@ -577,6 +637,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -598,9 +663,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!64 &3263047685204551782
 MeshCollider:
@@ -683,6 +750,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -704,9 +776,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!64 &6150633706305779878
 MeshCollider:
@@ -821,6 +895,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -842,9 +921,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &4078703892108375859
 BoxCollider:
@@ -926,6 +1007,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -947,9 +1033,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!64 &1292667533690770965
 MeshCollider:

--- a/moorestech_client/Assets/AddressableResources/Block/GearChainPole.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/GearChainPole.prefab
@@ -88,6 +88,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &6111979808977259825
 GameObject:
@@ -178,6 +179,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &6850029173131796601
 BoxCollider:
@@ -290,6 +292,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!64 &4327618837499139749
 MeshCollider:
@@ -413,6 +416,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &7588150132072967899
 GameObject:
@@ -468,20 +472,25 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.StateProcessor.GearStateChangeProcessor
   rotationInfos:
-  - rotationMode: 0
-    rotationAxis: 1
-    rotationTransform: {fileID: 1525459309663098135}
-    isReverse: 0
-    rotationSpeed: 1
-    animator: {fileID: 0}
-    rpm60Speed: 0
-  - rotationMode: 0
-    rotationAxis: 1
-    rotationTransform: {fileID: 3132322806867691930}
-    isReverse: 0
-    rotationSpeed: 1
-    animator: {fileID: 0}
-    rpm60Speed: 0
+  - rid: 3331677946101629084
+  - rid: 3331677946101629085
+  references:
+    version: 2
+    RefIds:
+    - rid: 3331677946101629084
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 1
+        rotationTransform: {fileID: 1525459309663098135}
+        rotationSpeed: 1
+    - rid: 3331677946101629085
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 1
+        rotationTransform: {fileID: 3132322806867691930}
+        rotationSpeed: 1
 --- !u!114 &4833313802552299297
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -612,6 +621,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &2850107204138790801
 BoxCollider:

--- a/moorestech_client/Assets/AddressableResources/Block/GearGenerator.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/GearGenerator.prefab
@@ -88,6 +88,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &5148459928240279573
 GameObject:
@@ -177,6 +178,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &6360553927929529955
 GameObject:
@@ -221,6 +223,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5658812533324408500}
   - component: {fileID: 1413506487705312501}
+  - component: {fileID: 6090445013276123468}
   m_Layer: 7
   m_Name: GearGenerator
   m_TagString: Untagged
@@ -257,10 +260,30 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   rotationInfos:
-  - rotationMode: 0
-    rotationAxis: 1
-    rotationTransform: {fileID: 425294154870311790}
-    animator: {fileID: 0}
-    rpm60Speed: 1
-    isReverse: 0
-    rotationSpeed: 1
+  - rid: 3331677946101629086
+  references:
+    version: 2
+    RefIds:
+    - rid: 3331677946101629086
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 1
+        rotationTransform: {fileID: 425294154870311790}
+        rotationSpeed: 1
+--- !u!114 &6090445013276123468
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8602712561740545474}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4bb7f8f1958ea4c37b753af86394eb8a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.StateProcessor.GearStateChangeProcessorSimulator
+  targetProcessor: {fileID: 1413506487705312501}
+  isSimulating: 0
+  simulateRpm: 60
+  simulateIsClockwise: 1

--- a/moorestech_client/Assets/AddressableResources/Block/GearPump.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/GearPump.prefab
@@ -95,6 +95,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -116,9 +118,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &131543095466679876
 BoxCollider:
@@ -203,6 +207,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -224,9 +230,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!64 &2998829122965390263
 MeshCollider:
@@ -312,6 +320,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -333,9 +343,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!64 &6204404724511453982
 MeshCollider:
@@ -369,6 +381,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5883432744439673512}
   - component: {fileID: 7866576508506021417}
+  - component: {fileID: 7139277890134963739}
   m_Layer: 7
   m_Name: GearPump
   m_TagString: Untagged
@@ -407,14 +420,41 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   rotationInfos:
-  - rotationAxis: 1
-    rotationTransform: {fileID: 1601366576592515872}
-    isReverse: 0
-    rotationSpeed: 1
-  - rotationAxis: 1
-    rotationTransform: {fileID: 1231787821692714487}
-    isReverse: 0
-    rotationSpeed: 1
+  - rid: 3331677946101629087
+  - rid: 3331677946101629088
+  references:
+    version: 2
+    RefIds:
+    - rid: 3331677946101629087
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 1
+        rotationTransform: {fileID: 1601366576592515872}
+        rotationSpeed: 1
+    - rid: 3331677946101629088
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 1
+        rotationTransform: {fileID: 1231787821692714487}
+        rotationSpeed: 1
+--- !u!114 &7139277890134963739
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8004703537945082689}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4bb7f8f1958ea4c37b753af86394eb8a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.StateProcessor.GearStateChangeProcessorSimulator
+  targetProcessor: {fileID: 7866576508506021417}
+  isSimulating: 0
+  simulateRpm: 60
+  simulateIsClockwise: 1
 --- !u!1001 &4984704745912876594
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/moorestech_client/Assets/AddressableResources/Block/Ore_Crusher.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/Ore_Crusher.prefab
@@ -88,6 +88,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &1098583249194049680
 GameObject:
@@ -177,6 +178,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &1222757879334386990
 GameObject:
@@ -267,6 +269,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &6009878685193743928
 BoxCollider:
@@ -411,6 +414,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &6830411883225395555
 BoxCollider:
@@ -521,6 +525,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &2599359834380128669
 GameObject:
@@ -611,6 +616,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &143792421737021832
 BoxCollider:
@@ -722,6 +728,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &9197969655521851700
 BoxCollider:
@@ -832,6 +839,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &3378564395071023244
 GameObject:
@@ -922,6 +930,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &3029129553974664637
 BoxCollider:
@@ -1066,6 +1075,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &3514811075240174259
 GameObject:
@@ -1155,6 +1165,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &5418008480785875564
 GameObject:
@@ -1244,6 +1255,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &5578004651690675952
 GameObject:
@@ -1333,6 +1345,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &5773187035507029786
 GameObject:
@@ -1455,6 +1468,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &6001239325339001842
 GameObject:
@@ -1518,48 +1532,57 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   rotationInfos:
-  - rotationMode: 0
-    rotationAxis: 1
-    rotationTransform: {fileID: 580472665107816593}
-    isReverse: 1
-    rotationSpeed: 1
-    animator: {fileID: 0}
-    rpm60Speed: 1
-  - rotationMode: 0
-    rotationAxis: 1
-    rotationTransform: {fileID: 6365465298445728280}
-    isReverse: 0
-    rotationSpeed: 1
-    animator: {fileID: 0}
-    rpm60Speed: 1
-  - rotationMode: 0
-    rotationAxis: 1
-    rotationTransform: {fileID: 1953966024594732965}
-    isReverse: 1
-    rotationSpeed: 1
-    animator: {fileID: 0}
-    rpm60Speed: 1
-  - rotationMode: 0
-    rotationAxis: 1
-    rotationTransform: {fileID: 3444385633380213084}
-    isReverse: 1
-    rotationSpeed: 1
-    animator: {fileID: 0}
-    rpm60Speed: 1
-  - rotationMode: 0
-    rotationAxis: 1
-    rotationTransform: {fileID: 3165029329073223443}
-    isReverse: 1
-    rotationSpeed: 1
-    animator: {fileID: 0}
-    rpm60Speed: 1
-  - rotationMode: 0
-    rotationAxis: 1
-    rotationTransform: {fileID: 3999524834855363369}
-    isReverse: 1
-    rotationSpeed: 1
-    animator: {fileID: 0}
-    rpm60Speed: 1
+  - rid: 3331677946101629094
+  - rid: 3331677946101629095
+  - rid: 3331677946101629096
+  - rid: 3331677946101629097
+  - rid: 3331677946101629098
+  - rid: 3331677946101629099
+  references:
+    version: 2
+    RefIds:
+    - rid: 3331677946101629094
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 1
+        rotationAxis: 1
+        rotationTransform: {fileID: 580472665107816593}
+        rotationSpeed: 1
+    - rid: 3331677946101629095
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 1
+        rotationTransform: {fileID: 6365465298445728280}
+        rotationSpeed: 1
+    - rid: 3331677946101629096
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 1
+        rotationAxis: 1
+        rotationTransform: {fileID: 1953966024594732965}
+        rotationSpeed: 1
+    - rid: 3331677946101629097
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 1
+        rotationAxis: 1
+        rotationTransform: {fileID: 3444385633380213084}
+        rotationSpeed: 1
+    - rid: 3331677946101629098
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 1
+        rotationAxis: 1
+        rotationTransform: {fileID: 3165029329073223443}
+        rotationSpeed: 1
+    - rid: 3331677946101629099
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 1
+        rotationAxis: 1
+        rotationTransform: {fileID: 3999524834855363369}
+        rotationSpeed: 1
 --- !u!114 &1061048431520410805
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1664,6 +1687,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &6486006647613928617
 GameObject:
@@ -1753,6 +1777,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &6769780007618333432
 GameObject:
@@ -1843,6 +1868,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &8316003516340498152
 BoxCollider:
@@ -1988,6 +2014,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &4045214237352630250
 BoxCollider:
@@ -2098,6 +2125,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &8971093106949415060
 GameObject:
@@ -2187,6 +2215,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &9215334756045166261
 GameObject:

--- a/moorestech_client/Assets/AddressableResources/Block/Primitive Centrifuge.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/Primitive Centrifuge.prefab
@@ -54,6 +54,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -75,9 +80,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!114 &7719600914138549709
 MonoBehaviour:
@@ -137,20 +144,23 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 00000000
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 0
   m_isCullingEnabled: 0
@@ -181,6 +191,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2234336759905747110}
   - component: {fileID: 1133369575847100089}
+  - component: {fileID: 223063206586247296}
   m_Layer: 7
   m_Name: Primitive Centrifuge
   m_TagString: Untagged
@@ -219,10 +230,33 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   rotationInfos:
-  - rotationAxis: 1
-    rotationTransform: {fileID: 3979171563678568355}
-    isReverse: 0
-    rotationSpeed: 1
+  - rid: 3331677946101629100
+  references:
+    version: 2
+    RefIds:
+    - rid: 3331677946101629100
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 1
+        rotationTransform: {fileID: 3979171563678568355}
+        rotationSpeed: 1
+--- !u!114 &223063206586247296
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5575862882397089563}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4bb7f8f1958ea4c37b753af86394eb8a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.StateProcessor.GearStateChangeProcessorSimulator
+  targetProcessor: {fileID: 1133369575847100089}
+  isSimulating: 0
+  simulateRpm: 60
+  simulateIsClockwise: 1
 --- !u!1 &6354870569503064852
 GameObject:
   m_ObjectHideFlags: 0
@@ -282,6 +316,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -303,9 +342,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!136 &224003521752949364
 CapsuleCollider:
@@ -389,6 +430,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -410,9 +456,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!136 &1855814733541578938
 CapsuleCollider:

--- a/moorestech_client/Assets/AddressableResources/Block/Primitive logging machine.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/Primitive logging machine.prefab
@@ -92,6 +92,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -113,9 +118,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!136 &2793933530930016519
 CapsuleCollider:
@@ -183,6 +190,7 @@ GameObject:
   m_Component:
   - component: {fileID: 743813655841741807}
   - component: {fileID: 7702827523668355967}
+  - component: {fileID: 2193224948945948191}
   m_Layer: 7
   m_Name: Primitive logging machine
   m_TagString: Untagged
@@ -219,10 +227,33 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   rotationInfos:
-  - rotationAxis: 1
-    rotationTransform: {fileID: 279611936339862467}
-    isReverse: 0
-    rotationSpeed: 1
+  - rid: 3331677946101629101
+  references:
+    version: 2
+    RefIds:
+    - rid: 3331677946101629101
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 1
+        rotationTransform: {fileID: 279611936339862467}
+        rotationSpeed: 1
+--- !u!114 &2193224948945948191
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7076013413797805302}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4bb7f8f1958ea4c37b753af86394eb8a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.StateProcessor.GearStateChangeProcessorSimulator
+  targetProcessor: {fileID: 7702827523668355967}
+  isSimulating: 0
+  simulateRpm: 60
+  simulateIsClockwise: 1
 --- !u!1 &7434589826483082784
 GameObject:
   m_ObjectHideFlags: 0
@@ -282,6 +313,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -303,9 +339,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!136 &3777642189903843843
 CapsuleCollider:
@@ -389,6 +427,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -410,9 +453,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &6185745429031705157
 BoxCollider:

--- a/moorestech_client/Assets/AddressableResources/Block/Primitive_Miner.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/Primitive_Miner.prefab
@@ -89,6 +89,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &5332742362700185759
 BoxCollider:
@@ -200,6 +201,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!64 &5167138661711672579
 MeshCollider:
@@ -311,6 +313,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &656107633676687791
 GameObject:
@@ -401,6 +404,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &5598521592733391317
 BoxCollider:
@@ -512,6 +516,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &6092612823191508785
 BoxCollider:
@@ -622,6 +627,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &1008574169515922057
 GameObject:
@@ -712,6 +718,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &206750390181715174
 BoxCollider:
@@ -823,6 +830,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &8719483556939023130
 BoxCollider:
@@ -933,6 +941,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &1710036042866352401
 GameObject:
@@ -1073,6 +1082,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &6301915325347374900
 BoxCollider:
@@ -1184,6 +1194,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &6946416758219730702
 BoxCollider:
@@ -1294,6 +1305,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &2015962154966608291
 GameObject:
@@ -1383,6 +1395,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &2039461559378117891
 GameObject:
@@ -1473,6 +1486,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!136 &2569584531746247361
 CapsuleCollider:
@@ -1585,6 +1599,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &2276896887799152996
 GameObject:
@@ -1675,6 +1690,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &7785627222799929244
 BoxCollider:
@@ -1786,6 +1802,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &4910026350975676764
 BoxCollider:
@@ -1896,6 +1913,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &2862876030337334240
 GameObject:
@@ -1986,6 +2004,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &1611802873719978764
 BoxCollider:
@@ -2097,6 +2116,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &7424959619009681132
 BoxCollider:
@@ -2208,6 +2228,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &3758824061972794370
 BoxCollider:
@@ -2353,6 +2374,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &1859556615008612661
 BoxCollider:
@@ -2464,6 +2486,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!64 &3260302336141631770
 MeshCollider:
@@ -2575,6 +2598,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &3766388255688599050
 GameObject:
@@ -2664,6 +2688,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &3791354098957467302
 GameObject:
@@ -2754,6 +2779,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &5253207622697956166
 BoxCollider:
@@ -2865,6 +2891,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &1708621637305902346
 BoxCollider:
@@ -2975,6 +3002,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &4057105948733159752
 GameObject:
@@ -3065,6 +3093,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &4332800898931439116
 BoxCollider:
@@ -3176,6 +3205,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &716111325105691268
 BoxCollider:
@@ -3287,6 +3317,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &7173646938362945252
 BoxCollider:
@@ -3398,6 +3429,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &5690559378565841568
 BoxCollider:
@@ -3509,6 +3541,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &1784644638748403886
 BoxCollider:
@@ -3620,6 +3653,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &996533901246208832
 BoxCollider:
@@ -3731,6 +3765,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &2528645590654179383
 BoxCollider:
@@ -3842,6 +3877,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &6338008259875857316
 BoxCollider:
@@ -3953,6 +3989,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &302066587159556630
 BoxCollider:
@@ -4064,6 +4101,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &4609457246387424918
 BoxCollider:
@@ -4208,6 +4246,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!64 &2896092646085389970
 MeshCollider:
@@ -4320,6 +4359,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &4476949338850717973
 BoxCollider:
@@ -4431,6 +4471,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!64 &6444108972719330000
 MeshCollider:
@@ -4543,6 +4584,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &6098254273431861712
 BoxCollider:
@@ -4721,6 +4763,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &1013310322671927488
 BoxCollider:
@@ -4831,6 +4874,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &5618686783257207203
 GameObject:
@@ -4920,6 +4964,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &5653315780151761859
 GameObject:
@@ -5009,6 +5054,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &5659820162664648809
 GameObject:
@@ -5099,6 +5145,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &1917775695420506043
 BoxCollider:
@@ -5209,6 +5256,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &6162913659269828353
 GameObject:
@@ -5299,6 +5347,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &7984583706688807479
 BoxCollider:
@@ -5409,6 +5458,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &6341712135781855609
 GameObject:
@@ -5499,6 +5549,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &1589272021555515189
 BoxCollider:
@@ -5609,6 +5660,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &6558391994948223627
 GameObject:
@@ -5698,6 +5750,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &6791559921189425164
 GameObject:
@@ -5788,6 +5841,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &5241458944488362115
 BoxCollider:
@@ -5932,6 +5986,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &6947715010700453987
 GameObject:
@@ -6021,6 +6076,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &7169645171723788259
 GameObject:
@@ -6111,6 +6167,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &2895335111047180559
 BoxCollider:
@@ -6221,6 +6278,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &7200541347293696750
 GameObject:
@@ -6311,6 +6369,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &390621216488069583
 BoxCollider:
@@ -6421,6 +6480,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &7455962746079930088
 GameObject:
@@ -6510,6 +6570,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &7627266642864209490
 GameObject:
@@ -6600,6 +6661,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &8555884891230622529
 BoxCollider:
@@ -6710,6 +6772,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &7867512525359152246
 GameObject:
@@ -6835,6 +6898,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &8234383652808865890
 GameObject:
@@ -6925,6 +6989,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &305502598966022672
 BoxCollider:
@@ -7036,6 +7101,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &3758207867826701701
 BoxCollider:
@@ -7123,27 +7189,33 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.StateProcessor.GearStateChangeProcessor
   rotationInfos:
-  - rotationMode: 0
-    rotationAxis: 0
-    rotationTransform: {fileID: 5540162150683285732}
-    isReverse: 0
-    rotationSpeed: 1
-    animator: {fileID: 0}
-    rpm60Speed: 0
-  - rotationMode: 0
-    rotationAxis: 2
-    rotationTransform: {fileID: 4916444550280249049}
-    isReverse: 1
-    rotationSpeed: 0.3
-    animator: {fileID: 0}
-    rpm60Speed: 0
-  - rotationMode: 0
-    rotationAxis: 1
-    rotationTransform: {fileID: 3728065500461631347}
-    isReverse: 1
-    rotationSpeed: 0.2
-    animator: {fileID: 0}
-    rpm60Speed: 0
+  - rid: 3331677946101629109
+  - rid: 3331677946101629110
+  - rid: 3331677946101629111
+  references:
+    version: 2
+    RefIds:
+    - rid: 3331677946101629109
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 0
+        rotationTransform: {fileID: 5540162150683285732}
+        rotationSpeed: 1
+    - rid: 3331677946101629110
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 1
+        rotationAxis: 2
+        rotationTransform: {fileID: 4916444550280249049}
+        rotationSpeed: 0.3
+    - rid: 3331677946101629111
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 1
+        rotationAxis: 1
+        rotationTransform: {fileID: 3728065500461631347}
+        rotationSpeed: 0.2
 --- !u!1 &8596840273744103934
 GameObject:
   m_ObjectHideFlags: 0
@@ -7268,6 +7340,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &9137038533853039737
 BoxCollider:
@@ -7305,6 +7378,22 @@ PrefabInstance:
     - target: {fileID: 1069051896562662691, guid: a22f794443335e74c82387a9f622ffcd, type: 3}
       propertyPath: m_IsActive
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1920843585219452797, guid: a22f794443335e74c82387a9f622ffcd, type: 3}
+      propertyPath: 'managedReferences[-2]'
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1920843585219452797, guid: a22f794443335e74c82387a9f622ffcd, type: 3}
+      propertyPath: 'rotationInfos.Array.data[0]'
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1920843585219452797, guid: a22f794443335e74c82387a9f622ffcd, type: 3}
+      propertyPath: 'rotationInfos.Array.data[1]'
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1920843585219452797, guid: a22f794443335e74c82387a9f622ffcd, type: 3}
+      propertyPath: 'rotationInfos.Array.data[2]'
+      value: -2
       objectReference: {fileID: 0}
     - target: {fileID: 2750780202867129520, guid: a22f794443335e74c82387a9f622ffcd, type: 3}
       propertyPath: m_LocalPosition.x

--- a/moorestech_client/Assets/AddressableResources/Block/Primitive_Windmill blue.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/Primitive_Windmill blue.prefab
@@ -91,6 +91,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -112,9 +117,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &2536247810950133649
 BoxCollider:
@@ -196,6 +203,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -217,9 +229,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &4452295358893541811
 BoxCollider:
@@ -301,6 +315,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -322,9 +341,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &6536906588653809106
 BoxCollider:
@@ -406,6 +427,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -427,9 +453,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &5864399533283827712
 BoxCollider:
@@ -575,6 +603,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -596,9 +629,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &8523896894288564604
 BoxCollider:
@@ -680,6 +715,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -701,9 +741,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!136 &5439493658976503463
 CapsuleCollider:
@@ -787,6 +829,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -808,9 +855,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &8002510351233095514
 BoxCollider:
@@ -892,6 +941,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -913,9 +967,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &4751097757795773003
 BoxCollider:
@@ -997,6 +1053,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1018,9 +1079,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &7063037160770227218
 BoxCollider:
@@ -1134,6 +1197,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1155,9 +1223,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &5868826007802854913
 BoxCollider:
@@ -1271,6 +1341,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1292,9 +1367,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!136 &6042266939485348125
 CapsuleCollider:
@@ -1378,6 +1455,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1399,9 +1481,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &7083213379901578871
 BoxCollider:
@@ -1483,6 +1567,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1504,9 +1593,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &8207226564424673076
 BoxCollider:
@@ -1539,6 +1630,7 @@ GameObject:
   m_Component:
   - component: {fileID: 6070916361125752825}
   - component: {fileID: 8115039583878400241}
+  - component: {fileID: 7249301893741290361}
   m_Layer: 7
   m_Name: Primitive_Windmill blue
   m_TagString: Untagged
@@ -1583,18 +1675,49 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   rotationInfos:
-  - rotationAxis: 1
-    rotationTransform: {fileID: 1249975213152999919}
-    isReverse: 1
-    rotationSpeed: 1
-  - rotationAxis: 1
-    rotationTransform: {fileID: 1484686555961022137}
-    isReverse: 0
-    rotationSpeed: 1
-  - rotationAxis: 0
-    rotationTransform: {fileID: 6466623224438294828}
-    isReverse: 0
-    rotationSpeed: 1
+  - rid: 3331677946101629112
+  - rid: 3331677946101629113
+  - rid: 3331677946101629114
+  references:
+    version: 2
+    RefIds:
+    - rid: 3331677946101629112
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 1
+        rotationAxis: 1
+        rotationTransform: {fileID: 1249975213152999919}
+        rotationSpeed: 1
+    - rid: 3331677946101629113
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 1
+        rotationTransform: {fileID: 1484686555961022137}
+        rotationSpeed: 1
+    - rid: 3331677946101629114
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 0
+        rotationTransform: {fileID: 6466623224438294828}
+        rotationSpeed: 1
+--- !u!114 &7249301893741290361
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5597865423700543452}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4bb7f8f1958ea4c37b753af86394eb8a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.StateProcessor.GearStateChangeProcessorSimulator
+  targetProcessor: {fileID: 8115039583878400241}
+  isSimulating: 0
+  simulateRpm: 60
+  simulateIsClockwise: 1
 --- !u!1 &5706012872980177505
 GameObject:
   m_ObjectHideFlags: 0
@@ -1686,6 +1809,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1707,9 +1835,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &8702500896039488788
 BoxCollider:
@@ -1791,6 +1921,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1812,9 +1947,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &1903319745466989393
 BoxCollider:
@@ -1896,6 +2033,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1917,9 +2059,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &1418025536358767174
 BoxCollider:
@@ -2001,6 +2145,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -2022,9 +2171,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &6445554690155575544
 BoxCollider:
@@ -2247,6 +2398,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -2268,9 +2424,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &2191995603529210457
 BoxCollider:
@@ -2448,6 +2606,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -2469,9 +2632,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &2865815601582902789
 BoxCollider:
@@ -2553,6 +2718,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -2574,9 +2744,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &1690215613927346583
 BoxCollider:
@@ -2658,6 +2830,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -2679,9 +2856,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!136 &2236147176552118524
 CapsuleCollider:
@@ -2765,6 +2944,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -2786,9 +2970,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &2201352656538343862
 BoxCollider:

--- a/moorestech_client/Assets/AddressableResources/Block/Primitive_Windmill.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/Primitive_Windmill.prefab
@@ -91,6 +91,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -112,9 +117,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &2536247810950133649
 BoxCollider:
@@ -196,6 +203,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -217,9 +229,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &4452295358893541811
 BoxCollider:
@@ -301,6 +315,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -322,9 +341,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &6536906588653809106
 BoxCollider:
@@ -406,6 +427,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -427,9 +453,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &5864399533283827712
 BoxCollider:
@@ -575,6 +603,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -596,9 +629,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &8523896894288564604
 BoxCollider:
@@ -680,6 +715,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -701,9 +741,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!136 &5439493658976503463
 CapsuleCollider:
@@ -787,6 +829,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -808,9 +855,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &8002510351233095514
 BoxCollider:
@@ -892,6 +941,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -913,9 +967,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &4751097757795773003
 BoxCollider:
@@ -997,6 +1053,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1018,9 +1079,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &7063037160770227218
 BoxCollider:
@@ -1134,6 +1197,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1155,9 +1223,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &5868826007802854913
 BoxCollider:
@@ -1271,6 +1341,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1292,9 +1367,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!136 &6042266939485348125
 CapsuleCollider:
@@ -1378,6 +1455,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1399,9 +1481,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &7083213379901578871
 BoxCollider:
@@ -1483,6 +1567,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1504,9 +1593,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &8207226564424673076
 BoxCollider:
@@ -1539,6 +1630,7 @@ GameObject:
   m_Component:
   - component: {fileID: 6070916361125752825}
   - component: {fileID: 8115039583878400241}
+  - component: {fileID: 7249301893741290361}
   m_Layer: 7
   m_Name: Primitive_Windmill
   m_TagString: Untagged
@@ -1583,18 +1675,49 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   rotationInfos:
-  - rotationAxis: 1
-    rotationTransform: {fileID: 1249975213152999919}
-    isReverse: 1
-    rotationSpeed: 1
-  - rotationAxis: 1
-    rotationTransform: {fileID: 1484686555961022137}
-    isReverse: 0
-    rotationSpeed: 1
-  - rotationAxis: 0
-    rotationTransform: {fileID: 6466623224438294828}
-    isReverse: 0
-    rotationSpeed: 1
+  - rid: 3331677946101629115
+  - rid: 3331677946101629116
+  - rid: 3331677946101629117
+  references:
+    version: 2
+    RefIds:
+    - rid: 3331677946101629115
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 1
+        rotationAxis: 1
+        rotationTransform: {fileID: 1249975213152999919}
+        rotationSpeed: 1
+    - rid: 3331677946101629116
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 1
+        rotationTransform: {fileID: 1484686555961022137}
+        rotationSpeed: 1
+    - rid: 3331677946101629117
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 0
+        rotationTransform: {fileID: 6466623224438294828}
+        rotationSpeed: 1
+--- !u!114 &7249301893741290361
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5597865423700543452}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4bb7f8f1958ea4c37b753af86394eb8a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.StateProcessor.GearStateChangeProcessorSimulator
+  targetProcessor: {fileID: 8115039583878400241}
+  isSimulating: 0
+  simulateRpm: 60
+  simulateIsClockwise: 1
 --- !u!1 &5706012872980177505
 GameObject:
   m_ObjectHideFlags: 0
@@ -1686,6 +1809,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1707,9 +1835,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &8702500896039488788
 BoxCollider:
@@ -1791,6 +1921,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1812,9 +1947,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &1903319745466989393
 BoxCollider:
@@ -1896,6 +2033,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1917,9 +2059,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &1418025536358767174
 BoxCollider:
@@ -2001,6 +2145,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -2022,9 +2171,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &6445554690155575544
 BoxCollider:
@@ -2247,6 +2398,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -2268,9 +2424,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &2191995603529210457
 BoxCollider:
@@ -2448,6 +2606,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -2469,9 +2632,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &2865815601582902789
 BoxCollider:
@@ -2553,6 +2718,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -2574,9 +2744,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &1690215613927346583
 BoxCollider:
@@ -2658,6 +2830,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -2679,9 +2856,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!136 &2236147176552118524
 CapsuleCollider:
@@ -2765,6 +2944,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -2786,9 +2970,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &2201352656538343862
 BoxCollider:

--- a/moorestech_client/Assets/AddressableResources/Block/Primitive_cutting_machine.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/Primitive_cutting_machine.prefab
@@ -44,6 +44,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8792864431417798568}
   - component: {fileID: 8651810202492051769}
+  - component: {fileID: 6709010974657321009}
   m_Layer: 7
   m_Name: Primitive_cutting_machine
   m_TagString: Untagged
@@ -85,20 +86,41 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   rotationInfos:
-  - rotationMode: 0
-    rotationAxis: 0
-    rotationTransform: {fileID: 3683450157768047444}
-    animator: {fileID: 0}
-    rpm60Speed: 1
-    isReverse: 0
-    rotationSpeed: 1
-  - rotationMode: 0
-    rotationAxis: 0
-    rotationTransform: {fileID: 7410166980393421288}
-    animator: {fileID: 0}
-    rpm60Speed: 1
-    isReverse: 1
-    rotationSpeed: 1
+  - rid: 3331677946101629104
+  - rid: 3331677946101629105
+  references:
+    version: 2
+    RefIds:
+    - rid: 3331677946101629104
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 0
+        rotationTransform: {fileID: 3683450157768047444}
+        rotationSpeed: 1
+    - rid: 3331677946101629105
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 1
+        rotationAxis: 0
+        rotationTransform: {fileID: 7410166980393421288}
+        rotationSpeed: 1
+--- !u!114 &6709010974657321009
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1236561827234384917}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4bb7f8f1958ea4c37b753af86394eb8a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.StateProcessor.GearStateChangeProcessorSimulator
+  targetProcessor: {fileID: 8651810202492051769}
+  isSimulating: 0
+  simulateRpm: 60
+  simulateIsClockwise: 1
 --- !u!1 &2296858796672504072
 GameObject:
   m_ObjectHideFlags: 0
@@ -187,6 +209,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &2701157336844679651
 GameObject:
@@ -276,6 +299,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &3817603666536975396
 GameObject:
@@ -365,6 +389,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &5354697280752957405
 GameObject:
@@ -455,6 +480,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &2521137876974232069
 BoxCollider:
@@ -566,6 +592,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &8509409273807179723
 BoxCollider:
@@ -676,6 +703,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &7185150220764652369
 GameObject:
@@ -766,6 +794,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &2119691867238111783
 BoxCollider:
@@ -909,6 +938,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1001 &2017087857462084842
 PrefabInstance:

--- a/moorestech_client/Assets/AddressableResources/Block/Primitive_grinding_machine.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/Primitive_grinding_machine.prefab
@@ -89,6 +89,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &2165497209457815025
 BoxCollider:
@@ -267,6 +268,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &3134596801015574954
 BoxCollider:
@@ -377,6 +379,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &2178734274554687842
 GameObject:
@@ -466,6 +469,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &2672272605363945109
 GameObject:
@@ -555,6 +559,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &3480546368220801300
 GameObject:
@@ -644,6 +649,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &3606527697343180839
 GameObject:
@@ -733,6 +739,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &5063940934404737029
 GameObject:
@@ -744,6 +751,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7929173557335117081}
   - component: {fileID: 905202246393289745}
+  - component: {fileID: 8575316425333323511}
   m_Layer: 7
   m_Name: Primitive_grinding_machine
   m_TagString: Untagged
@@ -787,27 +795,49 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   rotationInfos:
-  - rotationMode: 0
-    rotationAxis: 0
-    rotationTransform: {fileID: 1356692783317118586}
-    animator: {fileID: 0}
-    rpm60Speed: 1
-    isReverse: 0
-    rotationSpeed: 1
-  - rotationMode: 0
-    rotationAxis: 0
-    rotationTransform: {fileID: 591279445889983248}
-    animator: {fileID: 0}
-    rpm60Speed: 1
-    isReverse: 1
-    rotationSpeed: 1
-  - rotationMode: 0
-    rotationAxis: 0
-    rotationTransform: {fileID: 1136102053694927671}
-    animator: {fileID: 0}
-    rpm60Speed: 1
-    isReverse: 1
-    rotationSpeed: 1
+  - rid: 3331677946101629106
+  - rid: 3331677946101629107
+  - rid: 3331677946101629108
+  references:
+    version: 2
+    RefIds:
+    - rid: 3331677946101629106
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 0
+        rotationTransform: {fileID: 1356692783317118586}
+        rotationSpeed: 1
+    - rid: 3331677946101629107
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 1
+        rotationAxis: 0
+        rotationTransform: {fileID: 591279445889983248}
+        rotationSpeed: 1
+    - rid: 3331677946101629108
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 1
+        rotationAxis: 0
+        rotationTransform: {fileID: 1136102053694927671}
+        rotationSpeed: 1
+--- !u!114 &8575316425333323511
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5063940934404737029}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4bb7f8f1958ea4c37b753af86394eb8a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.StateProcessor.GearStateChangeProcessorSimulator
+  targetProcessor: {fileID: 905202246393289745}
+  isSimulating: 0
+  simulateRpm: 60
+  simulateIsClockwise: 1
 --- !u!1 &5202328247936442386
 GameObject:
   m_ObjectHideFlags: 0
@@ -897,6 +927,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &3349955429481317317
 BoxCollider:
@@ -1008,6 +1039,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &3548543138197661567
 BoxCollider:
@@ -1152,6 +1184,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &6770674783697840777
 GameObject:
@@ -1241,6 +1274,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &7125864236833155229
 GameObject:
@@ -1330,6 +1364,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1001 &2313473886916177
 PrefabInstance:

--- a/moorestech_client/Assets/AddressableResources/Block/Shaft Box.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/Shaft Box.prefab
@@ -89,6 +89,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &3214380421433759258
 BoxCollider:
@@ -159,27 +160,33 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   rotationInfos:
-  - rotationMode: 0
-    rotationAxis: 1
-    rotationTransform: {fileID: 4805851040691227100}
-    isReverse: 0
-    rotationSpeed: 1
-    animator: {fileID: 0}
-    rpm60Speed: 1
-  - rotationMode: 0
-    rotationAxis: 1
-    rotationTransform: {fileID: 5012737396614629131}
-    isReverse: 0
-    rotationSpeed: 1
-    animator: {fileID: 0}
-    rpm60Speed: 1
-  - rotationMode: 0
-    rotationAxis: 1
-    rotationTransform: {fileID: 6354654627036309130}
-    isReverse: 0
-    rotationSpeed: 1
-    animator: {fileID: 0}
-    rpm60Speed: 1
+  - rid: 3331677946101629118
+  - rid: 3331677946101629119
+  - rid: 3331677946101629120
+  references:
+    version: 2
+    RefIds:
+    - rid: 3331677946101629118
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 1
+        rotationTransform: {fileID: 4805851040691227100}
+        rotationSpeed: 1
+    - rid: 3331677946101629119
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 1
+        rotationTransform: {fileID: 5012737396614629131}
+        rotationSpeed: 1
+    - rid: 3331677946101629120
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 1
+        rotationTransform: {fileID: 6354654627036309130}
+        rotationSpeed: 1
 --- !u!114 &6021435405551411268
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -319,6 +326,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!64 &7037379113754812619
 MeshCollider:
@@ -431,6 +439,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!64 &185381356873697762
 MeshCollider:
@@ -543,6 +552,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!64 &9013138091566676299
 MeshCollider:

--- a/moorestech_client/Assets/AddressableResources/Block/Shaft Iron.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/Shaft Iron.prefab
@@ -89,6 +89,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &2113805635147444441
 BoxCollider:
@@ -200,6 +201,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!64 &4345664292913582027
 MeshCollider:
@@ -312,6 +314,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &7823243862517226935
 BoxCollider:
@@ -423,6 +426,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &2626167318218223539
 BoxCollider:
@@ -455,6 +459,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5170640774033062637}
   - component: {fileID: 4793429072188369667}
+  - component: {fileID: 3982003877050515246}
   m_Layer: 7
   m_Name: Shaft Iron
   m_TagString: Untagged
@@ -495,13 +500,33 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   rotationInfos:
-  - rotationMode: 0
-    rotationAxis: 2
-    rotationTransform: {fileID: 3253118763272804755}
-    isReverse: 0
-    rotationSpeed: 1
-    animator: {fileID: 0}
-    rpm60Speed: 1
+  - rid: 3331677946101629121
+  references:
+    version: 2
+    RefIds:
+    - rid: 3331677946101629121
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 2
+        rotationTransform: {fileID: 3253118763272804755}
+        rotationSpeed: 1
+--- !u!114 &3982003877050515246
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6697832017047719167}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4bb7f8f1958ea4c37b753af86394eb8a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.StateProcessor.GearStateChangeProcessorSimulator
+  targetProcessor: {fileID: 4793429072188369667}
+  isSimulating: 0
+  simulateRpm: 60
+  simulateIsClockwise: 1
 --- !u!1 &7397736660562999078
 GameObject:
   m_ObjectHideFlags: 0
@@ -623,6 +648,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &6310098919642952362
 BoxCollider:

--- a/moorestech_client/Assets/AddressableResources/Block/Shaft Vertical Iron.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/Shaft Vertical Iron.prefab
@@ -121,6 +121,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!64 &3273298225641266582
 MeshCollider:
@@ -154,6 +155,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4171492696549249580}
   - component: {fileID: 1124958943946363861}
+  - component: {fileID: 2615781573205560432}
   m_Layer: 7
   m_Name: Shaft Vertical Iron
   m_TagString: Untagged
@@ -190,10 +192,30 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   rotationInfos:
-  - rotationMode: 0
-    rotationAxis: 1
-    rotationTransform: {fileID: 7862785120130140679}
-    isReverse: 0
-    rotationSpeed: 1
-    animator: {fileID: 0}
-    rpm60Speed: 1
+  - rid: 3331677946101629122
+  references:
+    version: 2
+    RefIds:
+    - rid: 3331677946101629122
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 1
+        rotationTransform: {fileID: 7862785120130140679}
+        rotationSpeed: 1
+--- !u!114 &2615781573205560432
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6488469376614325054}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4bb7f8f1958ea4c37b753af86394eb8a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.StateProcessor.GearStateChangeProcessorSimulator
+  targetProcessor: {fileID: 1124958943946363861}
+  isSimulating: 0
+  simulateRpm: 60
+  simulateIsClockwise: 1

--- a/moorestech_client/Assets/AddressableResources/Block/Shaft Vertical.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/Shaft Vertical.prefab
@@ -121,6 +121,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!64 &3273298225641266582
 MeshCollider:
@@ -154,6 +155,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4171492696549249580}
   - component: {fileID: 1124958943946363861}
+  - component: {fileID: 2615781573205560432}
   m_Layer: 7
   m_Name: Shaft Vertical
   m_TagString: Untagged
@@ -190,10 +192,30 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   rotationInfos:
-  - rotationMode: 0
-    rotationAxis: 1
-    rotationTransform: {fileID: 7862785120130140679}
-    animator: {fileID: 0}
-    rpm60Speed: 1
-    isReverse: 0
-    rotationSpeed: 1
+  - rid: 3331677946101629123
+  references:
+    version: 2
+    RefIds:
+    - rid: 3331677946101629123
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 1
+        rotationTransform: {fileID: 7862785120130140679}
+        rotationSpeed: 1
+--- !u!114 &2615781573205560432
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6488469376614325054}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4bb7f8f1958ea4c37b753af86394eb8a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.StateProcessor.GearStateChangeProcessorSimulator
+  targetProcessor: {fileID: 1124958943946363861}
+  isSimulating: 0
+  simulateRpm: 60
+  simulateIsClockwise: 1

--- a/moorestech_client/Assets/AddressableResources/Block/Shaft.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/Shaft.prefab
@@ -89,6 +89,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &2113805635147444441
 BoxCollider:
@@ -200,6 +201,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!64 &4345664292913582027
 MeshCollider:
@@ -312,6 +314,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &7823243862517226935
 BoxCollider:
@@ -423,6 +426,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &2626167318218223539
 BoxCollider:
@@ -455,6 +459,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5170640774033062637}
   - component: {fileID: 4793429072188369667}
+  - component: {fileID: 3982003877050515246}
   m_Layer: 7
   m_Name: Shaft
   m_TagString: Untagged
@@ -495,13 +500,33 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   rotationInfos:
-  - rotationMode: 0
-    rotationAxis: 2
-    rotationTransform: {fileID: 3253118763272804755}
-    animator: {fileID: 0}
-    rpm60Speed: 1
-    isReverse: 0
-    rotationSpeed: 1
+  - rid: 3331677946101629124
+  references:
+    version: 2
+    RefIds:
+    - rid: 3331677946101629124
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 2
+        rotationTransform: {fileID: 3253118763272804755}
+        rotationSpeed: 1
+--- !u!114 &3982003877050515246
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6697832017047719167}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4bb7f8f1958ea4c37b753af86394eb8a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.StateProcessor.GearStateChangeProcessorSimulator
+  targetProcessor: {fileID: 4793429072188369667}
+  isSimulating: 0
+  simulateRpm: 60
+  simulateIsClockwise: 1
 --- !u!1 &7397736660562999078
 GameObject:
   m_ObjectHideFlags: 0
@@ -623,6 +648,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &6310098919642952362
 BoxCollider:

--- a/moorestech_client/Assets/AddressableResources/Block/Sieve.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/Sieve.prefab
@@ -63,6 +63,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -84,9 +86,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &8898197670320716334
 BoxCollider:
@@ -131,6 +135,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7302078999814900957}
   - component: {fileID: 3284992503063207861}
+  - component: {fileID: 881977842966659603}
   m_Layer: 7
   m_Name: Sieve
   m_TagString: Untagged
@@ -169,10 +174,33 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   rotationInfos:
-  - rotationAxis: 1
-    rotationTransform: {fileID: 6235335034392790157}
-    isReverse: 0
-    rotationSpeed: 1
+  - rid: 3331677946101629125
+  references:
+    version: 2
+    RefIds:
+    - rid: 3331677946101629125
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 1
+        rotationTransform: {fileID: 6235335034392790157}
+        rotationSpeed: 1
+--- !u!114 &881977842966659603
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3978568427011400544}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4bb7f8f1958ea4c37b753af86394eb8a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.StateProcessor.GearStateChangeProcessorSimulator
+  targetProcessor: {fileID: 3284992503063207861}
+  isSimulating: 0
+  simulateRpm: 60
+  simulateIsClockwise: 1
 --- !u!1 &5909192823532569512
 GameObject:
   m_ObjectHideFlags: 0
@@ -235,6 +263,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -256,9 +286,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!136 &8257885924443657452
 CapsuleCollider:
@@ -340,6 +372,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -361,9 +395,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!114 &1258280530966430134
 MonoBehaviour:
@@ -423,6 +459,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0

--- a/moorestech_client/Assets/AddressableResources/Block/SmallGear.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/SmallGear.prefab
@@ -89,6 +89,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &2113805635147444441
 BoxCollider:
@@ -200,6 +201,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!64 &4345664292913582027
 MeshCollider:
@@ -312,6 +314,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &7823243862517226935
 BoxCollider:
@@ -423,6 +426,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &2626167318218223539
 BoxCollider:
@@ -534,6 +538,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!64 &8660761407999225088
 MeshCollider:
@@ -645,6 +650,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &6697832017047719167
 GameObject:
@@ -713,13 +719,17 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   rotationInfos:
-  - rotationMode: 0
-    rotationAxis: 2
-    rotationTransform: {fileID: 3253118763272804755}
-    isReverse: 0
-    rotationSpeed: 1
-    animator: {fileID: 0}
-    rpm60Speed: 1
+  - rid: 3331677946101629126
+  references:
+    version: 2
+    RefIds:
+    - rid: 3331677946101629126
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 2
+        rotationTransform: {fileID: 3253118763272804755}
+        rotationSpeed: 1
 --- !u!1 &7397736660562999078
 GameObject:
   m_ObjectHideFlags: 0
@@ -843,6 +853,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &6310098919642952362
 BoxCollider:

--- a/moorestech_client/Assets/AddressableResources/Block/SmallSimpleGeneretor.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/SmallSimpleGeneretor.prefab
@@ -62,6 +62,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -83,9 +85,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!64 &7279126621332200883
 MeshCollider:
@@ -171,6 +175,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -192,9 +198,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!64 &6171502409456483691
 MeshCollider:
@@ -280,6 +288,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -301,9 +311,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &1825169855798123712
 BoxCollider:
@@ -421,6 +433,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -442,9 +456,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!64 &8545849264215043172
 MeshCollider:
@@ -563,6 +579,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -584,9 +602,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!64 &2222978094881979589
 MeshCollider:
@@ -672,6 +692,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -693,9 +715,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &4014938795613505217
 BoxCollider:
@@ -813,6 +837,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -834,9 +860,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!64 &452147472127927197
 MeshCollider:
@@ -922,6 +950,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -943,9 +973,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &8707362093043450995
 BoxCollider:
@@ -1030,6 +1062,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1051,9 +1085,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!64 &3639292551944454745
 MeshCollider:
@@ -1139,6 +1175,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1160,9 +1198,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &6029533770521953027
 BoxCollider:
@@ -1195,6 +1235,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3379907037286674538}
   - component: {fileID: 6928747975424123339}
+  - component: {fileID: 5183806330142026491}
   m_Layer: 7
   m_Name: SmallSimpleGeneretor
   m_TagString: Untagged
@@ -1237,15 +1278,46 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   rotationInfos:
-  - rotationAxis: 2
-    rotationTransform: {fileID: 8628083112779359352}
-    isReverse: 0
-    rotationSpeed: 1
-  - rotationAxis: 2
-    rotationTransform: {fileID: 5880635445525047251}
-    isReverse: 0
-    rotationSpeed: 1
-  - rotationAxis: 2
-    rotationTransform: {fileID: 8177799141612118953}
-    isReverse: 0
-    rotationSpeed: 1
+  - rid: 3331677946101629127
+  - rid: 3331677946101629128
+  - rid: 3331677946101629129
+  references:
+    version: 2
+    RefIds:
+    - rid: 3331677946101629127
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 2
+        rotationTransform: {fileID: 8628083112779359352}
+        rotationSpeed: 1
+    - rid: 3331677946101629128
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 2
+        rotationTransform: {fileID: 5880635445525047251}
+        rotationSpeed: 1
+    - rid: 3331677946101629129
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 2
+        rotationTransform: {fileID: 8177799141612118953}
+        rotationSpeed: 1
+--- !u!114 &5183806330142026491
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9055832900192800997}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4bb7f8f1958ea4c37b753af86394eb8a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.StateProcessor.GearStateChangeProcessorSimulator
+  targetProcessor: {fileID: 6928747975424123339}
+  isSimulating: 0
+  simulateRpm: 60
+  simulateIsClockwise: 1

--- a/moorestech_client/Assets/AddressableResources/Block/Spinning_machine.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/Spinning_machine.prefab
@@ -88,6 +88,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &1771589847624464567
 GameObject:
@@ -178,6 +179,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &3298962317742768033
 BoxCollider:
@@ -289,6 +291,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &1660206484359146406
 BoxCollider:
@@ -432,6 +435,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &4015027712132961087
 GameObject:
@@ -555,6 +559,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &4209988312854455961
 BoxCollider:
@@ -666,6 +671,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &8751402121613398688
 BoxCollider:
@@ -809,6 +815,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &7603681714720562614
 GameObject:
@@ -898,6 +905,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &7719031868932841997
 GameObject:
@@ -909,6 +917,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1435142415163663850}
   - component: {fileID: 6228782247826079162}
+  - component: {fileID: 238947393174282337}
   m_Layer: 7
   m_Name: Spinning_machine
   m_TagString: Untagged
@@ -953,27 +962,49 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.StateProcessor.GearStateChangeProcessor
   rotationInfos:
-  - rotationMode: 0
-    rotationAxis: 0
-    rotationTransform: {fileID: 8328443248141879796}
-    animator: {fileID: 0}
-    rpm60Speed: 0
-    isReverse: 0
-    rotationSpeed: 1
-  - rotationMode: 0
-    rotationAxis: 0
-    rotationTransform: {fileID: 893701178434877315}
-    animator: {fileID: 0}
-    rpm60Speed: 0
-    isReverse: 1
-    rotationSpeed: 1
-  - rotationMode: 0
-    rotationAxis: 0
-    rotationTransform: {fileID: 5797853074005850548}
-    animator: {fileID: 0}
-    rpm60Speed: 0
-    isReverse: 0
-    rotationSpeed: 1
+  - rid: 3331677946101629130
+  - rid: 3331677946101629131
+  - rid: 3331677946101629132
+  references:
+    version: 2
+    RefIds:
+    - rid: 3331677946101629130
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 0
+        rotationTransform: {fileID: 8328443248141879796}
+        rotationSpeed: 1
+    - rid: 3331677946101629131
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 1
+        rotationAxis: 0
+        rotationTransform: {fileID: 893701178434877315}
+        rotationSpeed: 1
+    - rid: 3331677946101629132
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 0
+        rotationTransform: {fileID: 5797853074005850548}
+        rotationSpeed: 1
+--- !u!114 &238947393174282337
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7719031868932841997}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4bb7f8f1958ea4c37b753af86394eb8a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.StateProcessor.GearStateChangeProcessorSimulator
+  targetProcessor: {fileID: 6228782247826079162}
+  isSimulating: 0
+  simulateRpm: 60
+  simulateIsClockwise: 1
 --- !u!1 &8798205852491939933
 GameObject:
   m_ObjectHideFlags: 0
@@ -1062,6 +1093,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &9096001950124460103
 GameObject:
@@ -1151,6 +1183,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1001 &3704062693294410839
 PrefabInstance:

--- a/moorestech_client/Assets/AddressableResources/Block/Wood_Assembly_Machine.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/Wood_Assembly_Machine.prefab
@@ -88,6 +88,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &843800603537561650
 GameObject:
@@ -178,6 +179,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &482884245671668276
 BoxCollider:
@@ -210,6 +212,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7782724675987526266}
   - component: {fileID: 7461901296845201302}
+  - component: {fileID: 7771852933238812760}
   m_Layer: 7
   m_Name: Wood_Assembly_Machine
   m_TagString: Untagged
@@ -263,20 +266,41 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.StateProcessor.GearStateChangeProcessor
   rotationInfos:
-  - rotationMode: 0
-    rotationAxis: 0
-    rotationTransform: {fileID: 3697350091011299585}
-    animator: {fileID: 0}
-    rpm60Speed: 0
-    isReverse: 0
-    rotationSpeed: 1
-  - rotationMode: 0
-    rotationAxis: 0
-    rotationTransform: {fileID: 2224114636043452918}
-    animator: {fileID: 0}
-    rpm60Speed: 0
-    isReverse: 1
-    rotationSpeed: 1
+  - rid: 3331677946101629136
+  - rid: 3331677946101629137
+  references:
+    version: 2
+    RefIds:
+    - rid: 3331677946101629136
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 0
+        rotationTransform: {fileID: 3697350091011299585}
+        rotationSpeed: 1
+    - rid: 3331677946101629137
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 1
+        rotationAxis: 0
+        rotationTransform: {fileID: 2224114636043452918}
+        rotationSpeed: 1
+--- !u!114 &7771852933238812760
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 849929986324189567}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4bb7f8f1958ea4c37b753af86394eb8a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.StateProcessor.GearStateChangeProcessorSimulator
+  targetProcessor: {fileID: 7461901296845201302}
+  isSimulating: 0
+  simulateRpm: 60
+  simulateIsClockwise: 1
 --- !u!1 &1760750256291729057
 GameObject:
   m_ObjectHideFlags: 0
@@ -365,6 +389,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &1912029307972232574
 GameObject:
@@ -488,6 +513,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &5418065250353866793
 BoxCollider:
@@ -599,6 +625,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &4705993354591637680
 BoxCollider:
@@ -743,6 +770,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &2919004352440484251
 BoxCollider:
@@ -853,6 +881,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &4643974476213827873
 GameObject:
@@ -943,6 +972,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &374236305869674880
 BoxCollider:
@@ -1054,6 +1084,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &6180663712605043261
 BoxCollider:
@@ -1165,6 +1196,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &9074737826174880443
 BoxCollider:
@@ -1276,6 +1308,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &2787508885553479713
 BoxCollider:
@@ -1387,6 +1420,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &4043033324254614257
 BoxCollider:
@@ -1498,6 +1532,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &2720425215183584458
 BoxCollider:
@@ -1609,6 +1644,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &5640693849236505851
 BoxCollider:
@@ -1720,6 +1756,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &7789650179893433705
 BoxCollider:
@@ -1831,6 +1868,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &852733506981487624
 BoxCollider:
@@ -1941,6 +1979,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1001 &884721006191668907
 PrefabInstance:

--- a/moorestech_client/Assets/AddressableResources/Block/Wood_Processing_Machine.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/Wood_Processing_Machine.prefab
@@ -261,20 +261,25 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.StateProcessor.GearStateChangeProcessor
   rotationInfos:
-  - rotationMode: 0
-    rotationAxis: 0
-    rotationTransform: {fileID: 3697350091011299585}
-    isReverse: 0
-    rotationSpeed: 1
-    animator: {fileID: 0}
-    rpm60Speed: 0
-  - rotationMode: 0
-    rotationAxis: 0
-    rotationTransform: {fileID: 2224114636043452918}
-    isReverse: 1
-    rotationSpeed: 1
-    animator: {fileID: 0}
-    rpm60Speed: 0
+  - rid: 3331677946101629141
+  - rid: 3331677946101629142
+  references:
+    version: 2
+    RefIds:
+    - rid: 3331677946101629141
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 0
+        rotationTransform: {fileID: 3697350091011299585}
+        rotationSpeed: 1
+    - rid: 3331677946101629142
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 1
+        rotationAxis: 0
+        rotationTransform: {fileID: 2224114636043452918}
+        rotationSpeed: 1
 --- !u!114 &7771852933238812760
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/moorestech_client/Assets/AddressableResources/Block/bronze_miner.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/bronze_miner.prefab
@@ -62,6 +62,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -83,9 +85,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &5699275914158567705
 BoxCollider:
@@ -170,6 +174,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -191,9 +197,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &8288307801893026173
 BoxCollider:
@@ -310,6 +318,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -331,9 +341,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &4019630327301068071
 BoxCollider:
@@ -418,6 +430,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -439,9 +453,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!135 &2243830455431487365
 SphereCollider:
@@ -525,6 +541,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -546,9 +564,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &4290573385882375303
 GameObject:
@@ -612,6 +632,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -633,9 +655,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &2385301746784173914
 BoxCollider:
@@ -720,6 +744,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -741,9 +767,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!136 &123247637658937004
 CapsuleCollider:
@@ -829,6 +857,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -850,9 +880,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &6650428553740698591
 GameObject:
@@ -864,6 +896,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2864312415366314551}
   - component: {fileID: 6036322953463296240}
+  - component: {fileID: 3321913396363004208}
   m_Layer: 7
   m_Name: bronze_miner
   m_TagString: Untagged
@@ -908,20 +941,41 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   rotationInfos:
-  - rotationMode: 0
-    rotationAxis: 0
-    rotationTransform: {fileID: 8291855290040201034}
-    animator: {fileID: 0}
-    rpm60Speed: 1
-    isReverse: 0
-    rotationSpeed: 1
-  - rotationMode: 0
-    rotationAxis: 1
-    rotationTransform: {fileID: 8004967725647890796}
-    animator: {fileID: 0}
-    rpm60Speed: 1
-    isReverse: 0
-    rotationSpeed: 1
+  - rid: 3331677946101629064
+  - rid: 3331677946101629065
+  references:
+    version: 2
+    RefIds:
+    - rid: 3331677946101629064
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 0
+        rotationTransform: {fileID: 8291855290040201034}
+        rotationSpeed: 1
+    - rid: 3331677946101629065
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 1
+        rotationTransform: {fileID: 8004967725647890796}
+        rotationSpeed: 1
+--- !u!114 &3321913396363004208
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6650428553740698591}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4bb7f8f1958ea4c37b753af86394eb8a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.StateProcessor.GearStateChangeProcessorSimulator
+  targetProcessor: {fileID: 6036322953463296240}
+  isSimulating: 0
+  simulateRpm: 60
+  simulateIsClockwise: 1
 --- !u!1 &7232818041516098256
 GameObject:
   m_ObjectHideFlags: 0
@@ -984,6 +1038,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1005,9 +1061,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &2340499365527496309
 BoxCollider:
@@ -1125,6 +1183,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1146,9 +1206,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &4325666998497606607
 BoxCollider:
@@ -1266,6 +1328,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1287,9 +1351,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1001 &2160082747987484630
 PrefabInstance:

--- a/moorestech_client/Assets/AddressableResources/Block/bronze_sawmill.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/bronze_sawmill.prefab
@@ -61,6 +61,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -82,9 +84,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &1796802073827190942
 GameObject:
@@ -147,6 +151,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -168,9 +174,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &2405489614145153864
 GameObject:
@@ -234,6 +242,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -255,9 +265,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &8889981988157040327
 BoxCollider:
@@ -341,6 +353,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -362,9 +376,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &4136622925272130558
 GameObject:
@@ -376,6 +392,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8736375804090706838}
   - component: {fileID: 6039713562615356459}
+  - component: {fileID: 8724673714139374470}
   m_Layer: 7
   m_Name: bronze_sawmill
   m_TagString: Untagged
@@ -417,14 +434,41 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   rotationInfos:
-  - rotationAxis: 0
-    rotationTransform: {fileID: 458783854469350616}
-    isReverse: 0
-    rotationSpeed: 1
-  - rotationAxis: 0
-    rotationTransform: {fileID: 660948004848531355}
-    isReverse: 1
-    rotationSpeed: 1
+  - rid: 3331677946101629066
+  - rid: 3331677946101629067
+  references:
+    version: 2
+    RefIds:
+    - rid: 3331677946101629066
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 0
+        rotationTransform: {fileID: 458783854469350616}
+        rotationSpeed: 1
+    - rid: 3331677946101629067
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 1
+        rotationAxis: 0
+        rotationTransform: {fileID: 660948004848531355}
+        rotationSpeed: 1
+--- !u!114 &8724673714139374470
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4136622925272130558}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4bb7f8f1958ea4c37b753af86394eb8a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.StateProcessor.GearStateChangeProcessorSimulator
+  targetProcessor: {fileID: 6039713562615356459}
+  isSimulating: 0
+  simulateRpm: 60
+  simulateIsClockwise: 1
 --- !u!1 &5100227100758773828
 GameObject:
   m_ObjectHideFlags: 0
@@ -554,6 +598,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -575,9 +621,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &2012414359247213831
 BoxCollider:
@@ -661,6 +709,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -682,9 +732,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &8349503292999934348
 GameObject:
@@ -747,6 +799,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -768,9 +822,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &8545418420448470717
 GameObject:
@@ -834,6 +890,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -855,9 +913,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &4910769255719087746
 BoxCollider:

--- a/moorestech_client/Assets/AddressableResources/Block/gear belt conveyor down.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/gear belt conveyor down.prefab
@@ -50,27 +50,33 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   rotationInfos:
-  - rotationMode: 0
-    rotationAxis: 1
-    rotationTransform: {fileID: 2477971098258162781}
-    isReverse: 0
-    rotationSpeed: 1
-    animator: {fileID: 0}
-    rpm60Speed: 1
-  - rotationMode: 0
-    rotationAxis: 1
-    rotationTransform: {fileID: 2671674868993767854}
-    isReverse: 0
-    rotationSpeed: 1
-    animator: {fileID: 0}
-    rpm60Speed: 1
-  - rotationMode: 0
-    rotationAxis: 1
-    rotationTransform: {fileID: 2097194405952621663}
-    isReverse: 1
-    rotationSpeed: 2
-    animator: {fileID: 0}
-    rpm60Speed: 1
+  - rid: 3331677946101629072
+  - rid: 3331677946101629073
+  - rid: 3331677946101629074
+  references:
+    version: 2
+    RefIds:
+    - rid: 3331677946101629072
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 1
+        rotationTransform: {fileID: 2477971098258162781}
+        rotationSpeed: 1
+    - rid: 3331677946101629073
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 1
+        rotationTransform: {fileID: 2671674868993767854}
+        rotationSpeed: 1
+    - rid: 3331677946101629074
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 1
+        rotationAxis: 1
+        rotationTransform: {fileID: 2097194405952621663}
+        rotationSpeed: 2
 --- !u!114 &6446912578113309129
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -214,6 +220,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &2574353410751142360
 GameObject:
@@ -304,6 +311,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &3763414243015773423
 GameObject:
@@ -433,6 +441,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &4153788072374072657
 GameObject:
@@ -523,6 +532,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &5367520258318766535
 GameObject:
@@ -612,6 +622,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &6688012244738825396
 GameObject:
@@ -701,6 +712,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &6995253071953018703
 GameObject:
@@ -790,6 +802,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &9102739910984863393
 GameObject:
@@ -879,6 +892,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1001 &625136982750171179
 PrefabInstance:

--- a/moorestech_client/Assets/AddressableResources/Block/gear belt conveyor up.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/gear belt conveyor up.prefab
@@ -88,6 +88,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &3431729297357695143
 GameObject:
@@ -178,6 +179,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &3606633545684795409
 GameObject:
@@ -267,6 +269,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &3661652225155609364
 GameObject:
@@ -318,27 +321,33 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   rotationInfos:
-  - rotationMode: 0
-    rotationAxis: 1
-    rotationTransform: {fileID: 2637895851318216672}
-    isReverse: 0
-    rotationSpeed: 1
-    animator: {fileID: 0}
-    rpm60Speed: 1
-  - rotationMode: 0
-    rotationAxis: 1
-    rotationTransform: {fileID: 4986544531191271322}
-    isReverse: 0
-    rotationSpeed: 1
-    animator: {fileID: 0}
-    rpm60Speed: 1
-  - rotationMode: 0
-    rotationAxis: 1
-    rotationTransform: {fileID: 1912839138483461826}
-    isReverse: 1
-    rotationSpeed: 2
-    animator: {fileID: 0}
-    rpm60Speed: 1
+  - rid: 3331677946101629075
+  - rid: 3331677946101629076
+  - rid: 3331677946101629077
+  references:
+    version: 2
+    RefIds:
+    - rid: 3331677946101629075
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 1
+        rotationTransform: {fileID: 2637895851318216672}
+        rotationSpeed: 1
+    - rid: 3331677946101629076
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 1
+        rotationTransform: {fileID: 4986544531191271322}
+        rotationSpeed: 1
+    - rid: 3331677946101629077
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 1
+        rotationAxis: 1
+        rotationTransform: {fileID: 1912839138483461826}
+        rotationSpeed: 2
 --- !u!114 &4599936828064805141
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -476,6 +485,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &5396840770809954993
 GameObject:
@@ -565,6 +575,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &6350559978255813061
 GameObject:
@@ -655,6 +666,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &6618156764846002076
 GameObject:
@@ -744,6 +756,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &6741941487171357498
 GameObject:
@@ -872,6 +885,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1001 &6434862057143140667
 PrefabInstance:

--- a/moorestech_client/Assets/AddressableResources/Block/gear belt conveyor.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/gear belt conveyor.prefab
@@ -146,27 +146,33 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   rotationInfos:
-  - rotationMode: 0
-    rotationAxis: 1
-    rotationTransform: {fileID: 2327336885064555751}
-    isReverse: 0
-    rotationSpeed: 1
-    animator: {fileID: 0}
-    rpm60Speed: 1
-  - rotationMode: 0
-    rotationAxis: 1
-    rotationTransform: {fileID: 5134743680452918481}
-    isReverse: 0
-    rotationSpeed: 1
-    animator: {fileID: 0}
-    rpm60Speed: 1
-  - rotationMode: 0
-    rotationAxis: 1
-    rotationTransform: {fileID: 1377822839245419227}
-    isReverse: 1
-    rotationSpeed: 2
-    animator: {fileID: 0}
-    rpm60Speed: 1
+  - rid: 3331677946101629078
+  - rid: 3331677946101629079
+  - rid: 3331677946101629080
+  references:
+    version: 2
+    RefIds:
+    - rid: 3331677946101629078
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 1
+        rotationTransform: {fileID: 2327336885064555751}
+        rotationSpeed: 1
+    - rid: 3331677946101629079
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 1
+        rotationTransform: {fileID: 5134743680452918481}
+        rotationSpeed: 1
+    - rid: 3331677946101629080
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 1
+        rotationAxis: 1
+        rotationTransform: {fileID: 1377822839245419227}
+        rotationSpeed: 2
 --- !u!114 &2028982629869620035
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -286,6 +292,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &7694470400270729898
 BoxCollider:
@@ -396,6 +403,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &2136113639108234395
 GameObject:
@@ -486,6 +494,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &2179920069505685605
 GameObject:
@@ -576,6 +585,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &1436725232993406919
 BoxCollider:
@@ -687,6 +697,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &1592760886226733639
 BoxCollider:
@@ -798,6 +809,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &3455719862078743256
 GameObject:
@@ -888,6 +900,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &6228356672972598975
 BoxCollider:
@@ -1070,6 +1083,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &1846268650014240651
 BoxCollider:
@@ -1213,6 +1227,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &5766548961410028115
 GameObject:
@@ -1302,6 +1317,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &5913713925475466795
 GameObject:
@@ -1392,6 +1408,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &7045572876576730451
 GameObject:
@@ -1482,6 +1499,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &9158254990239776200
 GameObject:
@@ -1571,6 +1589,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1001 &2338125121409371268
 PrefabInstance:

--- a/moorestech_client/Assets/AddressableResources/Block/iron_miner.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/iron_miner.prefab
@@ -62,6 +62,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -83,9 +85,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &5699275914158567705
 BoxCollider:
@@ -170,6 +174,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -191,9 +197,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &8288307801893026173
 BoxCollider:
@@ -310,6 +318,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -331,9 +341,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &4019630327301068071
 BoxCollider:
@@ -418,6 +430,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -439,9 +453,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!135 &2243830455431487365
 SphereCollider:
@@ -525,6 +541,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -546,9 +564,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &4290573385882375303
 GameObject:
@@ -612,6 +632,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -633,9 +655,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &2385301746784173914
 BoxCollider:
@@ -720,6 +744,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -741,9 +767,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!136 &123247637658937004
 CapsuleCollider:
@@ -829,6 +857,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -850,9 +880,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &6650428553740698591
 GameObject:
@@ -864,6 +896,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2864312415366314551}
   - component: {fileID: 6036322953463296240}
+  - component: {fileID: 3321913396363004208}
   m_Layer: 7
   m_Name: iron_miner
   m_TagString: Untagged
@@ -908,20 +941,41 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   rotationInfos:
-  - rotationMode: 0
-    rotationAxis: 0
-    rotationTransform: {fileID: 8291855290040201034}
-    animator: {fileID: 0}
-    rpm60Speed: 1
-    isReverse: 0
-    rotationSpeed: 1
-  - rotationMode: 0
-    rotationAxis: 1
-    rotationTransform: {fileID: 8004967725647890796}
-    animator: {fileID: 0}
-    rpm60Speed: 1
-    isReverse: 0
-    rotationSpeed: 1
+  - rid: 3331677946101629089
+  - rid: 3331677946101629090
+  references:
+    version: 2
+    RefIds:
+    - rid: 3331677946101629089
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 0
+        rotationTransform: {fileID: 8291855290040201034}
+        rotationSpeed: 1
+    - rid: 3331677946101629090
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 1
+        rotationTransform: {fileID: 8004967725647890796}
+        rotationSpeed: 1
+--- !u!114 &3321913396363004208
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6650428553740698591}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4bb7f8f1958ea4c37b753af86394eb8a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.StateProcessor.GearStateChangeProcessorSimulator
+  targetProcessor: {fileID: 6036322953463296240}
+  isSimulating: 0
+  simulateRpm: 60
+  simulateIsClockwise: 1
 --- !u!1 &7232818041516098256
 GameObject:
   m_ObjectHideFlags: 0
@@ -984,6 +1038,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1005,9 +1061,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &2340499365527496309
 BoxCollider:
@@ -1125,6 +1183,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1146,9 +1206,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &4325666998497606607
 BoxCollider:
@@ -1266,6 +1328,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1287,9 +1351,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1001 &2160082747987484630
 PrefabInstance:

--- a/moorestech_client/Assets/AddressableResources/Block/itemshooter accelerator.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/itemshooter accelerator.prefab
@@ -122,6 +122,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &5637992315124539630
 GameObject:
@@ -211,6 +212,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &6713531220963643454
 GameObject:
@@ -300,6 +302,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &8150190987432831577
 GameObject:
@@ -351,27 +354,33 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.StateProcessor.GearStateChangeProcessor
   rotationInfos:
-  - rotationMode: 0
-    rotationAxis: 1
-    rotationTransform: {fileID: 5598601185852058203}
-    isReverse: 0
-    rotationSpeed: 1
-    animator: {fileID: 0}
-    rpm60Speed: 1
-  - rotationMode: 0
-    rotationAxis: 1
-    rotationTransform: {fileID: 7430110277937470655}
-    isReverse: 1
-    rotationSpeed: 1
-    animator: {fileID: 0}
-    rpm60Speed: 1
-  - rotationMode: 0
-    rotationAxis: 1
-    rotationTransform: {fileID: 3123064065566498143}
-    isReverse: 0
-    rotationSpeed: 1
-    animator: {fileID: 0}
-    rpm60Speed: 1
+  - rid: 3331677946101629091
+  - rid: 3331677946101629092
+  - rid: 3331677946101629093
+  references:
+    version: 2
+    RefIds:
+    - rid: 3331677946101629091
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 1
+        rotationTransform: {fileID: 5598601185852058203}
+        rotationSpeed: 1
+    - rid: 3331677946101629092
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 1
+        rotationAxis: 1
+        rotationTransform: {fileID: 7430110277937470655}
+        rotationSpeed: 1
+    - rid: 3331677946101629093
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 1
+        rotationTransform: {fileID: 3123064065566498143}
+        rotationSpeed: 1
 --- !u!114 &6695819620671512670
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/moorestech_client/Assets/AddressableResources/Block/primitive miner tmp.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/primitive miner tmp.prefab
@@ -58,6 +58,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -79,9 +84,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &790000121550288354
 GameObject:
@@ -93,6 +100,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7779342916117498845}
   - component: {fileID: 7119229288272271055}
+  - component: {fileID: 5319479923118802031}
   m_Layer: 7
   m_Name: primitive miner tmp
   m_TagString: Untagged
@@ -134,14 +142,41 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   rotationInfos:
-  - rotationAxis: 0
-    rotationTransform: {fileID: 601988005290110924}
-    isReverse: 0
-    rotationSpeed: 1
-  - rotationAxis: 0
-    rotationTransform: {fileID: 2446003655637231047}
-    isReverse: 1
-    rotationSpeed: 1
+  - rid: 3331677946101629102
+  - rid: 3331677946101629103
+  references:
+    version: 2
+    RefIds:
+    - rid: 3331677946101629102
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 0
+        rotationTransform: {fileID: 601988005290110924}
+        rotationSpeed: 1
+    - rid: 3331677946101629103
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 1
+        rotationAxis: 0
+        rotationTransform: {fileID: 2446003655637231047}
+        rotationSpeed: 1
+--- !u!114 &5319479923118802031
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 790000121550288354}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4bb7f8f1958ea4c37b753af86394eb8a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.StateProcessor.GearStateChangeProcessorSimulator
+  targetProcessor: {fileID: 7119229288272271055}
+  isSimulating: 0
+  simulateRpm: 60
+  simulateIsClockwise: 1
 --- !u!1 &1575071636828677746
 GameObject:
   m_ObjectHideFlags: 0
@@ -200,6 +235,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -221,9 +261,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &2888949188799723996
 GameObject:
@@ -283,6 +325,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -304,9 +351,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &4178592812132616559
 GameObject:
@@ -367,6 +416,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -388,9 +442,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!135 &2216714501763459831
 SphereCollider:
@@ -505,6 +561,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -526,9 +587,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &516293476467294150
 BoxCollider:
@@ -610,6 +673,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -631,9 +699,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &3185326282896712824
 BoxCollider:
@@ -715,6 +785,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -736,9 +811,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &1210953904133966723
 BoxCollider:
@@ -820,6 +897,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -841,9 +923,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &1955476266177299981
 BoxCollider:
@@ -924,6 +1008,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -945,9 +1034,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &9165136633323514691
 GameObject:

--- a/moorestech_client/Assets/AddressableResources/Block/static steam engine.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/static steam engine.prefab
@@ -30,7 +30,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &1670434827028133469
 SkinnedMeshRenderer:
@@ -79,17 +79,18 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: -5469953991570997238, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: 0.34526595, y: 1.2410156, z: -0.4516931}
     m_Extent: {x: 0.04167685, y: 0.18982708, z: 0.16119668}
@@ -124,8 +125,211 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2894995899346259609}
-  m_Father: {fileID: 8908440856845343672}
+  m_Father: {fileID: 7927408147114546845}
   m_LocalEulerAnglesHint: {x: -1.4053345, y: 0.000013660386, z: -0.00000196978}
+--- !u!1 &246727982847319164
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6839459537215372305}
+  - component: {fileID: 3171908953398541091}
+  - component: {fileID: 3491313802990878924}
+  m_Layer: 7
+  m_Name: "\u7ACB\u65B9\u4F53.028"
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6839459537215372305
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 246727982847319164}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -1.3877786e-17, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.3995, y: 1.3995, z: 1.3995}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5835814158261443487}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &3171908953398541091
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 246727982847319164}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 43a7d2d53259df94cb60e51d30df1810, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &3491313802990878924
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 246727982847319164}
+  m_Mesh: {fileID: -2341553740804746264, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
+--- !u!1 &435751485102737255
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6686287418671959815}
+  - component: {fileID: 4484614253515619000}
+  - component: {fileID: 2342272041893375011}
+  - component: {fileID: 8819111834074682610}
+  m_Layer: 7
+  m_Name: Cylinder_1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6686287418671959815
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 435751485102737255}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.5, y: -0.5, z: -0.5, w: 0.5}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.1, y: 0.5, z: 0.1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2898157000496097117}
+  m_LocalEulerAnglesHint: {x: 0, y: -90, z: -90}
+--- !u!33 &4484614253515619000
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 435751485102737255}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &2342272041893375011
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 435751485102737255}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 1840b4da3e420491ea213ba45d84e21e, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!64 &8819111834074682610
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 435751485102737255}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 1
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &650410253580625400
 GameObject:
   m_ObjectHideFlags: 0
@@ -156,7 +360,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &6835481999679382191
 SkinnedMeshRenderer:
@@ -206,17 +410,18 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: 6072970195418141121, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: -0.042533174, y: 2.7589774, z: -0.051264126}
     m_Extent: {x: 0.23247023, y: 0.17065048, z: 0.17065062}
@@ -252,7 +457,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &4808608276797466665
 MeshFilter:
@@ -309,6 +514,97 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &785685337164212645
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2893123765269819818}
+  - component: {fileID: 4681488961827278354}
+  - component: {fileID: 2781177875954378578}
+  m_Layer: 7
+  m_Name: Cylinder.001
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2893123765269819818
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 785685337164212645}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.7071068, y: 0, z: -0, w: 0.7071067}
+  m_LocalPosition: {x: -0, y: 0.01574564, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1150115793190891956}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &4681488961827278354
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 785685337164212645}
+  m_Mesh: {fileID: -7387706064836869012, guid: 9c52b0f86ea0c4f4e8fa0af85fbdc32a, type: 3}
+--- !u!23 &2781177875954378578
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 785685337164212645}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: f8198bb6d71c2614ca0a3d15a91a74e8, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &804224238214634639
 GameObject:
@@ -340,7 +636,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &8883218622822571270
 SkinnedMeshRenderer:
@@ -389,17 +685,18 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: -1912165525772834761, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: 0.34526592, y: -1.1969255, z: -0.5581356}
     m_Extent: {x: 0.04167685, y: 0.19356215, z: 0.17039186}
@@ -434,7 +731,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &4871337226066980549
 SkinnedMeshRenderer:
@@ -483,17 +780,18 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: 3042639451891401894, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: 0.34526637, y: -0.55813545, z: 1.1969255}
     m_Extent: {x: 0.04167685, y: 0.17039186, z: 0.19356227}
@@ -529,7 +827,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &6683329550786712009
 MeshFilter:
@@ -586,6 +884,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &981391624117096569
 GameObject:
@@ -617,7 +916,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &5622545364009747033
 SkinnedMeshRenderer:
@@ -666,17 +965,18 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: -7998616483175831387, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: 0.38970053, y: -0.504507, z: -0.2836757}
     m_Extent: {x: 0.034884453, y: 0.53975123, z: 0.3192207}
@@ -711,7 +1011,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &9177413251155390827
 SkinnedMeshRenderer:
@@ -760,17 +1060,18 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: -4108722219584223019, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: 0.00000011920929, y: 0.2890124, z: -0.0053702574}
     m_Extent: {x: 0.04097542, y: 0.03596744, z: 0.022229554}
@@ -805,7 +1106,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &5871660142885820529
 SkinnedMeshRenderer:
@@ -854,17 +1155,18 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: -5292892564286445321, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: 0.503904, y: -1.2410157, z: 0.45169282}
     m_Extent: {x: 0.041676864, y: 0.18982708, z: 0.16119665}
@@ -899,7 +1201,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &5891923569064526465
 SkinnedMeshRenderer:
@@ -948,21 +1250,112 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: 963444907736523418, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: 0.503904, y: 1.1969255, z: 0.5581354}
     m_Extent: {x: 0.04167682, y: 0.19356215, z: 0.17039186}
   m_DirtyAABB: 0
+--- !u!1 &1677435648774944743
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5332125297912603167}
+  - component: {fileID: 831316476073313015}
+  - component: {fileID: 76646822519513926}
+  m_Layer: 7
+  m_Name: "\u7ACB\u65B9\u4F53.030"
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5332125297912603167
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1677435648774944743}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -1.3877786e-17, w: 1}
+  m_LocalPosition: {x: 0, y: -0, z: 0.712}
+  m_LocalScale: {x: 1.3995, y: 1.3995, z: 1.3995}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 667894217056216189}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &831316476073313015
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1677435648774944743}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 43a7d2d53259df94cb60e51d30df1810, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &76646822519513926
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1677435648774944743}
+  m_Mesh: {fileID: -4317265095898143861, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
 --- !u!1 &1901087538525674000
 GameObject:
   m_ObjectHideFlags: 0
@@ -993,7 +1386,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &7744400283154766435
 SkinnedMeshRenderer:
@@ -1042,17 +1435,18 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: 1257652222431994682, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: 0.38970074, y: 0.0776891, z: 0.56641227}
     m_Extent: {x: 0.034884572, y: 0.13229132, z: 0.60275894}
@@ -1087,7 +1481,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &1504980473534530381
 SkinnedMeshRenderer:
@@ -1136,17 +1530,18 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: -3175261063665375801, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: 0.38970065, y: -0.48941404, z: 0.293832}
     m_Extent: {x: 0.034884512, y: 0.5309207, z: 0.34570503}
@@ -1183,6 +1578,336 @@ Transform:
   - {fileID: 5765857490429102456}
   m_Father: {fileID: 622467291796069570}
   m_LocalEulerAnglesHint: {x: 0, y: -89.99997, z: 0}
+--- !u!1 &1948750704443643431
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8790723513852981435}
+  - component: {fileID: 2952231798035583739}
+  - component: {fileID: 5626636243473466891}
+  m_Layer: 7
+  m_Name: "\u7ACB\u65B9\u4F53.025"
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8790723513852981435
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1948750704443643431}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -1.3877786e-17, w: 1}
+  m_LocalPosition: {x: 0, y: -0, z: 0.1156}
+  m_LocalScale: {x: 1.3995, y: 1.3995, z: 1.5963886}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 667894217056216189}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &2952231798035583739
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1948750704443643431}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 43a7d2d53259df94cb60e51d30df1810, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &5626636243473466891
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1948750704443643431}
+  m_Mesh: {fileID: -6418098087496152842, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
+--- !u!1 &2199668222682887253
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5835814158261443487}
+  m_Layer: 7
+  m_Name: Pillar 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5835814158261443487
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2199668222682887253}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7379409884249244608}
+  - {fileID: 3400217516757698052}
+  - {fileID: 6839459537215372305}
+  - {fileID: 8404593997164791054}
+  m_Father: {fileID: 7959091770065418225}
+  m_LocalEulerAnglesHint: {x: -60, y: 0, z: 0}
+--- !u!1 &2208054396320957083
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7379409884249244608}
+  - component: {fileID: 1737941913387042548}
+  - component: {fileID: 8253677363908218503}
+  m_Layer: 7
+  m_Name: "\u7ACB\u65B9\u4F53.025"
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7379409884249244608
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2208054396320957083}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -1.3877786e-17, w: 1}
+  m_LocalPosition: {x: 0, y: -0, z: 0.1156}
+  m_LocalScale: {x: 1.3995, y: 1.3995, z: 1.5963886}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5835814158261443487}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1737941913387042548
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2208054396320957083}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 43a7d2d53259df94cb60e51d30df1810, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &8253677363908218503
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2208054396320957083}
+  m_Mesh: {fileID: -6418098087496152842, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
+--- !u!1 &2267840860538726042
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7420816610305347764}
+  - component: {fileID: 637293004719037227}
+  m_Layer: 7
+  m_Name: SteamModel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7420816610305347764
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2267840860538726042}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 1.28, y: 2.51, z: 8.504}
+  m_LocalScale: {x: 1.3994997, y: 1.3994997, z: 1.3994997}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 622467291796069570}
+  - {fileID: 1285117743129950732}
+  - {fileID: 4960928932909569502}
+  - {fileID: 1067985226139714622}
+  - {fileID: 7223637868204151986}
+  - {fileID: 7064894508351025699}
+  - {fileID: 2414499544187176475}
+  - {fileID: 8462850176426544791}
+  - {fileID: 4325457601123313454}
+  - {fileID: 3978340055639171498}
+  - {fileID: 5540000528189073937}
+  - {fileID: 8807765913946642295}
+  - {fileID: 8806991448011158317}
+  - {fileID: 1231219378367787050}
+  - {fileID: 7900117261892519996}
+  - {fileID: 4209201724304870559}
+  - {fileID: 5011063934222674157}
+  - {fileID: 4853490345019064720}
+  - {fileID: 6067399541739464817}
+  - {fileID: 8746407955354605972}
+  - {fileID: 3540761935530946097}
+  - {fileID: 663752141704902775}
+  - {fileID: 1169090996918075063}
+  - {fileID: 573399710710321895}
+  - {fileID: 7301728783295800733}
+  - {fileID: 2987862145691392093}
+  - {fileID: 7251806857608164181}
+  - {fileID: 2349218121579530425}
+  - {fileID: 2733973606981406431}
+  - {fileID: 5978497540272317500}
+  - {fileID: 6720474120037104398}
+  - {fileID: 630550674496470491}
+  - {fileID: 2635912400560812961}
+  - {fileID: 6834746550858373215}
+  - {fileID: 1098043300540817012}
+  - {fileID: 2406400098237354630}
+  - {fileID: 4731495697054399717}
+  - {fileID: 245908998568101192}
+  - {fileID: 3391575848919812348}
+  - {fileID: 4564982470600443263}
+  - {fileID: 2267736611458616720}
+  - {fileID: 3775507879228285520}
+  - {fileID: 164940488543638540}
+  - {fileID: 3867931253292325484}
+  - {fileID: 7680299843741715363}
+  - {fileID: 849338864680149736}
+  - {fileID: 3248480668151622942}
+  - {fileID: 2136365079008895619}
+  - {fileID: 8352025471290747189}
+  - {fileID: 5388775004098696261}
+  - {fileID: 4621136657440664343}
+  - {fileID: 8838133164274870350}
+  - {fileID: 1033530043408842079}
+  - {fileID: 4446384861915388241}
+  - {fileID: 1282866244860391412}
+  - {fileID: 7064663393157948160}
+  - {fileID: 3013603522013735830}
+  - {fileID: 8767101986187278193}
+  - {fileID: 5263453244319583975}
+  - {fileID: 6844810338033643208}
+  - {fileID: 821942717196116330}
+  m_Father: {fileID: 5472978091728215009}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!95 &637293004719037227
+Animator:
+  serializedVersion: 7
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2267840860538726042}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 087ac8c399d57a941b291f99ae910081, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
 --- !u!1 &2281380725472448658
 GameObject:
   m_ObjectHideFlags: 0
@@ -1214,7 +1939,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &4295480566775343856
 MeshFilter:
@@ -1271,7 +1996,188 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &2384968457660483782
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3060874294461282588}
+  - component: {fileID: 8533396235414588377}
+  - component: {fileID: 8236590673462906136}
+  m_Layer: 7
+  m_Name: "\u7ACB\u65B9\u4F53.028"
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3060874294461282588
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2384968457660483782}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -1.3877786e-17, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.3995, y: 1.3995, z: 1.3995}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 667894217056216189}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &8533396235414588377
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2384968457660483782}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 43a7d2d53259df94cb60e51d30df1810, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &8236590673462906136
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2384968457660483782}
+  m_Mesh: {fileID: -2341553740804746264, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
+--- !u!1 &2414648258335182743
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1595057432795465123}
+  - component: {fileID: 848879331054525593}
+  - component: {fileID: 634432830381103659}
+  m_Layer: 7
+  m_Name: "\u7ACB\u65B9\u4F53.026"
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1595057432795465123
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2414648258335182743}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -1.3877786e-17, w: 1}
+  m_LocalPosition: {x: 0, y: -0, z: 0.1156}
+  m_LocalScale: {x: 1.3995, y: 1.3995, z: 1.5963886}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 424991132554101304}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &848879331054525593
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2414648258335182743}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 43a7d2d53259df94cb60e51d30df1810, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &634432830381103659
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2414648258335182743}
+  m_Mesh: {fileID: 1458587861500994407, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
 --- !u!1 &2521160946907620828
 GameObject:
   m_ObjectHideFlags: 0
@@ -1302,7 +2208,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &2572469478755320883
 SkinnedMeshRenderer:
@@ -1351,17 +2257,18 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: -3551019249789492363, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: 0.00000011920929, y: -0.15585595, z: 0.00289597}
     m_Extent: {x: 0.040975425, y: 0.023631096, z: 0.023631116}
@@ -1396,7 +2303,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &968297148533960821
 SkinnedMeshRenderer:
@@ -1445,17 +2352,18 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: 1638016073362324484, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: 0.50390416, y: 0.45169306, z: 1.2410156}
     m_Extent: {x: 0.04167682, y: 0.16119665, z: 0.18982708}
@@ -1487,11 +2395,11 @@ Transform:
   m_GameObject: {fileID: 2680641375808638072}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.24466494, y: 0.000000011471965, z: 0}
+  m_LocalPosition: {x: -0.229, y: 0.000000011471965, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &3122505648883789126
 MeshFilter:
@@ -1548,6 +2456,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &2707394472401333108
 GameObject:
@@ -1580,7 +2489,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &286413654694649203
 MeshFilter:
@@ -1637,6 +2546,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &2715026105738693507
 GameObject:
@@ -1668,7 +2578,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &3585023316071231902
 SkinnedMeshRenderer:
@@ -1717,17 +2627,18 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: 7184308701481391260, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: 0.061576337, y: 4.2556105, z: 0.6373057}
     m_Extent: {x: 0.15332298, y: 1.6259174, z: 0.86691993}
@@ -1763,7 +2674,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &9094681218453952020
 MeshFilter:
@@ -1820,6 +2731,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &2849606663913258158
 GameObject:
@@ -1852,6 +2764,96 @@ Transform:
   m_Children: []
   m_Father: {fileID: 7395436055917026402}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3102364506715740642
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7304518045032733783}
+  - component: {fileID: 4923455839629393185}
+  - component: {fileID: 4017326002473726973}
+  m_Layer: 7
+  m_Name: Cylinder.009_1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7304518045032733783
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3102364506715740642}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: 1, z: -0, w: 0.0000028610227}
+  m_LocalPosition: {x: 0.001, y: -0.00059998035, z: -0.135}
+  m_LocalScale: {x: 0.6672396, y: 0.6672396, z: 0.6672396}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1090121464604511345}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &4923455839629393185
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3102364506715740642}
+  m_Mesh: {fileID: 3525479140033381557, guid: ebcce7f00065e43b0af0dcf2b73bc059, type: 3}
+--- !u!23 &4017326002473726973
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3102364506715740642}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a519b1dcb96f86348b403a6f2d174643, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &3131294385272014022
 GameObject:
   m_ObjectHideFlags: 0
@@ -1883,7 +2885,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &7584131831369642029
 MeshFilter:
@@ -1940,7 +2942,98 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &3140172930377141818
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4276994365056859943}
+  - component: {fileID: 6990749836729565044}
+  - component: {fileID: 8622639436003883956}
+  m_Layer: 7
+  m_Name: "\u7ACB\u65B9\u4F53.025"
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4276994365056859943
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3140172930377141818}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -1.3877786e-17, w: 1}
+  m_LocalPosition: {x: 0, y: -0, z: 0.1156}
+  m_LocalScale: {x: 1.3995, y: 1.3995, z: 1.5963886}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 424991132554101304}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &6990749836729565044
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3140172930377141818}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 43a7d2d53259df94cb60e51d30df1810, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &8622639436003883956
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3140172930377141818}
+  m_Mesh: {fileID: -6418098087496152842, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
 --- !u!1 &3147674425614293234
 GameObject:
   m_ObjectHideFlags: 0
@@ -1972,7 +3065,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &4000276535839006106
 MeshFilter:
@@ -2029,6 +3122,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &3185116094308856944
 GameObject:
@@ -2060,7 +3154,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &3588810192962796198
 SkinnedMeshRenderer:
@@ -2109,17 +3203,18 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: 1458587861500994407, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: -0.17465675, y: 1.6359131, z: 0.07953614}
     m_Extent: {x: 0.07051402, y: 1.0726135, z: 0.09389064}
@@ -2153,10 +3248,134 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 7395436055917026402}
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: -89.98021, y: 0, z: 0}
+--- !u!1 &3332150197035538623
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2898157000496097117}
+  m_Layer: 7
+  m_Name: Big Gear
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2898157000496097117
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3332150197035538623}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.45844993, y: 0.53835356, z: 0.4584487, w: -0.53835297}
+  m_LocalPosition: {x: 2.196, y: 1.5, z: 7.5}
+  m_LocalScale: {x: 0.7082278, y: 0.7082278, z: 0.7082278}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1150115793190891956}
+  - {fileID: 6686287418671959815}
+  - {fileID: 3905701564900410449}
+  m_Father: {fileID: 5472978091728215009}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3524747294516141066
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7015886005362267287}
+  - component: {fileID: 945375632377773189}
+  - component: {fileID: 8142957386769845762}
+  m_Layer: 7
+  m_Name: "\u7ACB\u65B9\u4F53.030"
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7015886005362267287
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3524747294516141066}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -1.3877786e-17, w: 1}
+  m_LocalPosition: {x: 0, y: -0, z: 0.712}
+  m_LocalScale: {x: 1.3995, y: 1.3995, z: 1.3995}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 424991132554101304}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &945375632377773189
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3524747294516141066}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 43a7d2d53259df94cb60e51d30df1810, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &8142957386769845762
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3524747294516141066}
+  m_Mesh: {fileID: -4317265095898143861, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
 --- !u!1 &3661368962528302615
 GameObject:
   m_ObjectHideFlags: 0
@@ -2187,7 +3406,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &1871855814873240756
 SkinnedMeshRenderer:
@@ -2236,17 +3455,18 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: -6418098087496152842, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: -0.17465681, y: 1.6318295, z: -0.14025384}
     m_Extent: {x: 0.07051402, y: 1.0726137, z: 0.09389074}
@@ -2260,7 +3480,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1150115793190891956}
-  - component: {fileID: 7368238985426315784}
   m_Layer: 7
   m_Name: Model
   m_TagString: Untagged
@@ -2276,94 +3495,130 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3676729935209554105}
   serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 1.28, y: 2.51, z: 8.504}
-  m_LocalScale: {x: 1.3994997, y: 1.3994997, z: 1.3994997}
+  m_LocalRotation: {x: 0.7071058, y: -0, z: -0, w: 0.70710784}
+  m_LocalPosition: {x: -0, y: 0.001, z: -0.019}
+  m_LocalScale: {x: 1.3658098, y: 1.3658098, z: 1.3658098}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 622467291796069570}
-  - {fileID: 1285117743129950732}
-  - {fileID: 4960928932909569502}
-  - {fileID: 1067985226139714622}
-  - {fileID: 7223637868204151986}
-  - {fileID: 7064894508351025699}
-  - {fileID: 2414499544187176475}
-  - {fileID: 8462850176426544791}
-  - {fileID: 4325457601123313454}
-  - {fileID: 3978340055639171498}
-  - {fileID: 5540000528189073937}
-  - {fileID: 8807765913946642295}
-  - {fileID: 8806991448011158317}
-  - {fileID: 1231219378367787050}
-  - {fileID: 7900117261892519996}
-  - {fileID: 4209201724304870559}
-  - {fileID: 5011063934222674157}
-  - {fileID: 4853490345019064720}
-  - {fileID: 6067399541739464817}
-  - {fileID: 8746407955354605972}
-  - {fileID: 3540761935530946097}
-  - {fileID: 663752141704902775}
-  - {fileID: 1169090996918075063}
-  - {fileID: 573399710710321895}
-  - {fileID: 7301728783295800733}
-  - {fileID: 2987862145691392093}
-  - {fileID: 7251806857608164181}
-  - {fileID: 2349218121579530425}
-  - {fileID: 2733973606981406431}
-  - {fileID: 5978497540272317500}
-  - {fileID: 6720474120037104398}
-  - {fileID: 630550674496470491}
-  - {fileID: 2635912400560812961}
-  - {fileID: 6834746550858373215}
-  - {fileID: 1098043300540817012}
-  - {fileID: 2406400098237354630}
-  - {fileID: 4731495697054399717}
-  - {fileID: 245908998568101192}
-  - {fileID: 3391575848919812348}
-  - {fileID: 4564982470600443263}
-  - {fileID: 2267736611458616720}
-  - {fileID: 3775507879228285520}
-  - {fileID: 3867931253292325484}
-  - {fileID: 7680299843741715363}
-  - {fileID: 3248480668151622942}
-  - {fileID: 2136365079008895619}
-  - {fileID: 8352025471290747189}
-  - {fileID: 5388775004098696261}
-  - {fileID: 4621136657440664343}
-  - {fileID: 8838133164274870350}
-  - {fileID: 1033530043408842079}
-  - {fileID: 4446384861915388241}
-  - {fileID: 1282866244860391412}
-  - {fileID: 7064663393157948160}
-  - {fileID: 3013603522013735830}
-  - {fileID: 8767101986187278193}
-  - {fileID: 5263453244319583975}
-  - {fileID: 6844810338033643208}
-  - {fileID: 821942717196116330}
-  m_Father: {fileID: 5472978091728215009}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!95 &7368238985426315784
-Animator:
-  serializedVersion: 7
+  - {fileID: 2893123765269819818}
+  - {fileID: 6632177307854383458}
+  - {fileID: 7581559172467946455}
+  - {fileID: 6855006959205021223}
+  m_Father: {fileID: 2898157000496097117}
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!1 &3882125764060389624
+GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3676729935209554105}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5802730961300987366}
+  - component: {fileID: 2229944624751220756}
+  - component: {fileID: 2338053853166676178}
+  - component: {fileID: 834105177945057635}
+  m_Layer: 7
+  m_Name: Cylinder_1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5802730961300987366
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3882125764060389624}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.5, y: -0.5, z: -0.5, w: 0.5}
+  m_LocalPosition: {x: -0, y: -0, z: -0.122}
+  m_LocalScale: {x: 0.09115005, y: 0.45885825, z: 0.091150075}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1090121464604511345}
+  m_LocalEulerAnglesHint: {x: 0, y: -90, z: -90}
+--- !u!33 &2229944624751220756
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3882125764060389624}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &2338053853166676178
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3882125764060389624}
   m_Enabled: 1
-  m_Avatar: {fileID: 0}
-  m_Controller: {fileID: 9100000, guid: 087ac8c399d57a941b291f99ae910081, type: 2}
-  m_CullingMode: 0
-  m_UpdateMode: 0
-  m_ApplyRootMotion: 0
-  m_LinearVelocityBlending: 0
-  m_StabilizeFeet: 0
-  m_AnimatePhysics: 0
-  m_WarningMessage: 
-  m_HasTransformHierarchy: 1
-  m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorStateOnDisable: 0
-  m_WriteDefaultValuesOnDisable: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: ea421dfc65052ae47a41293f6a19a3b1, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!64 &834105177945057635
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3882125764060389624}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 1
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &3951437347972007229
 GameObject:
   m_ObjectHideFlags: 0
@@ -2425,7 +3680,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &2006625985523979206
 SkinnedMeshRenderer:
@@ -2474,17 +3729,18 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: -7413989609088122970, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: 0.34526575, y: 0.55813557, z: -1.1969258}
     m_Extent: {x: 0.04167682, y: 0.17039186, z: 0.19356215}
@@ -2519,7 +3775,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &6692435990775922708
 SkinnedMeshRenderer:
@@ -2568,21 +3824,55 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: -1144662279493218094, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: 0.000000052154064, y: 0.41010678, z: -0.11755319}
     m_Extent: {x: 0.07051401, y: 0.5206264, z: 0.0709099}
   m_DirtyAABB: 0
+--- !u!1 &4243483925804707271
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2571832457641246833}
+  m_Layer: 7
+  m_Name: OtherGear
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2571832457641246833
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4243483925804707271}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7368751018962305523}
+  - {fileID: 7959091770065418225}
+  m_Father: {fileID: 5472978091728215009}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &4247968425591866940
 GameObject:
   m_ObjectHideFlags: 0
@@ -2613,7 +3903,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &3739952677576626179
 SkinnedMeshRenderer:
@@ -2663,17 +3953,18 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: -2466738709969075148, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: -0.118171066, y: 0.67046446, z: -0.012457792}
     m_Extent: {x: 0.16711056, y: 0.12863892, z: 0.12863897}
@@ -2708,7 +3999,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &7280845950589166908
 SkinnedMeshRenderer:
@@ -2757,21 +4048,112 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: -4822751320093441184, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: 0.38970047, y: -0.07768907, z: -0.5664125}
     m_Extent: {x: 0.034884512, y: 0.1322913, z: 0.60275894}
   m_DirtyAABB: 0
+--- !u!1 &4627350484823788220
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6855006959205021223}
+  - component: {fileID: 7872776763171044735}
+  - component: {fileID: 5492046929923666938}
+  m_Layer: 7
+  m_Name: Cylinder.004
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6855006959205021223
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4627350484823788220}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.7071068, y: 0, z: -0, w: 0.7071067}
+  m_LocalPosition: {x: -0, y: 0.01574564, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1150115793190891956}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &7872776763171044735
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4627350484823788220}
+  m_Mesh: {fileID: 6255687079079774844, guid: 9c52b0f86ea0c4f4e8fa0af85fbdc32a, type: 3}
+--- !u!23 &5492046929923666938
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4627350484823788220}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a519b1dcb96f86348b403a6f2d174643, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &4775560106689322143
 GameObject:
   m_ObjectHideFlags: 0
@@ -2802,7 +4184,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &3586557029551766174
 SkinnedMeshRenderer:
@@ -2851,17 +4233,18 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: -6669591755832747216, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: 0.000000115484, y: 0.4938801, z: -0.009176809}
     m_Extent: {x: 0.04097542, y: 0.035967454, z: 0.022229556}
@@ -2896,7 +4279,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &7276551781125499288
 SkinnedMeshRenderer:
@@ -2945,17 +4328,18 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: -6314566307145985727, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: -0.17465675, y: 2.574265, z: -0.047832064}
     m_Extent: {x: 0.04097542, y: 0.036500692, z: 0.022838458}
@@ -2990,7 +4374,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &1029778802775092032
 SkinnedMeshRenderer:
@@ -3039,17 +4423,18 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: -4317265095898143861, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: -0.17465678, y: 2.7536616, z: -0.051032364}
     m_Extent: {x: 0.08042285, y: 0.24868417, z: 0.18972328}
@@ -3084,7 +4469,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &3688692596226922786
 SkinnedMeshRenderer:
@@ -3133,21 +4518,145 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: 3181457100467967643, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: 0.38970053, y: 0.48941404, z: -0.29383218}
     m_Extent: {x: 0.034884453, y: 0.5309207, z: 0.34570497}
   m_DirtyAABB: 0
+--- !u!1 &5186323450663814781
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6337629311732039660}
+  - component: {fileID: 7510854356080882410}
+  - component: {fileID: 6097083213828878017}
+  m_Layer: 7
+  m_Name: "\u7ACB\u65B9\u4F53.026"
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6337629311732039660
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5186323450663814781}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -1.3877786e-17, w: 1}
+  m_LocalPosition: {x: 0, y: -0, z: 0.1156}
+  m_LocalScale: {x: 1.3995, y: 1.3995, z: 1.5963886}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 667894217056216189}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &7510854356080882410
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5186323450663814781}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 43a7d2d53259df94cb60e51d30df1810, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &6097083213828878017
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5186323450663814781}
+  m_Mesh: {fileID: 1458587861500994407, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
+--- !u!1 &5437194977410655383
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1090121464604511345}
+  m_Layer: 7
+  m_Name: Small Gear
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1090121464604511345
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5437194977410655383}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.69050914, y: 0.15230572, z: -0.69050956, w: 0.15230478}
+  m_LocalPosition: {x: 2.326, y: 2.5, z: 8.5}
+  m_LocalScale: {x: 1.0446867, y: 1.0446867, z: 1.0446867}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7304518045032733783}
+  - {fileID: 5802730961300987366}
+  m_Father: {fileID: 5472978091728215009}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &5516100901009736001
 GameObject:
   m_ObjectHideFlags: 0
@@ -3178,7 +4687,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &8611799101811423711
 SkinnedMeshRenderer:
@@ -3227,21 +4736,112 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: 2816512666862760757, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: 0.5039035, y: -0.45169282, z: -1.2410158}
     m_Extent: {x: 0.04167682, y: 0.1611966, z: 0.18982708}
   m_DirtyAABB: 0
+--- !u!1 &5574342965219729693
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3400217516757698052}
+  - component: {fileID: 5822439529057099946}
+  - component: {fileID: 9197911682120525159}
+  m_Layer: 7
+  m_Name: "\u7ACB\u65B9\u4F53.026"
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3400217516757698052
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5574342965219729693}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -1.3877786e-17, w: 1}
+  m_LocalPosition: {x: 0, y: -0, z: 0.1156}
+  m_LocalScale: {x: 1.3995, y: 1.3995, z: 1.5963886}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5835814158261443487}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &5822439529057099946
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5574342965219729693}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 43a7d2d53259df94cb60e51d30df1810, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &9197911682120525159
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5574342965219729693}
+  m_Mesh: {fileID: 1458587861500994407, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
 --- !u!1 &5640103439028823640
 GameObject:
   m_ObjectHideFlags: 0
@@ -3272,7 +4872,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &4517370486129261165
 SkinnedMeshRenderer:
@@ -3321,17 +4921,18 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: -6472720329393319626, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: 0.5039037, y: -1.1969255, z: -0.5581356}
     m_Extent: {x: 0.04167682, y: 0.19356215, z: 0.1703919}
@@ -3366,7 +4967,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &8777540013277526338
 SkinnedMeshRenderer:
@@ -3415,17 +5016,18 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: -7578920988896096450, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: 0.50390416, y: -0.55813545, z: 1.1969255}
     m_Extent: {x: 0.04167682, y: 0.17039186, z: 0.19356227}
@@ -3460,7 +5062,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &8458303949106895176
 SkinnedMeshRenderer:
@@ -3509,17 +5111,18 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 0
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: -512599916311783058, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: 0.42458484, y: 0, z: -0.00000011920929}
     m_Extent: {x: 0.12629345, y: 1.4889742, z: 1.4889742}
@@ -3554,7 +5157,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &1463230069590688959
 SkinnedMeshRenderer:
@@ -3603,21 +5206,112 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: 5410497317680721734, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: -0.17465673, y: 0.51460826, z: -0.00956169}
     m_Extent: {x: 0.04097542, y: 0.024207294, z: 0.024207318}
   m_DirtyAABB: 0
+--- !u!1 &5894459963478679759
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6632177307854383458}
+  - component: {fileID: 5892896030917519768}
+  - component: {fileID: 5832982720347345828}
+  m_Layer: 7
+  m_Name: Cylinder.002
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6632177307854383458
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5894459963478679759}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.7071068, y: 0, z: -0, w: 0.7071067}
+  m_LocalPosition: {x: -0, y: 0.01574564, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1150115793190891956}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &5892896030917519768
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5894459963478679759}
+  m_Mesh: {fileID: 8691780276856062721, guid: 9c52b0f86ea0c4f4e8fa0af85fbdc32a, type: 3}
+--- !u!23 &5832982720347345828
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5894459963478679759}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a519b1dcb96f86348b403a6f2d174643, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &6121243998353169912
 GameObject:
   m_ObjectHideFlags: 0
@@ -3649,7 +5343,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &559715493927183771
 MeshFilter:
@@ -3706,6 +5400,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &6132083378934186737
 GameObject:
@@ -3737,7 +5432,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &2180607314253447039
 SkinnedMeshRenderer:
@@ -3786,17 +5481,18 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: -7316466408458586225, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: 0.50390375, y: 1.2410156, z: -0.4516931}
     m_Extent: {x: 0.041676864, y: 0.18982708, z: 0.16119668}
@@ -3831,7 +5527,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &1577233104339322410
 SkinnedMeshRenderer:
@@ -3880,17 +5576,18 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: -9021945706768964213, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: 0.00000008940697, y: 0.063117266, z: -0.00077584386}
     m_Extent: {x: 0.080422826, y: 0.29360393, z: 0.18721242}
@@ -3925,7 +5622,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &6924474202161605345
 SkinnedMeshRenderer:
@@ -3974,21 +5671,112 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: 2601466532094746953, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: 0.00000008940697, y: 0.6956263, z: -0.0133224875}
     m_Extent: {x: 0.08042283, y: 0.26928574, z: 0.18676053}
   m_DirtyAABB: 0
+--- !u!1 &6651255929546561855
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7581559172467946455}
+  - component: {fileID: 3061347389662347242}
+  - component: {fileID: 9213654533941017884}
+  m_Layer: 7
+  m_Name: Cylinder.003
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7581559172467946455
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6651255929546561855}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071067}
+  m_LocalPosition: {x: 0, y: 0.0109, z: -0}
+  m_LocalScale: {x: 0.99, y: 0.99, z: 1.160243}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1150115793190891956}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &3061347389662347242
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6651255929546561855}
+  m_Mesh: {fileID: 6239881831769578202, guid: 9c52b0f86ea0c4f4e8fa0af85fbdc32a, type: 3}
+--- !u!23 &9213654533941017884
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6651255929546561855}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: f8198bb6d71c2614ca0a3d15a91a74e8, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &6652462383234282761
 GameObject:
   m_ObjectHideFlags: 0
@@ -4019,7 +5807,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &4024118522474846774
 SkinnedMeshRenderer:
@@ -4069,17 +5857,18 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: -3737404711157230007, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: 0.26292896, y: 0, z: -0.000000059604645}
     m_Extent: {x: 0.31556952, y: 0.12863891, z: 0.12863903}
@@ -4114,7 +5903,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &1985922476296846259
 SkinnedMeshRenderer:
@@ -4163,17 +5952,18 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: -7824465358579035947, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: -0.17465673, y: 0.95947677, z: -0.017827883}
     m_Extent: {x: 0.04097542, y: 0.03650093, z: 0.02283857}
@@ -4208,7 +5998,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &1066282895600940572
 SkinnedMeshRenderer:
@@ -4257,21 +6047,235 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: -2341553740804746264, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: -0.17465682, y: 0.73461217, z: -0.013782904}
     m_Extent: {x: 0.08042283, y: 0.29704195, z: 0.19119701}
   m_DirtyAABB: 0
+--- !u!1 &6832514712388271270
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7368751018962305523}
+  m_Layer: 7
+  m_Name: Big Gear Pillar_1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7368751018962305523
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6832514712388271270}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.5, y: -0, z: -0, w: 0.8660254}
+  m_LocalPosition: {x: 2.549, y: 1.494, z: 7.49}
+  m_LocalScale: {x: 0.7283586, y: 0.7283586, z: 0.7283586}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 424991132554101304}
+  - {fileID: 1922842309145263341}
+  m_Father: {fileID: 2571832457641246833}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6839824421459066175
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7431884237491508683}
+  - component: {fileID: 1363338110519306670}
+  - component: {fileID: 4018726386158376613}
+  m_Layer: 7
+  m_Name: "\u7ACB\u65B9\u4F53.025"
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7431884237491508683
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6839824421459066175}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -1.3877786e-17, w: 1}
+  m_LocalPosition: {x: 0, y: -0, z: 0.1156}
+  m_LocalScale: {x: 1.3995, y: 1.3995, z: 1.5963886}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1922842309145263341}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1363338110519306670
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6839824421459066175}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 43a7d2d53259df94cb60e51d30df1810, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &4018726386158376613
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6839824421459066175}
+  m_Mesh: {fileID: -6418098087496152842, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
+--- !u!1 &6957238646679074861
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1880520962952909699}
+  - component: {fileID: 4423473883345185822}
+  - component: {fileID: 3448147250593033748}
+  m_Layer: 7
+  m_Name: "\u7ACB\u65B9\u4F53.028"
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1880520962952909699
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6957238646679074861}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -1.3877786e-17, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.3995, y: 1.3995, z: 1.3995}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1922842309145263341}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &4423473883345185822
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6957238646679074861}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 43a7d2d53259df94cb60e51d30df1810, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &3448147250593033748
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6957238646679074861}
+  m_Mesh: {fileID: -2341553740804746264, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
 --- !u!1 &7067560714053345486
 GameObject:
   m_ObjectHideFlags: 0
@@ -4302,7 +6306,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &3038047977419203729
 SkinnedMeshRenderer:
@@ -4351,21 +6355,225 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: 1254053150568087354, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: 0.34526616, y: -1.2410157, z: 0.45169282}
     m_Extent: {x: 0.04167688, y: 0.18982708, z: 0.16119665}
   m_DirtyAABB: 0
+--- !u!1 &7143425545353489097
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7143942481018946920}
+  - component: {fileID: 7169039746427805102}
+  - component: {fileID: 5338656608751990153}
+  m_Layer: 7
+  m_Name: "\u7ACB\u65B9\u4F53.030"
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7143942481018946920
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7143425545353489097}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -1.3877786e-17, w: 1}
+  m_LocalPosition: {x: 0, y: -0, z: 0.712}
+  m_LocalScale: {x: 1.3995, y: 1.3995, z: 1.3995}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1922842309145263341}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &7169039746427805102
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7143425545353489097}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 43a7d2d53259df94cb60e51d30df1810, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &5338656608751990153
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7143425545353489097}
+  m_Mesh: {fileID: -4317265095898143861, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
+--- !u!1 &7151039507478848507
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3905701564900410449}
+  - component: {fileID: 5324862008906663796}
+  - component: {fileID: 5689877637197804819}
+  - component: {fileID: 8084693319199953320}
+  m_Layer: 7
+  m_Name: Cylinder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &3905701564900410449
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7151039507478848507}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.70710677, y: -0, z: -0, w: 0.7071069}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 3, y: 0.0353997, z: 3}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2898157000496097117}
+  m_LocalEulerAnglesHint: {x: -90, y: 0, z: 0}
+--- !u!33 &5324862008906663796
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7151039507478848507}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &5689877637197804819
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7151039507478848507}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 1840b4da3e420491ea213ba45d84e21e, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!64 &8084693319199953320
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7151039507478848507}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 1
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &7152712139784919903
 GameObject:
   m_ObjectHideFlags: 0
@@ -4377,6 +6585,7 @@ GameObject:
   - component: {fileID: 5472978091728215009}
   - component: {fileID: 5875213807572921758}
   - component: {fileID: 732146308378326896}
+  - component: {fileID: 423195591339075193}
   m_Layer: 7
   m_Name: static steam engine
   m_TagString: Untagged
@@ -4397,10 +6606,13 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1150115793190891956}
+  - {fileID: 7420816610305347764}
   - {fileID: 4270104883734146018}
   - {fileID: 3970421973864715510}
   - {fileID: 5758418431475034608}
+  - {fileID: 1090121464604511345}
+  - {fileID: 2898157000496097117}
+  - {fileID: 2571832457641246833}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &5875213807572921758
@@ -4418,11 +6630,25 @@ MonoBehaviour:
   rotationInfos:
   - rotationMode: 1
     rotationAxis: 0
-    rotationTransform: {fileID: 1150115793190891956}
+    rotationTransform: {fileID: 7420816610305347764}
     isReverse: 0
     rotationSpeed: 1
-    animator: {fileID: 7368238985426315784}
+    animator: {fileID: 637293004719037227}
+    rpm60Speed: 10
+  - rotationMode: 0
+    rotationAxis: 2
+    rotationTransform: {fileID: 1090121464604511345}
+    isReverse: 0
+    rotationSpeed: 3
+    animator: {fileID: 637293004719037227}
     rpm60Speed: 2.5
+  - rotationMode: 0
+    rotationAxis: 2
+    rotationTransform: {fileID: 2898157000496097117}
+    isReverse: 0
+    rotationSpeed: 1
+    animator: {fileID: 637293004719037227}
+    rpm60Speed: 1
 --- !u!114 &732146308378326896
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4510,75 +6736,57 @@ MonoBehaviour:
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 4
-  visualEffect: {fileID: 5504513973510221741}
-  rateMaxValue: 25
-  rateCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 2
-      outSlope: 2
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0
-      outWeight: 0
-    - serializedVersion: 3
-      time: 0.0054359324
-      value: 0.1605764
-      inSlope: 1.5263897
-      outSlope: 1.5263897
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.061999626
-    - serializedVersion: 3
-      time: 1
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0
-      outWeight: 0
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  rateSizeValue: 1.25
-  sizeCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 2
-      outSlope: 2
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0
-      outWeight: 0
-    - serializedVersion: 3
-      time: 0.0054359324
-      value: 0.1605764
-      inSlope: 1.5263897
-      outSlope: 1.5263897
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.061999626
-    - serializedVersion: 3
-      time: 1
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0
-      outWeight: 0
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
+--- !u!114 &423195591339075193
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7152712139784919903}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4bb7f8f1958ea4c37b753af86394eb8a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.StateProcessor.GearStateChangeProcessorSimulator
+  targetProcessor: {fileID: 5875213807572921758}
+  isSimulating: 0
+  simulateRpm: 10
+  simulateIsClockwise: 1
+--- !u!1 &7194734555194447839
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1922842309145263341}
+  m_Layer: 7
+  m_Name: Pillar 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1922842309145263341
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7194734555194447839}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.50000006, y: -0, z: -0, w: 0.8660254}
+  m_LocalPosition: {x: -0.21829896, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7431884237491508683}
+  - {fileID: 4301143017663026084}
+  - {fileID: 1880520962952909699}
+  - {fileID: 7143942481018946920}
+  m_Father: {fileID: 7368751018962305523}
+  m_LocalEulerAnglesHint: {x: -120, y: 0, z: 0}
 --- !u!1 &7289347223471085791
 GameObject:
   m_ObjectHideFlags: 0
@@ -4610,7 +6818,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &4978684560758395111
 MeshFilter:
@@ -4667,6 +6875,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &7301679100251604257
 GameObject:
@@ -4698,7 +6907,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &3431623007638443822
 SkinnedMeshRenderer:
@@ -4747,21 +6956,292 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: -6263828891175895679, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: 0.000000115484, y: 0.8714193, z: -0.016191933}
     m_Extent: {x: 0.040975425, y: 0.023631096, z: 0.023631122}
   m_DirtyAABB: 0
+--- !u!1 &7311032610518950792
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 849338864680149736}
+  - component: {fileID: 6816672488689425659}
+  - component: {fileID: 6783084030775690546}
+  m_Layer: 7
+  m_Name: "\u5E73\u9762.041_1"
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &849338864680149736
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7311032610518950792}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.9699, y: 0.000000011471965, z: 0}
+  m_LocalScale: {x: 0.16322273, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7420816610305347764}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &6816672488689425659
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7311032610518950792}
+  m_Mesh: {fileID: -4911381985187660733, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
+--- !u!23 &6783084030775690546
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7311032610518950792}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: b62294da1f8682547b915d2368d7d1f4, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &7365314647781266391
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4301143017663026084}
+  - component: {fileID: 8018620750646468162}
+  - component: {fileID: 2919274437103835109}
+  m_Layer: 7
+  m_Name: "\u7ACB\u65B9\u4F53.026"
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4301143017663026084
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7365314647781266391}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -1.3877786e-17, w: 1}
+  m_LocalPosition: {x: 0, y: -0, z: 0.1156}
+  m_LocalScale: {x: 1.3995, y: 1.3995, z: 1.5963886}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1922842309145263341}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &8018620750646468162
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7365314647781266391}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 43a7d2d53259df94cb60e51d30df1810, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &2919274437103835109
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7365314647781266391}
+  m_Mesh: {fileID: 1458587861500994407, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
+--- !u!1 &7498543962428964741
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 164940488543638540}
+  - component: {fileID: 8480367968844828376}
+  - component: {fileID: 6266913738716474224}
+  m_Layer: 7
+  m_Name: "\u5E73\u9762.023_1"
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &164940488543638540
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7498543962428964741}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 1.014, y: -1.0416327, z: 0.00003040491}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7420816610305347764}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &8480367968844828376
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7498543962428964741}
+  m_Mesh: {fileID: 8112048821735769639, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
+--- !u!23 &6266913738716474224
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7498543962428964741}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a519b1dcb96f86348b403a6f2d174643, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &7540473756023050465
 GameObject:
   m_ObjectHideFlags: 0
@@ -4793,7 +7273,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &2136219393143461045
 MeshFilter:
@@ -4851,6 +7331,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &7629232629237261827
 GameObject:
@@ -4882,7 +7363,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &1460515497062618670
 SkinnedMeshRenderer:
@@ -4931,17 +7412,18 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: 1382288082443244307, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: 0.5039035, y: 0.55813557, z: -1.1969258}
     m_Extent: {x: 0.041676864, y: 0.17039186, z: 0.19356215}
@@ -4976,7 +7458,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &4485786595946823124
 SkinnedMeshRenderer:
@@ -5025,17 +7507,18 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: 2940371314595117130, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: 0.34526637, y: 0.45169306, z: 1.2410156}
     m_Extent: {x: 0.04167685, y: 0.16119665, z: 0.18982708}
@@ -5071,7 +7554,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &8833177891821366539
 MeshFilter:
@@ -5128,6 +7611,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &7815067576590464697
 GameObject:
@@ -5159,7 +7643,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &2143037653893339476
 SkinnedMeshRenderer:
@@ -5208,17 +7692,18 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: 1369816607575210845, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: 0.34526575, y: -0.45169282, z: -1.2410158}
     m_Extent: {x: 0.04167682, y: 0.1611966, z: 0.18982708}
@@ -5253,7 +7738,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &622776712996054714
 SkinnedMeshRenderer:
@@ -5302,17 +7787,18 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: 7691577673020836693, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: -0.17465675, y: 2.915949, z: -0.05418102}
     m_Extent: {x: 0.04097542, y: 0.024207354, z: 0.02420729}
@@ -5348,7 +7834,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &7848254117837699666
 MeshFilter:
@@ -5405,6 +7891,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &8117931100113544022
 GameObject:
@@ -5438,6 +7925,41 @@ Transform:
   - {fileID: 7990698848233360228}
   m_Father: {fileID: 5472978091728215009}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8283042857566584520
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 667894217056216189}
+  m_Layer: 7
+  m_Name: Pillar 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &667894217056216189
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8283042857566584520}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.50000006, y: -0, z: -0, w: 0.8660254}
+  m_LocalPosition: {x: -0.21829896, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8790723513852981435}
+  - {fileID: 6337629311732039660}
+  - {fileID: 3060874294461282588}
+  - {fileID: 5332125297912603167}
+  m_Father: {fileID: 7959091770065418225}
+  m_LocalEulerAnglesHint: {x: -120, y: 0, z: 0}
 --- !u!1 &8340130088821040771
 GameObject:
   m_ObjectHideFlags: 0
@@ -5468,7 +7990,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &4493251040298604789
 SkinnedMeshRenderer:
@@ -5517,53 +8039,22 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: -5133223456739768877, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: 0.34526622, y: 1.1969255, z: 0.5581354}
     m_Extent: {x: 0.04167688, y: 0.19356215, z: 0.17039181}
   m_DirtyAABB: 0
---- !u!1 &8375126391460776612
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8908440856845343672}
-  m_Layer: 7
-  m_Name: boiler
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &8908440856845343672
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8375126391460776612}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.21643956, y: -0.00000011638357, z: 0.000000025801603, w: 0.976296}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 4427160237457434826}
-  m_Father: {fileID: 622467291796069570}
-  m_LocalEulerAnglesHint: {x: -24.999966, y: -0.000015072555, z: 0.0000063699313}
 --- !u!1 &8454901950003129732
 GameObject:
   m_ObjectHideFlags: 0
@@ -5594,7 +8085,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &4156850032855502379
 SkinnedMeshRenderer:
@@ -5643,21 +8134,145 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: 5142940637789827938, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: 0.00000011920929, y: 0.41419077, z: 0.10223672}
     m_Extent: {x: 0.07051401, y: 0.5206264, z: 0.07090992}
   m_DirtyAABB: 0
+--- !u!1 &8457360597736429377
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8248333053900934161}
+  - component: {fileID: 223661857246431611}
+  - component: {fileID: 7167977802300198383}
+  m_Layer: 7
+  m_Name: "\u7ACB\u65B9\u4F53.028"
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8248333053900934161
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8457360597736429377}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -1.3877786e-17, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.3995, y: 1.3995, z: 1.3995}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 424991132554101304}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &223661857246431611
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8457360597736429377}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 43a7d2d53259df94cb60e51d30df1810, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &7167977802300198383
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8457360597736429377}
+  m_Mesh: {fileID: -2341553740804746264, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
+--- !u!1 &8744794439926576030
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7959091770065418225}
+  m_Layer: 7
+  m_Name: Big Gear Pillar_2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7959091770065418225
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8744794439926576030}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.5, y: -0, z: -0, w: 0.8660254}
+  m_LocalPosition: {x: 1.98, y: 1.494, z: 7.49}
+  m_LocalScale: {x: 0.7283586, y: 0.7283586, z: 0.7283586}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5835814158261443487}
+  - {fileID: 667894217056216189}
+  m_Father: {fileID: 2571832457641246833}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &8765315462430596485
 GameObject:
   m_ObjectHideFlags: 0
@@ -5689,7 +8304,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &76169909849702320
 MeshFilter:
@@ -5746,7 +8361,98 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &8767509032813913462
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8404593997164791054}
+  - component: {fileID: 1787113398961344784}
+  - component: {fileID: 1895009143058530740}
+  m_Layer: 7
+  m_Name: "\u7ACB\u65B9\u4F53.030"
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8404593997164791054
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8767509032813913462}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -1.3877786e-17, w: 1}
+  m_LocalPosition: {x: 0, y: -0, z: 0.712}
+  m_LocalScale: {x: 1.3995, y: 1.3995, z: 1.3995}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5835814158261443487}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1787113398961344784
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8767509032813913462}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 43a7d2d53259df94cb60e51d30df1810, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1895009143058530740
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8767509032813913462}
+  m_Mesh: {fileID: -4317265095898143861, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
 --- !u!1 &8824823034781399465
 GameObject:
   m_ObjectHideFlags: 0
@@ -5777,7 +8483,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &8481761582313792278
 SkinnedMeshRenderer:
@@ -5826,21 +8532,89 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: -9049267605004311926, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: 0.38970068, y: 0.50450706, z: 0.28367543}
     m_Extent: {x: 0.034884512, y: 0.5397513, z: 0.3192206}
   m_DirtyAABB: 0
+--- !u!1 &8840340506088511755
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7927408147114546845}
+  m_Layer: 7
+  m_Name: boiler
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7927408147114546845
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8840340506088511755}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.21643956, y: -0.00000011638357, z: 0.000000025801603, w: 0.976296}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4427160237457434826}
+  m_Father: {fileID: 622467291796069570}
+  m_LocalEulerAnglesHint: {x: -24.999966, y: -0.000015072555, z: 0.0000063699313}
+--- !u!1 &8841760052186973015
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 424991132554101304}
+  m_Layer: 7
+  m_Name: Pillar 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &424991132554101304
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8841760052186973015}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4276994365056859943}
+  - {fileID: 1595057432795465123}
+  - {fileID: 8248333053900934161}
+  - {fileID: 7015886005362267287}
+  m_Father: {fileID: 7368751018962305523}
+  m_LocalEulerAnglesHint: {x: -60, y: 0, z: 0}
 --- !u!1 &9203854404084113193
 GameObject:
   m_ObjectHideFlags: 0
@@ -5871,7 +8645,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1150115793190891956}
+  m_Father: {fileID: 7420816610305347764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &9150846964783988341
 SkinnedMeshRenderer:
@@ -5920,17 +8694,18 @@ SkinnedMeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: -2868147342130071393, guid: 8702937238461774d9be1c48d6d5e578, type: 3}
   m_Bones:
-  - {fileID: 8908440856845343672}
+  - {fileID: 7927408147114546845}
   - {fileID: 4427160237457434826}
   - {fileID: 7395436055917026402}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8908440856845343672}
+  m_RootBone: {fileID: 7927408147114546845}
   m_AABB:
     m_Center: {x: 0.42458498, y: 0, z: -0.00000008940697}
     m_Extent: {x: 0.14501333, y: 0.25350446, z: 0.2535045}

--- a/moorestech_client/Assets/AddressableResources/Block/static steam engine.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/static steam engine.prefab
@@ -6628,27 +6628,32 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   rotationInfos:
-  - rotationMode: 1
-    rotationAxis: 0
-    rotationTransform: {fileID: 7420816610305347764}
-    isReverse: 0
-    rotationSpeed: 1
-    animator: {fileID: 637293004719037227}
-    rpm60Speed: 10
-  - rotationMode: 0
-    rotationAxis: 2
-    rotationTransform: {fileID: 1090121464604511345}
-    isReverse: 0
-    rotationSpeed: 3
-    animator: {fileID: 637293004719037227}
-    rpm60Speed: 2.5
-  - rotationMode: 0
-    rotationAxis: 2
-    rotationTransform: {fileID: 2898157000496097117}
-    isReverse: 0
-    rotationSpeed: 1
-    animator: {fileID: 637293004719037227}
-    rpm60Speed: 1
+  - rid: 3331677946101629133
+  - rid: 3331677946101629134
+  - rid: 3331677946101629135
+  references:
+    version: 2
+    RefIds:
+    - rid: 3331677946101629133
+      type: {class: AnimatorRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        animator: {fileID: 637293004719037227}
+        rpm60Speed: 10
+    - rid: 3331677946101629134
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 2
+        rotationTransform: {fileID: 1090121464604511345}
+        rotationSpeed: 3
+    - rid: 3331677946101629135
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 2
+        rotationTransform: {fileID: 2898157000496097117}
+        rotationSpeed: 1
 --- !u!114 &732146308378326896
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/moorestech_client/Assets/AddressableResources/Block/wood_conveyor.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/wood_conveyor.prefab
@@ -2256,27 +2256,33 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   rotationInfos:
-  - rotationMode: 0
-    rotationAxis: 1
-    rotationTransform: {fileID: 796761116917381936}
-    isReverse: 0
-    rotationSpeed: 1
-    animator: {fileID: 0}
-    rpm60Speed: 1
-  - rotationMode: 0
-    rotationAxis: 1
-    rotationTransform: {fileID: 4382060851992441623}
-    isReverse: 0
-    rotationSpeed: 1
-    animator: {fileID: 0}
-    rpm60Speed: 1
-  - rotationMode: 0
-    rotationAxis: 1
-    rotationTransform: {fileID: 6704414630968729764}
-    isReverse: 1
-    rotationSpeed: 2
-    animator: {fileID: 0}
-    rpm60Speed: 1
+  - rid: 3331677946101629138
+  - rid: 3331677946101629139
+  - rid: 3331677946101629140
+  references:
+    version: 2
+    RefIds:
+    - rid: 3331677946101629138
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 1
+        rotationTransform: {fileID: 796761116917381936}
+        rotationSpeed: 1
+    - rid: 3331677946101629139
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 1
+        rotationTransform: {fileID: 4382060851992441623}
+        rotationSpeed: 1
+    - rid: 3331677946101629140
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 1
+        rotationAxis: 1
+        rotationTransform: {fileID: 6704414630968729764}
+        rotationSpeed: 2
 --- !u!114 &4749019686752399308
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/moorestech_client/Assets/AddressableResources/Item/Iron Gear.prefab
+++ b/moorestech_client/Assets/AddressableResources/Item/Iron Gear.prefab
@@ -88,6 +88,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &4622773655420902686
 GameObject:
@@ -184,10 +185,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   rotationInfos:
-  - rotationMode: 0
-    rotationAxis: 2
-    rotationTransform: {fileID: 5786499207534134854}
-    isReverse: 0
-    rotationSpeed: 1
-    animator: {fileID: 0}
-    rpm60Speed: 1
+  - rid: 3331677946101629143
+  references:
+    version: 2
+    RefIds:
+    - rid: 3331677946101629143
+      type: {class: TransformRotationInfo, ns: Client.Game.InGame.BlockSystem.StateProcessor, asm: Client.Game}
+      data:
+        isReverse: 0
+        rotationAxis: 2
+        rotationTransform: {fileID: 5786499207534134854}
+        rotationSpeed: 1

--- a/moorestech_client/Assets/Asset/Common/URPSettings/UniversalRP-UltraLowQuality.asset
+++ b/moorestech_client/Assets/Asset/Common/URPSettings/UniversalRP-UltraLowQuality.asset
@@ -12,8 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bf2edee5c58d82540a51f03df9d42094, type: 3}
   m_Name: UniversalRP-UltraLowQuality
   m_EditorClassIdentifier: 
-  k_AssetVersion: 12
-  k_AssetPreviousVersion: 12
+  k_AssetVersion: 13
+  k_AssetPreviousVersion: 13
   m_RendererType: 1
   m_RendererData: {fileID: 0}
   m_RendererDataList:
@@ -128,9 +128,14 @@ MonoBehaviour:
   m_PrefilterSoftShadowsQualityHigh: 1
   m_PrefilterSoftShadows: 0
   m_PrefilterScreenCoord: 1
+  m_PrefilterScreenSpaceIrradiance: 0
   m_PrefilterNativeRenderPass: 1
   m_PrefilterUseLegacyLightmaps: 0
   m_PrefilterBicubicLightmapSampling: 1
+  m_PrefilterReflectionProbeRotation: 0
+  m_PrefilterReflectionProbeBlending: 0
+  m_PrefilterReflectionProbeBoxProjection: 0
+  m_PrefilterReflectionProbeAtlas: 0
   m_ShaderVariantLogLevel: 0
   m_ShadowCascades: 0
   m_Textures:

--- a/moorestech_client/Assets/Scenes/Game/MainGame.unity
+++ b/moorestech_client/Assets/Scenes/Game/MainGame.unity
@@ -13927,10 +13927,6 @@ PrefabInstance:
       propertyPath: instanceId
       value: 642
       objectReference: {fileID: 0}
-    - target: {fileID: 1065194689904620432, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 1069804963709548728, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
       propertyPath: instanceId
       value: 1529
@@ -15455,10 +15451,6 @@ PrefabInstance:
       propertyPath: instanceId
       value: 613
       objectReference: {fileID: 0}
-    - target: {fileID: 2717918626617621610, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
-      propertyPath: instanceId
-      value: 5
-      objectReference: {fileID: 0}
     - target: {fileID: 2721309639926601052, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
       propertyPath: instanceId
       value: 1492
@@ -15882,10 +15874,6 @@ PrefabInstance:
     - target: {fileID: 3163644455535706965, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
       propertyPath: instanceId
       value: 576
-      objectReference: {fileID: 0}
-    - target: {fileID: 3171488809621439426, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
-      propertyPath: m_IsActive
-      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3192093161103953381, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
       propertyPath: instanceId
@@ -17111,10 +17099,6 @@ PrefabInstance:
       propertyPath: instanceId
       value: 157
       objectReference: {fileID: 0}
-    - target: {fileID: 4636483539665400804, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
-      propertyPath: instanceId
-      value: 4
-      objectReference: {fileID: 0}
     - target: {fileID: 4639973367930867764, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
       propertyPath: instanceId
       value: 1614
@@ -17491,10 +17475,6 @@ PrefabInstance:
       propertyPath: instanceId
       value: 152
       objectReference: {fileID: 0}
-    - target: {fileID: 5076476182506482685, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
-      propertyPath: instanceId
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 5076682631164925481, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
       propertyPath: instanceId
       value: 1397
@@ -17810,14 +17790,6 @@ PrefabInstance:
     - target: {fileID: 5451541481653695670, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
       propertyPath: instanceId
       value: 1826
-      objectReference: {fileID: 0}
-    - target: {fileID: 5458107614731982492, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
-      propertyPath: m_LocalScale.y
-      value: 138.84
-      objectReference: {fileID: 0}
-    - target: {fileID: 5458107614731982492, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 80.0871
       objectReference: {fileID: 0}
     - target: {fileID: 5460466343172357957, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
       propertyPath: instanceId
@@ -18394,10 +18366,6 @@ PrefabInstance:
     - target: {fileID: 6229285670174489191, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
       propertyPath: instanceId
       value: 1040
-      objectReference: {fileID: 0}
-    - target: {fileID: 6237122741969395740, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
-      propertyPath: instanceId
-      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 6247446713483099883, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
       propertyPath: instanceId
@@ -19178,10 +19146,6 @@ PrefabInstance:
     - target: {fileID: 7122230087097285574, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
       propertyPath: instanceId
       value: 1283
-      objectReference: {fileID: 0}
-    - target: {fileID: 7124258199071091591, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
-      propertyPath: instanceId
-      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 7125506156833940294, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
       propertyPath: instanceId
@@ -21078,7 +21042,220 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 2345800080793341622, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 6186469005139375950, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 5325984158543274323, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 4983007518945246383, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 6048789289821531991, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 1044903139547444926, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 6352847292318733746, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 2789107225329735095, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 2888578519638477363, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 2829137490279429441, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 1972600494803916751, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 2361711083070659074, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 7913795904240110673, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 6640032458544290658, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 3022590020588798112, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 1937876748744736632, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 275985386491662088, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 1570383210981002124, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 1816416102456396953, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 6670986000122847509, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 3748732796558971514, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 3878442197947209973, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 7659498287186694918, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 4986400409923622698, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 8951714247016766456, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 8097025806375942514, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 3435488859256918802, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 8298917031184724141, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 1276969150652112567, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 6694131549083695660, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 935694676443057506, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 2551597609567129346, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 8894414695037093757, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 888982375407696353, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 5089601875899412056, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 1141349812854338490, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 6060228472524156398, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 818913370268389265, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 7982137518240052882, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 6114274561055195990, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 5783997125188379833, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 678874119927642416, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 7733975914572445188, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 5135248479114913808, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 5801059908893614360, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 1636086468583691694, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 252252077091035427, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 8478479187322184530, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 3131887026809295186, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 9068607647931090633, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 2719303884758993326, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 5551100430840485735, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 2641101431874598538, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 5769548873596392364, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 3103640984923065093, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 3881040598557470681, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 6955371529938443828, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 4039056520231657859, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 4520147855267640173, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 1267146711278631285, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 1139845083360630041, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 2771961851288584291, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 7854164454807303207, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 471052676499937856, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 8300532025878163118, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 4653088350050031779, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 7937580427364997, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 2407970631355042353, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 8114336358680924576, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 7119683190114520158, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 8766247776735475859, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
   m_SourcePrefab: {fileID: 100100000, guid: 53d25a583ee974aa59260ebc24130895, type: 3}
 --- !u!114 &1271903679 stripped
 MonoBehaviour:
@@ -39705,19 +39882,19 @@ PrefabInstance:
     - target: {fileID: 2378660713236389372, guid: efa1e9567bd6a46cc9bb22790eef4693, type: 3}
       propertyPath: 'mapObjects.Array.data[2011]'
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 1271903682}
     - target: {fileID: 2378660713236389372, guid: efa1e9567bd6a46cc9bb22790eef4693, type: 3}
       propertyPath: 'mapObjects.Array.data[2012]'
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 1271903681}
     - target: {fileID: 2378660713236389372, guid: efa1e9567bd6a46cc9bb22790eef4693, type: 3}
       propertyPath: 'mapObjects.Array.data[2013]'
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 1271903680}
     - target: {fileID: 2378660713236389372, guid: efa1e9567bd6a46cc9bb22790eef4693, type: 3}
       propertyPath: 'mapObjects.Array.data[2014]'
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 1271903679}
     - target: {fileID: 2378660713236389372, guid: efa1e9567bd6a46cc9bb22790eef4693, type: 3}
       propertyPath: 'mapObjects.Array.data[2015]'
       value: 

--- a/moorestech_client/Assets/Scenes/Other/BlockSetup.unity
+++ b/moorestech_client/Assets/Scenes/Other/BlockSetup.unity
@@ -235,6 +235,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!33 &1842943
 MeshFilter:
@@ -379,6 +380,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!33 &249690722
 MeshFilter:
@@ -439,6 +441,87 @@ Transform:
   - {fileID: 999817694}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &491389423
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2166917927933167143, guid: e039e23dd6ec87742ac59a0964a66fa0, type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2366686171965463955, guid: e039e23dd6ec87742ac59a0964a66fa0, type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2744815472301864861, guid: e039e23dd6ec87742ac59a0964a66fa0, type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3080275620989080107, guid: e039e23dd6ec87742ac59a0964a66fa0, type: 3}
+      propertyPath: m_Name
+      value: iron furnace with bellows
+      objectReference: {fileID: 0}
+    - target: {fileID: 3080275620989080107, guid: e039e23dd6ec87742ac59a0964a66fa0, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5909471806100412200, guid: e039e23dd6ec87742ac59a0964a66fa0, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5909471806100412200, guid: e039e23dd6ec87742ac59a0964a66fa0, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5909471806100412200, guid: e039e23dd6ec87742ac59a0964a66fa0, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5909471806100412200, guid: e039e23dd6ec87742ac59a0964a66fa0, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5909471806100412200, guid: e039e23dd6ec87742ac59a0964a66fa0, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5909471806100412200, guid: e039e23dd6ec87742ac59a0964a66fa0, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5909471806100412200, guid: e039e23dd6ec87742ac59a0964a66fa0, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5909471806100412200, guid: e039e23dd6ec87742ac59a0964a66fa0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5909471806100412200, guid: e039e23dd6ec87742ac59a0964a66fa0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5909471806100412200, guid: e039e23dd6ec87742ac59a0964a66fa0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 5909471806100412200, guid: e039e23dd6ec87742ac59a0964a66fa0, type: 3}
+      insertIndex: 6
+      addedObject: {fileID: 2122302002}
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e039e23dd6ec87742ac59a0964a66fa0, type: 3}
+--- !u!4 &491389424 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5909471806100412200, guid: e039e23dd6ec87742ac59a0964a66fa0, type: 3}
+  m_PrefabInstance: {fileID: 491389423}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &491824910
 GameObject:
   m_ObjectHideFlags: 0
@@ -555,6 +638,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!33 &491824915
 MeshFilter:
@@ -666,6 +750,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!33 &552025862
 MeshFilter:
@@ -716,14 +801,14 @@ Light:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 709433684}
   m_Enabled: 1
-  serializedVersion: 11
+  serializedVersion: 12
   m_Type: 1
   m_Color: {r: 1, g: 0.9794289, b: 0.8537736, a: 1}
   m_Intensity: 1.2
   m_Range: 10
   m_SpotAngle: 30
   m_InnerSpotAngle: 21.80208
-  m_CookieSize: 10
+  m_CookieSize2D: {x: 10, y: 10}
   m_Shadows:
     m_Type: 2
     m_Resolution: 3
@@ -918,6 +1003,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!33 &991681168
 MeshFilter:
@@ -1043,6 +1129,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!33 &999817698
 MeshFilter:
@@ -1132,6 +1219,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!33 &1153581176
 MeshFilter:
@@ -1343,6 +1431,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!33 &2028237064
 MeshFilter:
@@ -1352,6 +1441,125 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2028237060}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1001 &2122302001
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 491389424}
+    m_Modifications:
+    - target: {fileID: 1069051896562662691, guid: a22f794443335e74c82387a9f622ffcd, type: 3}
+      propertyPath: m_Name
+      value: gear belt conveyor_4
+      objectReference: {fileID: 0}
+    - target: {fileID: 2750780202867129520, guid: a22f794443335e74c82387a9f622ffcd, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2750780202867129520, guid: a22f794443335e74c82387a9f622ffcd, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2750780202867129520, guid: a22f794443335e74c82387a9f622ffcd, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2750780202867129520, guid: a22f794443335e74c82387a9f622ffcd, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7099969
+      objectReference: {fileID: 0}
+    - target: {fileID: 2750780202867129520, guid: a22f794443335e74c82387a9f622ffcd, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2750780202867129520, guid: a22f794443335e74c82387a9f622ffcd, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.70420486
+      objectReference: {fileID: 0}
+    - target: {fileID: 2750780202867129520, guid: a22f794443335e74c82387a9f622ffcd, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2750780202867129520, guid: a22f794443335e74c82387a9f622ffcd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2750780202867129520, guid: a22f794443335e74c82387a9f622ffcd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -89.531
+      objectReference: {fileID: 0}
+    - target: {fileID: 2750780202867129520, guid: a22f794443335e74c82387a9f622ffcd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a22f794443335e74c82387a9f622ffcd, type: 3}
+--- !u!4 &2122302002 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2750780202867129520, guid: a22f794443335e74c82387a9f622ffcd, type: 3}
+  m_PrefabInstance: {fileID: 2122302001}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2294760600596169148
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 5472978091728215009, guid: 4685e69708529f14084d76cb7178947d, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5472978091728215009, guid: 4685e69708529f14084d76cb7178947d, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5472978091728215009, guid: 4685e69708529f14084d76cb7178947d, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5472978091728215009, guid: 4685e69708529f14084d76cb7178947d, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5472978091728215009, guid: 4685e69708529f14084d76cb7178947d, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5472978091728215009, guid: 4685e69708529f14084d76cb7178947d, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5472978091728215009, guid: 4685e69708529f14084d76cb7178947d, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5472978091728215009, guid: 4685e69708529f14084d76cb7178947d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5472978091728215009, guid: 4685e69708529f14084d76cb7178947d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5472978091728215009, guid: 4685e69708529f14084d76cb7178947d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7152712139784919903, guid: 4685e69708529f14084d76cb7178947d, type: 3}
+      propertyPath: m_Name
+      value: static steam engine
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4685e69708529f14084d76cb7178947d, type: 3}
 --- !u!1001 &6544891171320384485
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1411,10 +1619,7 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 5372206247686862805, guid: 1e07ecbf44f2bf04ebac9e0e7ad2d0d4, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1e07ecbf44f2bf04ebac9e0e7ad2d0d4, type: 3}
 --- !u!1001 &8927088242621299891
 PrefabInstance:
@@ -1468,6 +1673,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Primitive Miner
       objectReference: {fileID: 0}
+    - target: {fileID: 8431477417945616397, guid: 4de48accd99c74e2eb6d961c7a5de6d4, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -1484,3 +1693,5 @@ SceneRoots:
   - {fileID: 1424496582}
   - {fileID: 1978912614}
   - {fileID: 8927088242621299891}
+  - {fileID: 491389423}
+  - {fileID: 2294760600596169148}

--- a/moorestech_client/Assets/Scripts/Client.Common/SubclassSelectorAttribute.cs
+++ b/moorestech_client/Assets/Scripts/Client.Common/SubclassSelectorAttribute.cs
@@ -1,0 +1,20 @@
+// Based on https://github.com/baba-s/Unity-SerializeReferenceExtensions
+
+using System;
+using UnityEngine;
+
+[AttributeUsage(AttributeTargets.Field, AllowMultiple = false)]
+public class SubclassSelectorAttribute : PropertyAttribute
+{
+    bool m_includeMono;
+
+    public SubclassSelectorAttribute(bool includeMono = false)
+    {
+        m_includeMono = includeMono;
+    }
+
+    public bool IsIncludeMono()
+    {
+        return m_includeMono;
+    }
+}

--- a/moorestech_client/Assets/Scripts/Client.Common/SubclassSelectorAttribute.cs
+++ b/moorestech_client/Assets/Scripts/Client.Common/SubclassSelectorAttribute.cs
@@ -18,3 +18,16 @@ public class SubclassSelectorAttribute : PropertyAttribute
         return m_includeMono;
     }
 }
+
+// サブクラス選択ポップアップ上に表示する名前をクラスごとに上書きする
+// Overrides the display name shown in the subclass-selector popup per class
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+public class SubclassSelectorNameAttribute : Attribute
+{
+    public string DisplayName { get; }
+
+    public SubclassSelectorNameAttribute(string displayName)
+    {
+        DisplayName = displayName;
+    }
+}

--- a/moorestech_client/Assets/Scripts/Client.Common/SubclassSelectorAttribute.cs
+++ b/moorestech_client/Assets/Scripts/Client.Common/SubclassSelectorAttribute.cs
@@ -6,17 +6,6 @@ using UnityEngine;
 [AttributeUsage(AttributeTargets.Field, AllowMultiple = false)]
 public class SubclassSelectorAttribute : PropertyAttribute
 {
-    bool m_includeMono;
-
-    public SubclassSelectorAttribute(bool includeMono = false)
-    {
-        m_includeMono = includeMono;
-    }
-
-    public bool IsIncludeMono()
-    {
-        return m_includeMono;
-    }
 }
 
 // サブクラス選択ポップアップ上に表示する名前をクラスごとに上書きする

--- a/moorestech_client/Assets/Scripts/Client.Common/SubclassSelectorAttribute.cs.meta
+++ b/moorestech_client/Assets/Scripts/Client.Common/SubclassSelectorAttribute.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 53f3ff0eca635491ead98f0e8500c413

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/StateProcessor/GearStateChangeProcessor.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/StateProcessor/GearStateChangeProcessor.cs
@@ -11,115 +11,110 @@ namespace Client.Game.InGame.BlockSystem.StateProcessor
     public class GearStateChangeProcessor : MonoBehaviour, IBlockStateChangeProcessor
     {
         public IReadOnlyList<RotationInfo> RotationInfos => rotationInfos;
-        [SerializeField] private List<RotationInfo> rotationInfos;
-        
+        [SerializeReference, SubclassSelector] private List<RotationInfo> rotationInfos;
+
         private GearStateDetail _currentGearState;
-        
+
         public void Initialize(BlockGameObject blockGameObject) { }
-        
+
         public void OnChangeState(BlockStateMessagePack blockState)
         {
             _currentGearState = blockState.GetStateDetail<GearStateDetail>(GearStateDetail.BlockStateDetailKey);
         }
-        
+
         private void Update()
         {
             if (_currentGearState == null) return;
-            
+
             Rotate(_currentGearState);
         }
-        
+
         public void Rotate(GearStateDetail gearStateDetail)
         {
+            if (rotationInfos == null) return;
+
             foreach (var rotationInfo in rotationInfos)
             {
-                switch (rotationInfo.RotationMode)
-                {
-                    case RotationMode.TransformRotate:
-                        TransformRotate(rotationInfo);
-                        break;
-                    case RotationMode.Animator:
-                        AnimationRotate(rotationInfo);
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException();
-                }
+                if (rotationInfo == null) continue;
+                rotationInfo.Rotate(gearStateDetail);
             }
-            
-            #region Internal
-            
-            void TransformRotate(RotationInfo rotationInfo)
-            {
-                var rpm = gearStateDetail.CurrentRpm;
-                var rotation = rpm / 60 * Time.deltaTime * 360;
-                
-                var rotate = rotationInfo.RotationAxis switch
-                {
-                    RotationAxis.X => new Vector3(rotation, 0, 0),
-                    RotationAxis.Y => new Vector3(0, rotation, 0),
-                    RotationAxis.Z => new Vector3(0, 0, rotation),
-                    _ => Vector3.zero,
-                };
-                rotate *= rotationInfo.IsReverse ? -1 : 1;
-                rotate *= rotationInfo.RotationSpeed;
-                rotate *= gearStateDetail.IsClockwise ? 1 : -1;
-                
-                rotationInfo.RotationTransform.Rotate(rotate);
-            }
-            
-            void AnimationRotate(RotationInfo rotationInfo)
-            {
-                var rpmRate = gearStateDetail.CurrentRpm / 60f;
-                var speed = rotationInfo.Rpm60Speed * (rotationInfo.IsReverse ? -1 : 1) * (gearStateDetail.IsClockwise ? 1 : -1) * rpmRate;
-                rotationInfo.Animator.speed = speed;
-            }
-            
-  #endregion
         }
-        
+
         #if UNITY_EDITOR
         public GearStateDetail DebugCurrentGearState => _currentGearState;
         #endif
     }
-    
+
     [Serializable]
-    public class RotationInfo
+    public abstract class RotationInfo
     {
-        [SerializeField] private RotationMode rotationMode;
-        
-        [Header("TransformRotate Only")]
+        [SerializeField] protected bool isReverse;
+
+        public bool IsReverse => isReverse;
+
+        // TransformRotationInfoのみ値を返す。Simulator互換のためベースに公開
+        // Only TransformRotationInfo returns a value. Exposed on base for simulator compatibility
+        public virtual Transform RotationTransform => null;
+
+        public abstract void Rotate(GearStateDetail gearStateDetail);
+    }
+
+    [Serializable]
+    public class TransformRotationInfo : RotationInfo
+    {
         [SerializeField] private RotationAxis rotationAxis;
         [SerializeField] private Transform rotationTransform;
-        
-        [SerializeField] private bool isReverse;
         [SerializeField] private float rotationSpeed = 1;
-        
-        [Header("Animator Only")]
+
+        public RotationAxis RotationAxis => rotationAxis;
+        public override Transform RotationTransform => rotationTransform;
+        public float RotationSpeed => rotationSpeed;
+
+        public override void Rotate(GearStateDetail gearStateDetail)
+        {
+            if (rotationTransform == null) return;
+
+            var rpm = gearStateDetail.CurrentRpm;
+            var rotation = rpm / 60 * Time.deltaTime * 360;
+
+            var rotate = rotationAxis switch
+            {
+                RotationAxis.X => new Vector3(rotation, 0, 0),
+                RotationAxis.Y => new Vector3(0, rotation, 0),
+                RotationAxis.Z => new Vector3(0, 0, rotation),
+                _ => Vector3.zero,
+            };
+            rotate *= isReverse ? -1 : 1;
+            rotate *= rotationSpeed;
+            rotate *= gearStateDetail.IsClockwise ? 1 : -1;
+
+            rotationTransform.Rotate(rotate);
+        }
+    }
+
+    [Serializable]
+    public class AnimatorRotationInfo : RotationInfo
+    {
         [SerializeField] private Animator animator;
         [SerializeField] private float rpm60Speed = 1;
-        
-        public RotationMode RotationMode => rotationMode;
-        
-        public RotationAxis RotationAxis => rotationAxis;
-        public Transform RotationTransform => rotationTransform;
-        
+
         public Animator Animator => animator;
         public float Rpm60Speed => rpm60Speed;
-        
-        public bool IsReverse => isReverse;
-        public float RotationSpeed => rotationSpeed;
+
+        public override void Rotate(GearStateDetail gearStateDetail)
+        {
+            if (animator == null) return;
+
+            var rpmRate = gearStateDetail.CurrentRpm / 60f;
+            var speed = rpm60Speed * (isReverse ? -1 : 1) * (gearStateDetail.IsClockwise ? 1 : -1) * rpmRate;
+            animator.speed = speed;
+        }
     }
-    
+
     public enum RotationAxis
     {
         X,
         Y,
         Z,
-    }
-    
-    public enum RotationMode
-    {
-        TransformRotate,
-        Animator,
     }
 }

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/StateProcessor/GearStateChangeProcessor.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/StateProcessor/GearStateChangeProcessor.cs
@@ -11,7 +11,7 @@ namespace Client.Game.InGame.BlockSystem.StateProcessor
     public class GearStateChangeProcessor : MonoBehaviour, IBlockStateChangeProcessor
     {
         public IReadOnlyList<RotationInfo> RotationInfos => rotationInfos;
-        [SerializeReference, SubclassSelector] private List<RotationInfo> rotationInfos;
+        [SerializeReference, SubclassSelector] private List<RotationInfo> rotationInfos = new();
 
         private GearStateDetail _currentGearState;
 
@@ -31,8 +31,6 @@ namespace Client.Game.InGame.BlockSystem.StateProcessor
 
         public void Rotate(GearStateDetail gearStateDetail)
         {
-            if (rotationInfos == null) return;
-
             foreach (var rotationInfo in rotationInfos)
             {
                 if (rotationInfo == null) continue;

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/StateProcessor/GearStateChangeProcessor.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/StateProcessor/GearStateChangeProcessor.cs
@@ -60,6 +60,7 @@ namespace Client.Game.InGame.BlockSystem.StateProcessor
     }
 
     [Serializable]
+    [SubclassSelectorName("Transform Rotate")]
     public class TransformRotationInfo : RotationInfo
     {
         [SerializeField] private RotationAxis rotationAxis;
@@ -93,6 +94,7 @@ namespace Client.Game.InGame.BlockSystem.StateProcessor
     }
 
     [Serializable]
+    [SubclassSelectorName("Animator")]
     public class AnimatorRotationInfo : RotationInfo
     {
         [SerializeField] private Animator animator;

--- a/moorestech_client/Assets/Scripts/Editor/SubclassSelectorDrawer.cs
+++ b/moorestech_client/Assets/Scripts/Editor/SubclassSelectorDrawer.cs
@@ -60,7 +60,12 @@ public class SubclassSelectorDrawer : PropertyDrawer
 
     private void GetInheritedTypeNameArrays()
     {
-        typePopupNameArray = inheritedTypes.Select(type => type == null ? "<null>" : type.ToString()).ToArray();
+        typePopupNameArray = inheritedTypes.Select(type =>
+        {
+            if (type == null) return "<null>";
+            var nameAttr = type.GetCustomAttribute<SubclassSelectorNameAttribute>(inherit: false);
+            return nameAttr != null ? nameAttr.DisplayName : type.Name;
+        }).ToArray();
         typeFullNameArray = inheritedTypes.Select(type => type == null ? "" : string.Format("{0} {1}", type.Assembly.ToString().Split(',')[0], type.FullName)).ToArray();
     }
 

--- a/moorestech_client/Assets/Scripts/Editor/SubclassSelectorDrawer.cs
+++ b/moorestech_client/Assets/Scripts/Editor/SubclassSelectorDrawer.cs
@@ -11,7 +11,11 @@ using UnityEngine;
 [CustomPropertyDrawer(typeof(SubclassSelectorAttribute))]
 public class SubclassSelectorDrawer : PropertyDrawer
 {
-    bool initialized = false;
+    // PropertyDrawerインスタンスはリスト要素間で使い回されるため、
+    // 型配列はベース型をキーにしてキャッシュし、現在インデックスは毎OnGUIで再計算する
+    // PropertyDrawer instances are reused across list elements, so cache type
+    // arrays keyed by base type and recompute the current index every OnGUI
+    Type cachedBaseType;
     Type[] inheritedTypes;
     string[] typePopupNameArray;
     string[] typeFullNameArray;
@@ -20,12 +24,16 @@ public class SubclassSelectorDrawer : PropertyDrawer
     public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
     {
         if (property.propertyType != SerializedPropertyType.ManagedReference) return;
-        if (!initialized)
+
+        var baseType = GetType(property);
+        if (cachedBaseType != baseType)
         {
-            Initialize(property);
-            GetCurrentTypeIndex(property.managedReferenceFullTypename);
-            initialized = true;
+            GetAllInheritedTypes(baseType);
+            GetInheritedTypeNameArrays();
+            cachedBaseType = baseType;
         }
+        GetCurrentTypeIndex(property.managedReferenceFullTypename);
+
         int selectedTypeIndex = EditorGUI.Popup(GetPopupPosition(position), currentTypeIndex, typePopupNameArray);
         UpdatePropertyToSelectedTypeIndex(property, selectedTypeIndex);
         EditorGUI.PropertyField(position, property, label, true);
@@ -36,24 +44,19 @@ public class SubclassSelectorDrawer : PropertyDrawer
         return EditorGUI.GetPropertyHeight(property, true);
     }
 
-    private void Initialize(SerializedProperty property)
-    {
-        SubclassSelectorAttribute utility = (SubclassSelectorAttribute)attribute;
-        GetAllInheritedTypes(GetType(property), utility.IsIncludeMono());
-        GetInheritedTypeNameArrays();
-    }
-
     private void GetCurrentTypeIndex(string typeFullName)
     {
         currentTypeIndex = Array.IndexOf(typeFullNameArray, typeFullName);
     }
 
-    void GetAllInheritedTypes(Type baseType, bool includeMono)
+    // SerializeReferenceはUnityEngine.Object派生型を格納できない
+    // SerializeReference cannot store UnityEngine.Object-derived instances
+    void GetAllInheritedTypes(Type baseType)
     {
-        Type monoType = typeof(MonoBehaviour);
+        Type unityObjectType = typeof(UnityEngine.Object);
         inheritedTypes = AppDomain.CurrentDomain.GetAssemblies()
             .SelectMany(s => s.GetTypes())
-            .Where(p => baseType.IsAssignableFrom(p) && p.IsClass && !p.IsAbstract && (!monoType.IsAssignableFrom(p) || includeMono))
+            .Where(p => baseType.IsAssignableFrom(p) && p.IsClass && !p.IsAbstract && !unityObjectType.IsAssignableFrom(p))
             .Prepend(null)
             .ToArray();
     }

--- a/moorestech_client/Assets/Scripts/Editor/SubclassSelectorDrawer.cs
+++ b/moorestech_client/Assets/Scripts/Editor/SubclassSelectorDrawer.cs
@@ -1,0 +1,124 @@
+// Based on https://github.com/baba-s/Unity-SerializeReferenceExtensions
+
+#if UNITY_2019_3_OR_NEWER
+
+using System;
+using System.Linq;
+using System.Reflection;
+using UnityEditor;
+using UnityEngine;
+
+[CustomPropertyDrawer(typeof(SubclassSelectorAttribute))]
+public class SubclassSelectorDrawer : PropertyDrawer
+{
+    bool initialized = false;
+    Type[] inheritedTypes;
+    string[] typePopupNameArray;
+    string[] typeFullNameArray;
+    int currentTypeIndex;
+
+    public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+    {
+        if (property.propertyType != SerializedPropertyType.ManagedReference) return;
+        if (!initialized)
+        {
+            Initialize(property);
+            GetCurrentTypeIndex(property.managedReferenceFullTypename);
+            initialized = true;
+        }
+        int selectedTypeIndex = EditorGUI.Popup(GetPopupPosition(position), currentTypeIndex, typePopupNameArray);
+        UpdatePropertyToSelectedTypeIndex(property, selectedTypeIndex);
+        EditorGUI.PropertyField(position, property, label, true);
+    }
+
+    public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+    {
+        return EditorGUI.GetPropertyHeight(property, true);
+    }
+
+    private void Initialize(SerializedProperty property)
+    {
+        SubclassSelectorAttribute utility = (SubclassSelectorAttribute)attribute;
+        GetAllInheritedTypes(GetType(property), utility.IsIncludeMono());
+        GetInheritedTypeNameArrays();
+    }
+
+    private void GetCurrentTypeIndex(string typeFullName)
+    {
+        currentTypeIndex = Array.IndexOf(typeFullNameArray, typeFullName);
+    }
+
+    void GetAllInheritedTypes(Type baseType, bool includeMono)
+    {
+        Type monoType = typeof(MonoBehaviour);
+        inheritedTypes = AppDomain.CurrentDomain.GetAssemblies()
+            .SelectMany(s => s.GetTypes())
+            .Where(p => baseType.IsAssignableFrom(p) && p.IsClass && !p.IsAbstract && (!monoType.IsAssignableFrom(p) || includeMono))
+            .Prepend(null)
+            .ToArray();
+    }
+
+    private void GetInheritedTypeNameArrays()
+    {
+        typePopupNameArray = inheritedTypes.Select(type => type == null ? "<null>" : type.ToString()).ToArray();
+        typeFullNameArray = inheritedTypes.Select(type => type == null ? "" : string.Format("{0} {1}", type.Assembly.ToString().Split(',')[0], type.FullName)).ToArray();
+    }
+
+    public void UpdatePropertyToSelectedTypeIndex(SerializedProperty property, int selectedTypeIndex)
+    {
+        if (currentTypeIndex == selectedTypeIndex) return;
+        currentTypeIndex = selectedTypeIndex;
+        Type selectedType = inheritedTypes[selectedTypeIndex];
+        property.managedReferenceValue =
+            selectedType == null ? null : Activator.CreateInstance(selectedType);
+    }
+
+    Rect GetPopupPosition(Rect currentPosition)
+    {
+        Rect popupPosition = new Rect(currentPosition);
+        popupPosition.width -= EditorGUIUtility.labelWidth;
+        popupPosition.x += EditorGUIUtility.labelWidth;
+        popupPosition.height = EditorGUIUtility.singleLineHeight;
+        return popupPosition;
+    }
+
+    // ネストされたプロパティパスを完全に走査して型を解決する
+    // Fully traverse nested property paths to resolve the field type
+    public static Type GetType(SerializedProperty property)
+    {
+        const BindingFlags bindingAttr =
+            BindingFlags.NonPublic |
+            BindingFlags.Public |
+            BindingFlags.FlattenHierarchy |
+            BindingFlags.Instance;
+
+        var propertyPaths = property.propertyPath.Split('.');
+        var currentType = property.serializedObject.targetObject.GetType();
+
+        for (int i = 0; i < propertyPaths.Length; i++)
+        {
+            // 配列セグメントの場合、要素型を取得してdata[N]をスキップ
+            // For array segments, get element type and skip data[N]
+            if (propertyPaths[i] == "Array")
+            {
+                if (currentType.IsArray)
+                {
+                    currentType = currentType.GetElementType();
+                }
+                else
+                {
+                    currentType = currentType.GetGenericArguments()[0];
+                }
+                i++;
+                continue;
+            }
+
+            var fieldInfo = currentType.GetField(propertyPaths[i], bindingAttr);
+            if (fieldInfo == null) return currentType;
+            currentType = fieldInfo.FieldType;
+        }
+
+        return currentType;
+    }
+}
+#endif

--- a/moorestech_client/Assets/Scripts/Editor/SubclassSelectorDrawer.cs.meta
+++ b/moorestech_client/Assets/Scripts/Editor/SubclassSelectorDrawer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 557af30c26ddb4024b3af3a75836ef66


### PR DESCRIPTION
## Summary
- `GearStateChangeProcessor` の `RotationInfo` を抽象基底クラス化し、`TransformRotationInfo` / `AnimatorRotationInfo` の派生に分離してInspectorでのサブクラス切り替えに対応
- `SubclassSelectorAttribute` / `SubclassSelectorDrawer` を追加し、`[SubclassSelectorName("...")]` 属性による表示名上書きに対応
- 既存ブロック系プレハブ37件の `rotationInfos` データを新しい SerializeReference 形式へ移行、`MainGame` / `BlockSetup` シーンと URP UltraLowQuality 設定を更新

## Test plan
- [ ] Unity Editor で各ブロックプレハブの `RotationInfo` インスペクタ表示が "Transform Rotate" / "Animator" で切り替えられること
- [ ] MainGame シーンでブロック稼働時の回転挙動が従来どおり動作すること
- [ ] BlockSetup シーンでブロック設定が正しく反映されていること
- [ ] クライアントのコンパイルが通ること (`uloop compile --project-path ./moorestech_client`)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced gear rotation system with flexible configuration options. Gears now support multiple rotation approaches including both direct transform manipulation and animator-based speed control for greater customization possibilities.

* **Refactor**
  * Improved internal architecture of gear rotation handling for enhanced maintainability, extensibility, and editor usability when configuring complex gear behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->