### PR TITLE
WebUiHost で Kestrel HTTP サーバーを起動する仮コードを追加

### DIFF
--- a/moorestech_client/Assets/Scripts/Client.WebUiHost.meta
+++ b/moorestech_client/Assets/Scripts/Client.WebUiHost.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: df837d520fd8846d19168c511592c87c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/moorestech_client/Assets/Scripts/Client.WebUiHost/Client.WebUiHost.asmdef
+++ b/moorestech_client/Assets/Scripts/Client.WebUiHost/Client.WebUiHost.asmdef
@@ -1,0 +1,14 @@
+{
+    "name": "Client.WebUiHost",
+    "rootNamespace": "Client.WebUiHost",
+    "references": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/moorestech_client/Assets/Scripts/Client.WebUiHost/Client.WebUiHost.asmdef.meta
+++ b/moorestech_client/Assets/Scripts/Client.WebUiHost/Client.WebUiHost.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ae644dcb0670d4d1793e8c97c16dcc7c
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/moorestech_client/Assets/Scripts/Client.WebUiHost/WebUiHostBehaviour.cs
+++ b/moorestech_client/Assets/Scripts/Client.WebUiHost/WebUiHostBehaviour.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Threading;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using UnityEngine;
+
+namespace Client.WebUiHost
+{
+    // CEF Web UI 用のローカル HTTP サーバー起動テスト
+    // Local HTTP server boot test for the CEF Web UI
+    public class WebUiHostBehaviour : MonoBehaviour
+    {
+        [SerializeField] private int port = 5050;
+
+        private IWebHost _webHost;
+
+        private void Start()
+        {
+            StartWebHost();
+        }
+
+        private void OnDestroy()
+        {
+            StopWebHost();
+        }
+
+        #region Internal
+
+        private void StartWebHost()
+        {
+            // Kestrel を指定ポートで起動し、ルートだけ返す最小構成
+            // Minimal Kestrel host bound to the configured port, serving the root route only
+            var url = $"http://127.0.0.1:{port}";
+
+            _webHost = new WebHostBuilder()
+                .UseKestrel()
+                .UseUrls(url)
+                .ConfigureServices(services => services.AddRouting())
+                .Configure(Configure)
+                .Build();
+
+            _webHost.Start();
+            Debug.Log($"[WebUiHost] started at {url}");
+        }
+
+        private void Configure(IApplicationBuilder app)
+        {
+            // とりあえずのレスポンス。アイコン配信等は後段で差し替える
+            // Placeholder response; asset routes (icons, etc.) will be wired later
+            app.Run(async context =>
+            {
+                context.Response.ContentType = "text/plain; charset=utf-8";
+                await context.Response.WriteAsync("moorestech WebUiHost OK", CancellationToken.None);
+            });
+        }
+
+        private void StopWebHost()
+        {
+            if (_webHost == null) return;
+
+            // シャットダウン完了まで最大 2 秒待機
+            // Wait up to 2 seconds for graceful shutdown
+            try
+            {
+                _webHost.StopAsync(TimeSpan.FromSeconds(2)).GetAwaiter().GetResult();
+            }
+            finally
+            {
+                _webHost.Dispose();
+                _webHost = null;
+            }
+
+            Debug.Log("[WebUiHost] stopped");
+        }
+
+        #endregion
+    }
+}

--- a/moorestech_client/Assets/Scripts/Client.WebUiHost/WebUiHostBehaviour.cs.meta
+++ b/moorestech_client/Assets/Scripts/Client.WebUiHost/WebUiHostBehaviour.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 275d90d42b6f94a91bbb85ed0be9c0d9


### PR DESCRIPTION
## Summary
- `Client.WebUiHost` アセンブリを新設し、`WebUiHostBehaviour`（MonoBehaviour）を 1 本追加
- `Start()` で `127.0.0.1:5050` に Kestrel を bind、ルートで `moorestech WebUiHost OK` を返すプレースホルダ実装
- `OnDestroy()` で最大 2 秒の graceful shutdown

## 依存
- Base ブランチは #862（ASP.NET Core パッケージ追加）。#862 マージ後に master 向けへ付け替え予定

## 動作確認
- Unity PlayMode 中に `WebUiHostBehaviour` をアタッチした GameObject を生成 → 起動ログ確認
- `curl http://127.0.0.1:5050/` で `200 OK` / body = `moorestech WebUiHost OK` を確認済み

## Test plan
- [ ] `uloop compile --project-path ./moorestech_client` が ErrorCount=0 で通る
- [ ] PlayMode で `WebUiHostBehaviour` を有効化するとローカルで HTTP 疎通できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)