### PR TITLE
ブロック隣接設置の座標計算修正とWeb UI基盤プラン整備

### DIFF
--- a/docs/superpowers/plans/2026-04-22-web-ui-foundation.md
+++ b/docs/superpowers/plans/2026-04-22-web-ui-foundation.md
@@ -1,0 +1,2092 @@
+# Web UI Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Unity クライアントを起動すると内部で Kestrel と Vite dev server が自動起動し、ブラウザで `http://localhost:5173/` を開くと React 製画面にローカルプレイヤーのインベントリがリアルタイム表示される基盤を構築する。
+
+**Architecture:** Unity プロセス内で ASP.NET Core 2.3 の Kestrel（`127.0.0.1:5050`）を立て、同じプロセスから Node を spawn して Vite dev server（`127.0.0.1:5173`）を起動する。Vite の `server.proxy` で `/ws` と `/api/*` を Kestrel に転送。WebSocket 上の購読ベースプロトコルで Unity→Web のデータ push を実装。ライフサイクルは pure C# かつ既存の `InitializeScenePipeline` と `GameShutdownEvent`（新規）に同期させる。
+
+**Tech Stack:**
+- サーバー: ASP.NET Core 2.3 (netstandard2.0 LTS) / Kestrel (既存 NuGet パッケージ再利用)
+- クライアント: React 18 + TypeScript 5 + Vite 5 + Tailwind CSS
+- JS ランタイム: Node.js LTS standalone binary
+- パッケージマネージャ: pnpm (`node-linker=hoisted`, `@pnpm/exe` standalone)
+- 非同期: UniTask (`UniTask.SwitchToMainThread()` でメインスレッド marshalling)
+
+**Spec:** `docs/superpowers/specs/2026-04-22-web-ui-foundation-design.md`
+
+---
+
+## File Structure
+
+### 新規作成（C#）
+
+| ファイル | 責務 |
+|---|---|
+| `moorestech_client/Assets/Scripts/Client.Game/Common/GameShutdownEvent.cs` | `GameInitializedEvent` と対称のシャットダウンイベント。`BackToMainMenu.Disconnect()` から fire、WebUiHost が購読 |
+| `moorestech_client/Assets/Scripts/Client.WebUiHost/Client.WebUiHost.asmdef` | 新規 asmdef。Client.Game と UniRx/UniTask/Microsoft.AspNetCore.* を参照 |
+| `moorestech_client/Assets/Scripts/Client.WebUiHost/Boot/WebUiPaths.cs` | `moorestech_web/` への絶対パス解決 |
+| `moorestech_client/Assets/Scripts/Client.WebUiHost/Boot/WebSocketHub.cs` | WS 接続ごとの購読 topic set 管理、トピックハンドラ登録 |
+| `moorestech_client/Assets/Scripts/Client.WebUiHost/Boot/WebUiEndpoints.cs` | `/ws` と `/api` のルーティング |
+| `moorestech_client/Assets/Scripts/Client.WebUiHost/Boot/KestrelServer.cs` | Kestrel `IWebHost` の起動/停止ラッパ |
+| `moorestech_client/Assets/Scripts/Client.WebUiHost/Boot/ViteProcess.cs` | Node spawn、stdout ready 監視、kill |
+| `moorestech_client/Assets/Scripts/Client.WebUiHost/Boot/WebUiHost.cs` | static facade。StartAsync / Stop / Hub |
+| `moorestech_client/Assets/Scripts/Client.WebUiHost/Game/WebUiGameBinder.cs` | static facade。BindTopics() |
+| `moorestech_client/Assets/Scripts/Client.WebUiHost/Game/Topics/InventoryTopic.cs` | `LocalPlayerInventory.OnItemChange` を購読し `local_player.inventory` トピックに push |
+
+### 新規作成（リポジトリルート）
+
+| パス | 責務 |
+|---|---|
+| `moorestech_web/.gitignore` | node_modules / node binaries を除外 |
+| `moorestech_web/setup.sh` | 開発環境用 Node + pnpm ダウンロードスクリプト（macOS/Linux） |
+| `moorestech_web/setup.ps1` | 開発環境用 Node + pnpm ダウンロードスクリプト（Windows） |
+| `moorestech_web/webui/package.json` | React/Vite 依存定義 |
+| `moorestech_web/webui/.npmrc` | `node-linker=hoisted` |
+| `moorestech_web/webui/tsconfig.json` | TS 設定 |
+| `moorestech_web/webui/vite.config.ts` | Vite 設定、`server.proxy` で /ws と /api を :5050 に転送 |
+| `moorestech_web/webui/tailwind.config.ts` | Tailwind 設定 |
+| `moorestech_web/webui/postcss.config.js` | PostCSS (Tailwind) |
+| `moorestech_web/webui/index.html` | Vite エントリ |
+| `moorestech_web/webui/src/main.tsx` | React root マウント |
+| `moorestech_web/webui/src/App.tsx` | ルートコンポーネント |
+| `moorestech_web/webui/src/index.css` | Tailwind directives |
+| `moorestech_web/webui/src/bridge/webSocketClient.ts` | WS 接続・再接続・envelope 送受信 |
+| `moorestech_web/webui/src/bridge/useTopic.ts` | `useTopic<T>(topicName)` React フック |
+| `moorestech_web/webui/src/components/InventoryView.tsx` | インベントリ表示コンポーネント |
+
+### 変更
+
+| ファイル | 変更内容 |
+|---|---|
+| `moorestech_client/Assets/Scripts/Client.Starter/InitializeScenePipeline.cs` | `Initialize()` 冒頭に `WebUiHost.StartAsync()` と `GameShutdownEvent` 購読を追加。`new ClientContext(...)` 直後に `WebUiGameBinder.BindTopics()` を追加 |
+| `moorestech_client/Assets/Scripts/Client.Game/InGame/Presenter/PauseMenu/BackToMainMenu.cs` | `Disconnect()` 末尾に `GameShutdownEvent.FireGameShutdown()` を追加 |
+
+---
+
+## Conventions
+
+- **コメント:** 日本語・英語 2 行セット（`// 日本語 → // English`）を 3〜10 行ごと
+- **try-catch 禁止:** nullチェック/条件分岐で対応
+- **デフォルト引数禁止**
+- **`#region Internal` はメソッド内のローカル関数用途のみ**
+- **UniRx** を使用（C# 標準 Action/event は使わない）
+- **コード変更後は必ずコンパイル:** `uloop compile --project-path ./moorestech_client`
+- **各タスク末で commit**（AGENTS.md の「タスク終了前に必ず全作業をコミット」に従う）
+
+---
+
+## Task 1: moorestech_web ディレクトリ骨格と setup スクリプト作成
+
+**Files:**
+- Create: `moorestech_web/.gitignore`
+- Create: `moorestech_web/setup.sh`
+- Create: `moorestech_web/setup.ps1`
+- Create: `moorestech_web/README.md`
+
+- [ ] **Step 1: `moorestech_web/.gitignore` を作成**
+
+```gitignore
+# Node.js / pnpm standalone binaries (download via setup.sh / setup.ps1)
+node/
+
+# Dependencies
+webui/node_modules/
+
+# Vite output
+webui/dist/
+webui/.vite/
+```
+
+- [ ] **Step 2: `moorestech_web/setup.sh` を作成（macOS/Linux 用）**
+
+```bash
+#!/usr/bin/env bash
+# moorestech_web セットアップ: Node.js LTS と pnpm スタンドアロンバイナリを
+# moorestech_web/node/<platform>/ にダウンロードする。
+# Setup for moorestech_web: downloads Node.js LTS and pnpm standalone
+# binaries into moorestech_web/node/<platform>/.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NODE_VERSION="20.18.1"
+PNPM_VERSION="9.15.0"
+
+uname_os="$(uname -s)"
+uname_arch="$(uname -m)"
+
+case "$uname_os-$uname_arch" in
+  Darwin-arm64) PLATFORM="mac-arm64"; NODE_PLATFORM="darwin-arm64"; PNPM_SUFFIX="macos-arm64"; NODE_EXT="tar.gz";;
+  Darwin-x86_64) PLATFORM="mac-x64"; NODE_PLATFORM="darwin-x64"; PNPM_SUFFIX="macos-x64"; NODE_EXT="tar.gz";;
+  Linux-x86_64) PLATFORM="linux-x64"; NODE_PLATFORM="linux-x64"; PNPM_SUFFIX="linux-x64"; NODE_EXT="tar.xz";;
+  *) echo "Unsupported platform: $uname_os-$uname_arch"; exit 1;;
+esac
+
+TARGET_DIR="$SCRIPT_DIR/node/$PLATFORM"
+mkdir -p "$TARGET_DIR"
+
+NODE_URL="https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-${NODE_PLATFORM}.${NODE_EXT}"
+PNPM_URL="https://github.com/pnpm/pnpm/releases/download/v${PNPM_VERSION}/pnpm-${PNPM_SUFFIX}"
+
+echo "[setup] downloading node from $NODE_URL"
+curl -fL "$NODE_URL" -o "/tmp/node.$NODE_EXT"
+if [ "$NODE_EXT" = "tar.xz" ]; then
+  tar -xJf "/tmp/node.$NODE_EXT" -C "$TARGET_DIR" --strip-components=1
+else
+  tar -xzf "/tmp/node.$NODE_EXT" -C "$TARGET_DIR" --strip-components=1
+fi
+rm "/tmp/node.$NODE_EXT"
+
+echo "[setup] downloading pnpm from $PNPM_URL"
+curl -fL "$PNPM_URL" -o "$TARGET_DIR/pnpm"
+chmod +x "$TARGET_DIR/pnpm"
+
+echo "[setup] done. node: $TARGET_DIR/bin/node, pnpm: $TARGET_DIR/pnpm"
+```
+
+- [ ] **Step 3: `moorestech_web/setup.ps1` を作成（Windows 用）**
+
+```powershell
+# moorestech_web セットアップ: Node.js LTS と pnpm スタンドアロンバイナリを
+# moorestech_web/node/win-x64/ にダウンロードする。
+# Setup for moorestech_web: downloads Node.js LTS and pnpm standalone
+# binaries into moorestech_web/node/win-x64/.
+$ErrorActionPreference = "Stop"
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$NodeVersion = "20.18.1"
+$PnpmVersion = "9.15.0"
+$Platform = "win-x64"
+$TargetDir = Join-Path $ScriptDir "node\$Platform"
+New-Item -ItemType Directory -Force -Path $TargetDir | Out-Null
+
+$NodeUrl = "https://nodejs.org/dist/v$NodeVersion/node-v$NodeVersion-win-x64.zip"
+$PnpmUrl = "https://github.com/pnpm/pnpm/releases/download/v$PnpmVersion/pnpm-win-x64.exe"
+
+Write-Host "[setup] downloading node from $NodeUrl"
+$NodeZip = Join-Path $env:TEMP "node.zip"
+Invoke-WebRequest -Uri $NodeUrl -OutFile $NodeZip
+Expand-Archive -Path $NodeZip -DestinationPath $TargetDir -Force
+# zip 内は node-v20.18.1-win-x64/ 配下なので 1階層下げる
+# The zip contains a top-level node-v20.18.1-win-x64/ dir, flatten it
+$Inner = Get-ChildItem -Path $TargetDir -Directory | Select-Object -First 1
+Move-Item -Path (Join-Path $Inner.FullName "*") -Destination $TargetDir
+Remove-Item -Path $Inner.FullName -Recurse -Force
+Remove-Item $NodeZip
+
+Write-Host "[setup] downloading pnpm from $PnpmUrl"
+Invoke-WebRequest -Uri $PnpmUrl -OutFile (Join-Path $TargetDir "pnpm.exe")
+
+Write-Host "[setup] done. node: $TargetDir\node.exe, pnpm: $TargetDir\pnpm.exe"
+```
+
+- [ ] **Step 4: `moorestech_web/README.md` を作成**
+
+```markdown
+# moorestech_web
+
+Web UI のフロントエンドプロジェクトと、Unity から spawn する Node.js / pnpm のバイナリを格納する。
+
+## セットアップ
+
+初回のみ、対応プラットフォームのセットアップスクリプトを実行する:
+
+- macOS / Linux: `bash setup.sh`
+- Windows (PowerShell): `.\setup.ps1`
+
+これで `moorestech_web/node/<platform>/` に Node.js と pnpm のスタンドアロンバイナリが展開される。バイナリは `.gitignore` されているので commit されない。
+
+## レイアウト
+
+- `webui/` TypeScript + React + Vite プロジェクト
+- `node/<platform>/` Node.js と pnpm のスタンドアロンバイナリ（setup スクリプトで配置）
+
+## 開発中の実行
+
+Unity クライアントを起動すると、内部から `node/<platform>/node` が自動 spawn されて Vite dev server が立ち上がる。手動で `pnpm dev` を回す必要はない。開発中に Vite を手動で再起動したい場合は Unity を再起動する。
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add moorestech_web/.gitignore moorestech_web/setup.sh moorestech_web/setup.ps1 moorestech_web/README.md
+chmod +x moorestech_web/setup.sh
+git commit -m "moorestech_web ディレクトリ骨格と Node/pnpm setup スクリプト追加"
+```
+
+---
+
+## Task 2: TS/React/Vite プロジェクト scaffold
+
+**Files:**
+- Create: `moorestech_web/webui/package.json`
+- Create: `moorestech_web/webui/.npmrc`
+- Create: `moorestech_web/webui/tsconfig.json`
+- Create: `moorestech_web/webui/tsconfig.node.json`
+- Create: `moorestech_web/webui/vite.config.ts`
+- Create: `moorestech_web/webui/tailwind.config.ts`
+- Create: `moorestech_web/webui/postcss.config.js`
+- Create: `moorestech_web/webui/index.html`
+- Create: `moorestech_web/webui/src/main.tsx`
+- Create: `moorestech_web/webui/src/App.tsx`
+- Create: `moorestech_web/webui/src/index.css`
+
+- [ ] **Step 1: `moorestech_web/webui/.npmrc` を作成**
+
+```
+node-linker=hoisted
+strict-peer-dependencies=false
+```
+
+- [ ] **Step 2: `moorestech_web/webui/package.json` を作成**
+
+```json
+{
+  "name": "moorestech-webui",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.4",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.49",
+    "tailwindcss": "^3.4.16",
+    "typescript": "^5.7.2",
+    "vite": "^5.4.11"
+  }
+}
+```
+
+- [ ] **Step 3: `moorestech_web/webui/tsconfig.json` を作成**
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}
+```
+
+- [ ] **Step 4: `moorestech_web/webui/tsconfig.node.json` を作成**
+
+```json
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowSyntheticDefaultImports": true,
+    "strict": true
+  },
+  "include": ["vite.config.ts", "tailwind.config.ts"]
+}
+```
+
+- [ ] **Step 5: `moorestech_web/webui/vite.config.ts` を作成**
+
+```ts
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+// Vite dev server の設定
+// Vite dev server configuration
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: "127.0.0.1",
+    port: 5173,
+    strictPort: true,
+    fs: {
+      // リポジトリ外や node_modules 階層への /@fs/ アクセスを封じる
+      // Prevent /@fs/ access to outside-repo / node_modules paths
+      allow: ["./src", "./public", "./index.html"],
+      strict: true,
+    },
+    proxy: {
+      // Kestrel への HTTP + WebSocket プロキシ
+      // Proxy HTTP and WebSocket to Kestrel
+      "/api": {
+        target: "http://127.0.0.1:5050",
+        changeOrigin: false,
+      },
+      "/ws": {
+        target: "ws://127.0.0.1:5050",
+        ws: true,
+        changeOrigin: false,
+      },
+    },
+  },
+});
+```
+
+- [ ] **Step 6: `moorestech_web/webui/tailwind.config.ts` を作成**
+
+```ts
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: ["./index.html", "./src/**/*.{ts,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+
+export default config;
+```
+
+- [ ] **Step 7: `moorestech_web/webui/postcss.config.js` を作成**
+
+```js
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};
+```
+
+- [ ] **Step 8: `moorestech_web/webui/index.html` を作成**
+
+```html
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>moorestech Web UI</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>
+```
+
+- [ ] **Step 9: `moorestech_web/webui/src/index.css` を作成**
+
+```css
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  background-color: #111;
+  color: #eee;
+}
+```
+
+- [ ] **Step 10: `moorestech_web/webui/src/main.tsx` を作成**
+
+```tsx
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
+import "./index.css";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);
+```
+
+- [ ] **Step 11: `moorestech_web/webui/src/App.tsx` を作成（仮実装）**
+
+```tsx
+export default function App() {
+  // インベントリ表示は Task 9 で差し替え
+  // Inventory rendering will be wired in Task 9
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold">moorestech Web UI</h1>
+      <p className="text-sm text-gray-400 mt-2">bootstrapping...</p>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 12: setup スクリプトを実行してバイナリ配置**
+
+```bash
+bash moorestech_web/setup.sh
+```
+
+Expected: `moorestech_web/node/mac-arm64/bin/node` (macOS ARM) と `moorestech_web/node/mac-arm64/pnpm` が配置される。
+
+- [ ] **Step 13: pnpm install でローカル動作確認**
+
+```bash
+cd moorestech_web/webui
+../node/mac-arm64/pnpm install
+```
+
+Expected: `node_modules/` がフラット配置（symlink なし）で生成される。
+
+- [ ] **Step 14: Vite dev server を手動起動して動作確認**
+
+```bash
+cd moorestech_web/webui
+../node/mac-arm64/pnpm dev
+```
+
+Expected: `Local: http://127.0.0.1:5173/` が表示され、ブラウザで開くと "moorestech Web UI / bootstrapping..." が表示される。Ctrl+C で停止。
+
+- [ ] **Step 15: Commit**
+
+```bash
+git add moorestech_web/webui/
+git commit -m "webui プロジェクト scaffold: React + Vite + Tailwind + TypeScript"
+```
+
+---
+
+## Task 3: GameShutdownEvent 新規作成と BackToMainMenu から fire
+
+**Files:**
+- Create: `moorestech_client/Assets/Scripts/Client.Game/Common/GameShutdownEvent.cs`
+- Modify: `moorestech_client/Assets/Scripts/Client.Game/InGame/Presenter/PauseMenu/BackToMainMenu.cs`
+
+- [ ] **Step 1: `GameShutdownEvent.cs` を作成（`GameInitializedEvent.cs` と対称）**
+
+```csharp
+using System;
+using UniRx;
+
+namespace Client.Game.Common
+{
+    /// <summary>
+    /// ゲームの終了パイプラインイベント
+    /// Game shutdown pipeline event
+    /// </summary>
+    public static class GameShutdownEvent
+    {
+        private static readonly Subject<Unit> _onGameShutdown = new();
+
+        // ゲーム終了時に発火するイベント
+        // Event fired when game shutdown begins
+        public static IObservable<Unit> OnGameShutdown => _onGameShutdown;
+
+        public static void FireGameShutdown()
+        {
+            _onGameShutdown.OnNext(Unit.Default);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: `BackToMainMenu.Disconnect()` 末尾に fire を追加**
+
+```csharp
+using System.Threading;
+using Client.Common;
+using Client.Game.Common;          // ← 追加
+using Client.Game.InGame.Context;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.UI;
+
+namespace Client.Game.InGame.Presenter.PauseMenu
+{
+    //ゲームが終了したときかメインメニューに戻るときはサーバーを終了させます
+    public class BackToMainMenu : MonoBehaviour
+    {
+        [SerializeField] private Button backToMainMenuButton;
+        
+        private void Start()
+        {
+            backToMainMenuButton.onClick.AddListener(Back);
+        }
+        
+        private void OnDestroy()
+        {
+            Disconnect();
+        }
+        
+        private void OnApplicationQuit()
+        {
+            Disconnect();
+        }
+        
+        private void Back()
+        {
+            Disconnect();
+            SceneManager.LoadScene(SceneConstant.MainMenuSceneName);
+        }
+        
+        private void Disconnect()
+        {
+            ClientContext.VanillaApi.SendOnly.Save();
+            Thread.Sleep(50);
+            ClientContext.VanillaApi.Disconnect();
+            // Web UI 等、ゲーム終了に同期したい購読者へ通知
+            // Notify subscribers tied to game shutdown (e.g. Web UI)
+            GameShutdownEvent.FireGameShutdown();
+        }
+    }
+}
+```
+
+- [ ] **Step 3: コンパイル**
+
+```bash
+uloop compile --project-path ./moorestech_client
+```
+
+Expected: エラーなし。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add moorestech_client/Assets/Scripts/Client.Game/Common/GameShutdownEvent.cs moorestech_client/Assets/Scripts/Client.Game/InGame/Presenter/PauseMenu/BackToMainMenu.cs
+git commit -m "GameShutdownEvent を追加し BackToMainMenu から fire"
+```
+
+注: `.meta` ファイルは Unity が起動時に自動生成するので手動作成しない。Unity 起動後にまとめて追加 commit する。
+
+---
+
+## Task 4: Client.WebUiHost asmdef 作成
+
+**Files:**
+- Create: `moorestech_client/Assets/Scripts/Client.WebUiHost/Client.WebUiHost.asmdef`
+
+- [ ] **Step 1: `Client.WebUiHost.asmdef` を作成**
+
+既存の `Client.Game.asmdef` をリファレンスとして参考にしつつ、以下の内容で作成。
+
+```json
+{
+    "name": "Client.WebUiHost",
+    "rootNamespace": "Client.WebUiHost",
+    "references": [
+        "GUID:0e2b9c8b00d0446c8b0e87d96a3e5d7c",
+        "Client.Common",
+        "Client.Game",
+        "Client.Network",
+        "Core.Item.Interface",
+        "Core.Master",
+        "Game.Context",
+        "Game.PlayerInventory.Interface",
+        "UniRx",
+        "UniTask"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}
+```
+
+注: Microsoft.AspNetCore.* DLL は既に `Assets/Packages/` 配下にあり NuGetForUnity 経由でグローバルに参照可能。`overrideReferences: false` と `autoReferenced: true` で取り込まれる。
+
+- [ ] **Step 2: `Client.Game.asmdef` の `name` と実 `GUID` を確認して `references` を必要に応じて修正**
+
+```bash
+cat moorestech_client/Assets/Scripts/Client.Game/Client.Game.asmdef | head -20
+```
+
+上記で `name` が `Client.Game` であれば references には "Client.Game" をそのまま記載すれば OK。GUID 参照が必要な場合は `.asmdef` 隣接の `.meta` 内 `guid` を使うが、可読性のため name 参照を優先。
+
+- [ ] **Step 3: ディレクトリだけ先に作る（空ファイルを 1 つ置く必要はない）**
+
+```bash
+mkdir -p moorestech_client/Assets/Scripts/Client.WebUiHost/Boot
+mkdir -p moorestech_client/Assets/Scripts/Client.WebUiHost/Game/Topics
+```
+
+- [ ] **Step 4: コンパイル**
+
+```bash
+uloop compile --project-path ./moorestech_client
+```
+
+Expected: エラーなし（中身のない asmdef だが問題なし）。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add moorestech_client/Assets/Scripts/Client.WebUiHost/
+git commit -m "Client.WebUiHost asmdef と Boot/Game ディレクトリ追加"
+```
+
+---
+
+## Task 5: WebUiPaths（絶対パス解決）
+
+**Files:**
+- Create: `moorestech_client/Assets/Scripts/Client.WebUiHost/Boot/WebUiPaths.cs`
+
+- [ ] **Step 1: `WebUiPaths.cs` を作成**
+
+```csharp
+using System.IO;
+using System.Runtime.InteropServices;
+using UnityEngine;
+
+namespace Client.WebUiHost.Boot
+{
+    /// <summary>
+    /// moorestech_web/ 配下の絶対パスを解決するユーティリティ
+    /// Resolves absolute paths under moorestech_web/
+    /// </summary>
+    public static class WebUiPaths
+    {
+        // エディタ実行時: moorestech_client/Assets の2階層上 = リポジトリルート
+        // At editor time: two levels up from moorestech_client/Assets == repo root
+        // Application.dataPath は moorestech_client/Assets を指すので、
+        // その親（moorestech_client）の親がリポジトリルート。
+        // Application.dataPath points at moorestech_client/Assets,
+        // so its parent's parent is the repo root.
+        public static string RepoRoot =>
+            Path.GetFullPath(Path.Combine(Application.dataPath, "..", ".."));
+
+        public static string WebRoot =>
+            Path.Combine(RepoRoot, "moorestech_web");
+
+        public static string WebuiRoot =>
+            Path.Combine(WebRoot, "webui");
+
+        public static string NodeBinary
+        {
+            get
+            {
+                var platform = GetPlatformDir();
+                // Windows は node.exe、それ以外は bin/node
+                // Windows: node.exe, others: bin/node
+                var rel = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                    ? "node.exe"
+                    : Path.Combine("bin", "node");
+                return Path.Combine(WebRoot, "node", platform, rel);
+            }
+        }
+
+        public static string PnpmBinary
+        {
+            get
+            {
+                var platform = GetPlatformDir();
+                var file = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "pnpm.exe" : "pnpm";
+                return Path.Combine(WebRoot, "node", platform, file);
+            }
+        }
+
+        // プラットフォーム別ディレクトリ名（setup.sh / setup.ps1 と一致）
+        // Per-platform directory name (matches setup.sh / setup.ps1)
+        public static string GetPlatformDir()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return RuntimeInformation.OSArchitecture == Architecture.Arm64 ? "mac-arm64" : "mac-x64";
+            }
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return "win-x64";
+            }
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return "linux-x64";
+            }
+            return "unknown";
+        }
+    }
+}
+```
+
+- [ ] **Step 2: コンパイル**
+
+```bash
+uloop compile --project-path ./moorestech_client
+```
+
+Expected: エラーなし。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add moorestech_client/Assets/Scripts/Client.WebUiHost/Boot/WebUiPaths.cs
+git commit -m "WebUiPaths: moorestech_web/ 配下の絶対パス解決ユーティリティ"
+```
+
+---
+
+## Task 6: WebSocketHub（接続・購読管理）
+
+**Files:**
+- Create: `moorestech_client/Assets/Scripts/Client.WebUiHost/Boot/WebSocketHub.cs`
+
+`WebSocketHub` は WS 接続ごとの購読 topic set を保持し、トピックハンドラを名前で登録する。ハンドラは `ITopicHandler` インターフェースに準拠。
+
+- [ ] **Step 1: `WebSocketHub.cs` を作成**
+
+```csharp
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Net.WebSockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Cysharp.Threading.Tasks;
+using UnityEngine;
+
+namespace Client.WebUiHost.Boot
+{
+    /// <summary>
+    /// トピックハンドラのインターフェース
+    /// Interface for topic handlers
+    /// </summary>
+    public interface ITopicHandler
+    {
+        // 新規購読者に現在値を snapshot として返す
+        // Return current value as snapshot for a new subscriber
+        UniTask<string> GetSnapshotJsonAsync();
+    }
+
+    /// <summary>
+    /// WS 接続の集約・購読管理・トピック配信
+    /// Aggregates WS connections, manages subscriptions, dispatches topic events
+    /// </summary>
+    public class WebSocketHub
+    {
+        private readonly ConcurrentDictionary<Guid, Connection> _connections = new();
+        private readonly ConcurrentDictionary<string, ITopicHandler> _handlers = new();
+
+        // トピックハンドラ登録（InventoryTopic などが呼ぶ）
+        // Register a topic handler (called by InventoryTopic etc.)
+        public void RegisterTopic(string topic, ITopicHandler handler)
+        {
+            _handlers[topic] = handler;
+        }
+
+        // 全接続のうち指定トピックを購読している接続に event を配信
+        // Broadcast an event payload to all connections subscribed to the topic
+        public void Publish(string topic, string dataJson)
+        {
+            var envelope = $"{{\"op\":\"event\",\"topic\":\"{EscapeJsonString(topic)}\",\"data\":{dataJson}}}";
+            foreach (var conn in _connections.Values)
+            {
+                if (conn.Topics.Contains(topic))
+                {
+                    conn.EnqueueSend(envelope);
+                }
+            }
+        }
+
+        // 新規接続を受け入れ、メッセージループを開始
+        // Accept a new connection and start its message loop
+        public async Task HandleConnectionAsync(WebSocket webSocket, CancellationToken ct)
+        {
+            var id = Guid.NewGuid();
+            var conn = new Connection(id, webSocket);
+            _connections[id] = conn;
+            
+            // 送信ループと受信ループを同時実行
+            // Run send loop and receive loop concurrently
+            var sendTask = SendLoop(conn, ct);
+            var receiveTask = ReceiveLoop(conn, ct);
+            await Task.WhenAny(sendTask, receiveTask);
+            
+            _connections.TryRemove(id, out _);
+        }
+
+        #region Internal
+
+        private async Task ReceiveLoop(Connection conn, CancellationToken ct)
+        {
+            var buffer = new byte[8192];
+            while (conn.WebSocket.State == WebSocketState.Open && !ct.IsCancellationRequested)
+            {
+                var result = await conn.WebSocket.ReceiveAsync(new ArraySegment<byte>(buffer), ct);
+                if (result.MessageType == WebSocketMessageType.Close)
+                {
+                    await conn.WebSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "bye", CancellationToken.None);
+                    return;
+                }
+                var json = Encoding.UTF8.GetString(buffer, 0, result.Count);
+                await HandleClientMessage(conn, json);
+            }
+        }
+
+        private async Task HandleClientMessage(Connection conn, string json)
+        {
+            // 超軽量 JSON パース: op / topics / topic を小さく取り出すだけ
+            // Minimal JSON parse: extract only op / topics / topic
+            var op = ExtractJsonString(json, "\"op\"");
+            if (op == "subscribe")
+            {
+                var topics = ExtractJsonStringArray(json, "\"topics\"");
+                foreach (var t in topics)
+                {
+                    conn.Topics.Add(t);
+                    if (_handlers.TryGetValue(t, out var handler))
+                    {
+                        var snap = await handler.GetSnapshotJsonAsync();
+                        var env = $"{{\"op\":\"snapshot\",\"topic\":\"{EscapeJsonString(t)}\",\"data\":{snap}}}";
+                        conn.EnqueueSend(env);
+                    }
+                }
+            }
+            else if (op == "unsubscribe")
+            {
+                var topics = ExtractJsonStringArray(json, "\"topics\"");
+                foreach (var t in topics) conn.Topics.Remove(t);
+            }
+            else if (op == "snapshot")
+            {
+                var topic = ExtractJsonString(json, "\"topic\"");
+                if (_handlers.TryGetValue(topic, out var handler))
+                {
+                    var snap = await handler.GetSnapshotJsonAsync();
+                    var env = $"{{\"op\":\"snapshot\",\"topic\":\"{EscapeJsonString(topic)}\",\"data\":{snap}}}";
+                    conn.EnqueueSend(env);
+                }
+            }
+        }
+
+        private async Task SendLoop(Connection conn, CancellationToken ct)
+        {
+            while (conn.WebSocket.State == WebSocketState.Open && !ct.IsCancellationRequested)
+            {
+                var msg = await conn.DequeueSendAsync(ct);
+                if (msg == null) continue;
+                var bytes = Encoding.UTF8.GetBytes(msg);
+                await conn.WebSocket.SendAsync(new ArraySegment<byte>(bytes), WebSocketMessageType.Text, true, ct);
+            }
+        }
+
+        public async Task CloseAllAsync()
+        {
+            foreach (var conn in _connections.Values)
+            {
+                if (conn.WebSocket.State == WebSocketState.Open)
+                {
+                    await conn.WebSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "server stopping", CancellationToken.None);
+                }
+            }
+            _connections.Clear();
+        }
+
+        private static string EscapeJsonString(string s) => s.Replace("\\", "\\\\").Replace("\"", "\\\"");
+
+        // 最小 JSON ヘルパ: "key":"value" パターンから value を返す
+        // Minimal JSON helper: extract string value after a "key": marker
+        private static string ExtractJsonString(string json, string key)
+        {
+            var idx = json.IndexOf(key, StringComparison.Ordinal);
+            if (idx < 0) return "";
+            var colon = json.IndexOf(':', idx);
+            if (colon < 0) return "";
+            var q1 = json.IndexOf('"', colon);
+            if (q1 < 0) return "";
+            var q2 = json.IndexOf('"', q1 + 1);
+            if (q2 < 0) return "";
+            return json.Substring(q1 + 1, q2 - q1 - 1);
+        }
+
+        // 最小 JSON ヘルパ: "key":[ "a", "b" ] から文字列配列を返す
+        // Minimal JSON helper: extract string array after a "key": marker
+        private static List<string> ExtractJsonStringArray(string json, string key)
+        {
+            var result = new List<string>();
+            var idx = json.IndexOf(key, StringComparison.Ordinal);
+            if (idx < 0) return result;
+            var lb = json.IndexOf('[', idx);
+            if (lb < 0) return result;
+            var rb = json.IndexOf(']', lb);
+            if (rb < 0) return result;
+            var inside = json.Substring(lb + 1, rb - lb - 1);
+            var pos = 0;
+            while (pos < inside.Length)
+            {
+                var q1 = inside.IndexOf('"', pos);
+                if (q1 < 0) break;
+                var q2 = inside.IndexOf('"', q1 + 1);
+                if (q2 < 0) break;
+                result.Add(inside.Substring(q1 + 1, q2 - q1 - 1));
+                pos = q2 + 1;
+            }
+            return result;
+        }
+
+        #endregion
+
+        /// <summary>
+        /// 1 本の WS 接続の状態
+        /// State of a single WS connection
+        /// </summary>
+        private sealed class Connection
+        {
+            public Guid Id { get; }
+            public WebSocket WebSocket { get; }
+            public HashSet<string> Topics { get; } = new();
+            private readonly Channel<string> _sendChannel = Channel.CreateUnbounded<string>();
+
+            public Connection(Guid id, WebSocket webSocket)
+            {
+                Id = id;
+                WebSocket = webSocket;
+            }
+
+            public void EnqueueSend(string msg) => _sendChannel.Writer.TryWrite(msg);
+
+            public async Task<string> DequeueSendAsync(CancellationToken ct)
+            {
+                return await _sendChannel.Reader.ReadAsync(ct);
+            }
+        }
+    }
+}
+```
+
+注: `System.Threading.Channels.Channel` は netstandard2.1 で利用可能。Unity 6 は netstandard2.1 対応（`apiCompatibilityLevel: 6` は .NET Standard 2.1）。利用できない場合は `BlockingCollection<string>` に置換する。
+
+- [ ] **Step 2: コンパイル**
+
+```bash
+uloop compile --project-path ./moorestech_client
+```
+
+Expected: エラーなし。`Channel` が解決できない場合は `System.Threading.Channels` NuGet パッケージを追加するか、`BlockingCollection<string>` で書き換える。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add moorestech_client/Assets/Scripts/Client.WebUiHost/Boot/WebSocketHub.cs
+git commit -m "WebSocketHub: 接続管理とトピック購読の中核"
+```
+
+---
+
+## Task 7: WebUiEndpoints（ルーティング）
+
+**Files:**
+- Create: `moorestech_client/Assets/Scripts/Client.WebUiHost/Boot/WebUiEndpoints.cs`
+
+- [ ] **Step 1: `WebUiEndpoints.cs` を作成**
+
+```csharp
+using System;
+using System.Net.WebSockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using UnityEngine;
+
+namespace Client.WebUiHost.Boot
+{
+    /// <summary>
+    /// Kestrel のルーティング設定。/api と /ws を提供
+    /// Kestrel routing: provides /api and /ws
+    /// </summary>
+    public static class WebUiEndpoints
+    {
+        public static void Configure(IApplicationBuilder app, WebSocketHub hub)
+        {
+            // WebSocket を有効化
+            // Enable WebSocket middleware
+            app.UseWebSockets();
+
+            app.Run(async context =>
+            {
+                var path = context.Request.Path.Value ?? "";
+
+                if (path == "/ws")
+                {
+                    // Origin ヘッダを検査
+                    // Validate Origin header
+                    if (!IsAllowedOrigin(context.Request.Headers["Origin"]))
+                    {
+                        context.Response.StatusCode = 403;
+                        await context.Response.WriteAsync("forbidden origin", CancellationToken.None);
+                        return;
+                    }
+                    if (!context.WebSockets.IsWebSocketRequest)
+                    {
+                        context.Response.StatusCode = 400;
+                        return;
+                    }
+                    var ws = await context.WebSockets.AcceptWebSocketAsync();
+                    await hub.HandleConnectionAsync(ws, context.RequestAborted);
+                    return;
+                }
+
+                if (path == "/api/ping")
+                {
+                    // ヘルスチェック兼疎通確認用エンドポイント
+                    // Health / connectivity check
+                    context.Response.ContentType = "application/json; charset=utf-8";
+                    await context.Response.WriteAsync("{\"ok\":true}", CancellationToken.None);
+                    return;
+                }
+
+                context.Response.StatusCode = 404;
+                await context.Response.WriteAsync("not found", CancellationToken.None);
+            });
+        }
+
+        private static bool IsAllowedOrigin(string origin)
+        {
+            if (string.IsNullOrEmpty(origin)) return false;
+            return origin == "http://localhost:5173" || origin == "http://127.0.0.1:5173";
+        }
+    }
+}
+```
+
+- [ ] **Step 2: コンパイル**
+
+```bash
+uloop compile --project-path ./moorestech_client
+```
+
+Expected: エラーなし。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add moorestech_client/Assets/Scripts/Client.WebUiHost/Boot/WebUiEndpoints.cs
+git commit -m "WebUiEndpoints: /api/ping と /ws のルーティング"
+```
+
+---
+
+## Task 8: KestrelServer（起動/停止ラッパ）
+
+**Files:**
+- Create: `moorestech_client/Assets/Scripts/Client.WebUiHost/Boot/KestrelServer.cs`
+
+- [ ] **Step 1: `KestrelServer.cs` を作成**
+
+```csharp
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using UnityEngine;
+
+namespace Client.WebUiHost.Boot
+{
+    /// <summary>
+    /// Kestrel IWebHost の起動/停止を包むラッパ
+    /// Wrapper around Kestrel IWebHost lifecycle
+    /// </summary>
+    public class KestrelServer
+    {
+        private const int Port = 5050;
+        private IWebHost _webHost;
+
+        public async Task StartAsync(WebSocketHub hub)
+        {
+            var url = $"http://127.0.0.1:{Port}";
+
+            _webHost = new WebHostBuilder()
+                .UseKestrel()
+                .UseUrls(url)
+                .ConfigureServices(services => services.AddRouting())
+                .Configure(app => WebUiEndpoints.Configure(app, hub))
+                .Build();
+
+            await _webHost.StartAsync();
+            Debug.Log($"[WebUiHost] Kestrel started at {url}");
+        }
+
+        public async Task StopAsync()
+        {
+            if (_webHost == null) return;
+            // 最大 2 秒で graceful shutdown
+            // Graceful shutdown capped at 2 seconds
+            await _webHost.StopAsync(TimeSpan.FromSeconds(2));
+            _webHost.Dispose();
+            _webHost = null;
+            Debug.Log("[WebUiHost] Kestrel stopped");
+        }
+    }
+}
+```
+
+- [ ] **Step 2: コンパイル**
+
+```bash
+uloop compile --project-path ./moorestech_client
+```
+
+Expected: エラーなし。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add moorestech_client/Assets/Scripts/Client.WebUiHost/Boot/KestrelServer.cs
+git commit -m "KestrelServer: IWebHost 起動/停止ラッパ"
+```
+
+---
+
+## Task 9: ViteProcess（Node spawn / ready 検出 / kill）
+
+**Files:**
+- Create: `moorestech_client/Assets/Scripts/Client.WebUiHost/Boot/ViteProcess.cs`
+
+- [ ] **Step 1: `ViteProcess.cs` を作成**
+
+```csharp
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using UnityEngine;
+using Debug = UnityEngine.Debug;
+
+namespace Client.WebUiHost.Boot
+{
+    /// <summary>
+    /// Node を spawn して Vite dev server を起動し、終了時に kill する
+    /// Spawn Node to run Vite dev server; kill it on shutdown
+    /// </summary>
+    public class ViteProcess
+    {
+        private Process _process;
+
+        public async UniTask StartAsync()
+        {
+            var nodePath = WebUiPaths.NodeBinary;
+            var pnpmPath = WebUiPaths.PnpmBinary;
+            var webuiRoot = WebUiPaths.WebuiRoot;
+
+            // Node / pnpm バイナリ / webui ディレクトリの存在確認
+            // Verify node / pnpm binaries and webui dir are present
+            if (!File.Exists(nodePath))
+            {
+                Debug.LogError($"[WebUiHost] Node binary not found at {nodePath}. Run moorestech_web/setup.sh (or setup.ps1) first.");
+                return;
+            }
+            if (!File.Exists(pnpmPath))
+            {
+                Debug.LogError($"[WebUiHost] pnpm binary not found at {pnpmPath}. Run moorestech_web/setup.sh (or setup.ps1) first.");
+                return;
+            }
+            if (!Directory.Exists(webuiRoot))
+            {
+                Debug.LogError($"[WebUiHost] webui dir not found at {webuiRoot}.");
+                return;
+            }
+
+            // node_modules が無ければ pnpm install を先に走らせる
+            // Run pnpm install first if node_modules is missing
+            if (!Directory.Exists(Path.Combine(webuiRoot, "node_modules")))
+            {
+                await RunPnpmInstallAsync(nodePath, pnpmPath, webuiRoot);
+            }
+
+            // Vite dev server を spawn
+            // Spawn Vite dev server
+            _process = SpawnViteDev(nodePath, pnpmPath, webuiRoot);
+
+            // stdout に "ready in" が出るまで待機（最大 30 秒）
+            // Wait for "ready in" marker in stdout (cap 30 seconds)
+            await WaitForReadyAsync(30);
+        }
+
+        public void Kill()
+        {
+            if (_process == null) return;
+            if (_process.HasExited) { _process = null; return; }
+            _process.Kill();
+            _process.WaitForExit(2000);
+            _process.Dispose();
+            _process = null;
+            Debug.Log("[WebUiHost] Vite process killed");
+        }
+
+        #region Internal
+
+        private readonly ManualResetEventSlim _readySignal = new(false);
+
+        private async UniTask RunPnpmInstallAsync(string nodePath, string pnpmPath, string cwd)
+        {
+            Debug.Log("[WebUiHost] running pnpm install...");
+            var psi = new ProcessStartInfo
+            {
+                FileName = nodePath,
+                Arguments = $"\"{pnpmPath}\" install",
+                WorkingDirectory = cwd,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+            };
+            using var p = Process.Start(psi);
+            if (p == null)
+            {
+                Debug.LogError("[WebUiHost] pnpm install: failed to spawn process");
+                return;
+            }
+            await UniTask.RunOnThreadPool(() => p.WaitForExit());
+            if (p.ExitCode != 0)
+            {
+                Debug.LogError($"[WebUiHost] pnpm install exited with code {p.ExitCode}\n{p.StandardError.ReadToEnd()}");
+            }
+            else
+            {
+                Debug.Log("[WebUiHost] pnpm install complete");
+            }
+        }
+
+        private Process SpawnViteDev(string nodePath, string pnpmPath, string cwd)
+        {
+            // node <pnpm> exec vite --port 5173 --strictPort --host 127.0.0.1
+            // pnpm exec を通すと webui/node_modules 内の vite を使ってくれる
+            // Using pnpm exec routes to the vite installed in webui/node_modules
+            var psi = new ProcessStartInfo
+            {
+                FileName = nodePath,
+                Arguments = $"\"{pnpmPath}\" exec vite --port 5173 --strictPort --host 127.0.0.1",
+                WorkingDirectory = cwd,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+            };
+            var p = new Process { StartInfo = psi, EnableRaisingEvents = true };
+            p.OutputDataReceived += OnViteStdout;
+            p.ErrorDataReceived += (_, e) => { if (!string.IsNullOrEmpty(e.Data)) Debug.LogWarning($"[Vite] {e.Data}"); };
+            p.Exited += (_, _) => Debug.Log("[WebUiHost] Vite process exited");
+            p.Start();
+            p.BeginOutputReadLine();
+            p.BeginErrorReadLine();
+            Debug.Log($"[WebUiHost] spawned Vite (pid={p.Id})");
+            return p;
+        }
+
+        private void OnViteStdout(object sender, DataReceivedEventArgs e)
+        {
+            if (string.IsNullOrEmpty(e.Data)) return;
+            Debug.Log($"[Vite] {e.Data}");
+            if (e.Data.Contains("ready in") || e.Data.Contains("Local:"))
+            {
+                _readySignal.Set();
+            }
+        }
+
+        private async UniTask WaitForReadyAsync(int timeoutSec)
+        {
+            var start = DateTime.UtcNow;
+            while (!_readySignal.IsSet)
+            {
+                if ((DateTime.UtcNow - start).TotalSeconds > timeoutSec)
+                {
+                    Debug.LogError($"[WebUiHost] Vite did not become ready within {timeoutSec}s");
+                    return;
+                }
+                await UniTask.Delay(100);
+            }
+        }
+
+        #endregion
+    }
+}
+```
+
+- [ ] **Step 2: コンパイル**
+
+```bash
+uloop compile --project-path ./moorestech_client
+```
+
+Expected: エラーなし。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add moorestech_client/Assets/Scripts/Client.WebUiHost/Boot/ViteProcess.cs
+git commit -m "ViteProcess: Node spawn と Vite ready 検出"
+```
+
+---
+
+## Task 10: WebUiHost facade（起動/停止の単一入口）
+
+**Files:**
+- Create: `moorestech_client/Assets/Scripts/Client.WebUiHost/Boot/WebUiHost.cs`
+
+- [ ] **Step 1: `WebUiHost.cs` を作成**
+
+```csharp
+using Cysharp.Threading.Tasks;
+using UnityEngine;
+
+namespace Client.WebUiHost.Boot
+{
+    /// <summary>
+    /// Web UI ホストの起動/停止の静的 facade。
+    /// Web UI host static facade for start/stop and Hub access.
+    /// </summary>
+    public static class WebUiHost
+    {
+        private static KestrelServer _kestrel;
+        private static ViteProcess _vite;
+        private static WebSocketHub _hub;
+
+        public static WebSocketHub Hub => _hub;
+
+        public static async UniTask StartAsync()
+        {
+            // 二重起動防止
+            // Prevent double-start
+            if (_kestrel != null) return;
+
+            _hub = new WebSocketHub();
+
+            _kestrel = new KestrelServer();
+            await _kestrel.StartAsync(_hub);
+
+            _vite = new ViteProcess();
+            await _vite.StartAsync();
+
+            Debug.Log("[WebUiHost] ready. Open http://localhost:5173/");
+        }
+
+        public static void Stop()
+        {
+            if (_kestrel == null) return;
+
+            // 先に WS を閉じてから HTTP を止め、最後に Vite を kill
+            // Close WS first, stop HTTP, then kill Vite
+            _hub?.CloseAllAsync().GetAwaiter().GetResult();
+            _kestrel.StopAsync().GetAwaiter().GetResult();
+            _vite?.Kill();
+
+            _hub = null;
+            _kestrel = null;
+            _vite = null;
+        }
+    }
+}
+```
+
+- [ ] **Step 2: コンパイル**
+
+```bash
+uloop compile --project-path ./moorestech_client
+```
+
+Expected: エラーなし。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add moorestech_client/Assets/Scripts/Client.WebUiHost/Boot/WebUiHost.cs
+git commit -m "WebUiHost facade: Kestrel と Vite の統合起動/停止"
+```
+
+---
+
+## Task 11: InventoryTopic（LocalPlayerInventory → WS）
+
+**Files:**
+- Create: `moorestech_client/Assets/Scripts/Client.WebUiHost/Game/Topics/InventoryTopic.cs`
+
+`InventoryTopic` は `LocalPlayerInventoryController` 経由で `ILocalPlayerInventory` を取得し、`OnItemChange` を購読して `local_player.inventory` トピックに push する。
+
+- [ ] **Step 1: `InventoryTopic.cs` を作成**
+
+```csharp
+using System.Text;
+using Client.Game.InGame.Context;
+using Client.Game.InGame.UI.Inventory.Main;
+using Client.WebUiHost.Boot;
+using Core.Item.Interface;
+using Cysharp.Threading.Tasks;
+using UniRx;
+using UnityEngine;
+
+namespace Client.WebUiHost.Game.Topics
+{
+    /// <summary>
+    /// local_player.inventory トピック: スロット変更のたびに全量を push
+    /// local_player.inventory topic: pushes the full inventory on every slot change
+    /// </summary>
+    public class InventoryTopic : ITopicHandler
+    {
+        public const string TopicName = "local_player.inventory";
+
+        private readonly WebSocketHub _hub;
+        private readonly LocalPlayerInventoryController _controller;
+
+        public InventoryTopic(WebSocketHub hub, LocalPlayerInventoryController controller)
+        {
+            _hub = hub;
+            _controller = controller;
+
+            // スロット変更通知を購読して全量を配信
+            // Subscribe to slot-change notifications and broadcast the full inventory
+            _controller.LocalPlayerInventory.OnItemChange.Subscribe(_ => Publish());
+        }
+
+        public UniTask<string> GetSnapshotJsonAsync()
+        {
+            return UniTask.FromResult(BuildJson(_controller.LocalPlayerInventory));
+        }
+
+        #region Internal
+
+        private void Publish()
+        {
+            var json = BuildJson(_controller.LocalPlayerInventory);
+            _hub.Publish(TopicName, json);
+        }
+
+        private static string BuildJson(ILocalPlayerInventory inv)
+        {
+            // ホットバーは既存定数がある場合はそちらに従うが、本スペックでは
+            // 単純化のため全スロットを mainSlots として出力する。
+            // Hotbar splitting will be refined later; for this spec we dump
+            // every slot into mainSlots to keep things simple.
+            var sb = new StringBuilder();
+            sb.Append("{\"mainSlots\":[");
+            for (var i = 0; i < inv.Count; i++)
+            {
+                var stack = inv[i];
+                if (i > 0) sb.Append(',');
+                sb.Append("{\"itemId\":");
+                sb.Append(stack.Id.AsPrimitive());
+                sb.Append(",\"count\":");
+                sb.Append(stack.Count);
+                sb.Append('}');
+            }
+            sb.Append("],\"hotBarSlots\":[]}");
+            return sb.ToString();
+        }
+
+        #endregion
+    }
+}
+```
+
+注: `ItemId.AsPrimitive()` は Mooresmaster 生成の int プリミティブ返却メソッド。
+
+- [ ] **Step 2: コンパイル**
+
+```bash
+uloop compile --project-path ./moorestech_client
+```
+
+Expected: エラーなし。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add moorestech_client/Assets/Scripts/Client.WebUiHost/Game/Topics/InventoryTopic.cs
+git commit -m "InventoryTopic: ローカルプレイヤーインベントリの WS 配信"
+```
+
+---
+
+## Task 12: WebUiGameBinder facade
+
+**Files:**
+- Create: `moorestech_client/Assets/Scripts/Client.WebUiHost/Game/WebUiGameBinder.cs`
+
+- [ ] **Step 1: `WebUiGameBinder.cs` を作成**
+
+```csharp
+using Client.Game.InGame.Context;
+using Client.Game.InGame.UI.Inventory.Main;
+using Client.WebUiHost.Boot;
+using Client.WebUiHost.Game.Topics;
+
+namespace Client.WebUiHost.Game
+{
+    /// <summary>
+    /// ゲーム系トピックを WebUiHost.Hub にバインドする facade。
+    /// ClientContext / ClientDIContext の準備が終わった後に 1 回呼ぶ。
+    /// Facade that binds game-side topics to WebUiHost.Hub.
+    /// Must be called once, after ClientContext / ClientDIContext are ready.
+    /// </summary>
+    public static class WebUiGameBinder
+    {
+        public static void BindTopics()
+        {
+            var hub = WebUiHost.Hub;
+            if (hub == null) return;
+
+            // DI からインベントリコントローラを取得
+            // Resolve the inventory controller from DI
+            var controller = ClientDIContext.DIContainer
+                .DIContainerResolver
+                .Resolve<LocalPlayerInventoryController>();
+
+            var inventoryTopic = new InventoryTopic(hub, controller);
+            hub.RegisterTopic(InventoryTopic.TopicName, inventoryTopic);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: コンパイル**
+
+```bash
+uloop compile --project-path ./moorestech_client
+```
+
+Expected: エラーなし。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add moorestech_client/Assets/Scripts/Client.WebUiHost/Game/WebUiGameBinder.cs
+git commit -m "WebUiGameBinder: ゲーム系トピックを Hub にバインド"
+```
+
+---
+
+## Task 13: InitializeScenePipeline 統合
+
+**Files:**
+- Modify: `moorestech_client/Assets/Scripts/Client.Starter/InitializeScenePipeline.cs`
+
+- [ ] **Step 1: `InitializeScenePipeline.cs` の using 追加と Initialize 先頭への hook 挿入、ClientContext 生成後への bind 呼び出し追加**
+
+変更箇所 1: ファイル先頭の using にこの 3 行を追加。
+
+```csharp
+using Client.Game.Common;
+using Client.WebUiHost.Boot;
+using Client.WebUiHost.Game;
+```
+
+変更箇所 2: `Initialize()` の最序盤（`var args = CliConvert.Parse...` の前）に以下を挿入。
+
+```csharp
+            // ---- Web UI サーバーの起動（最序盤）----
+            // ---- Web UI server bootstrap (earliest phase) ----
+            await WebUiHost.StartAsync();
+            GameShutdownEvent.OnGameShutdown.Subscribe(_ => WebUiHost.Stop());
+```
+
+変更箇所 3: `new ClientContext(...)` の**直後、MainGameScene 遷移の前**に以下を挿入。
+
+位置: 既存の `new ClientContext(...)` 行と `SceneManager.sceneLoaded += MainGameSceneLoaded;` 行の間。
+
+```csharp
+            // Web UI ゲーム系トピックを Hub にバインド
+            // Bind game-side Web UI topics to the hub
+            WebUiGameBinder.BindTopics();
+```
+
+注意: `new ClientContext(...)` は `ClientDIContext` 生成前に走るが、`WebUiGameBinder.BindTopics()` は `ClientDIContext` の `DIContainer` を参照する。`ClientDIContext` は `MainGameSceneLoaded` 内で作られる。よって `BindTopics()` は `MainGameSceneLoaded` 側に入れる必要がある。
+
+**差し戻し修正:** 変更箇所 3 は `MainGameSceneLoaded` 内（既存の `new ClientDIContext(...)` 直後、`GameInitializedEvent.FireGameInitialized();` の前）に入れる。
+
+```csharp
+            void MainGameSceneLoaded(Scene scene, LoadSceneMode mode)
+            {
+                SceneManager.sceneLoaded -= MainGameSceneLoaded;
+                var starter = FindObjectOfType<MainGameStarter>();
+                var resolver = starter.StartGame(handshakeResponse);
+                new ClientDIContext(new DIContainer(resolver));
+
+                // Web UI ゲーム系トピックを Hub にバインド
+                // Bind game-side Web UI topics to the hub
+                WebUiGameBinder.BindTopics();
+
+                // ゲーム初期化完了イベントを発火
+                // Fire game initialization complete event
+                GameInitializedEvent.FireGameInitialized();
+            }
+```
+
+- [ ] **Step 2: コンパイル**
+
+```bash
+uloop compile --project-path ./moorestech_client
+```
+
+Expected: エラーなし。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add moorestech_client/Assets/Scripts/Client.Starter/InitializeScenePipeline.cs
+git commit -m "InitializeScenePipeline に WebUiHost 起動と Topic bind を統合"
+```
+
+---
+
+## Task 14: Unity を起動して Kestrel + Vite の統合を手動検証
+
+**Files:** なし（動作確認のみ）
+
+- [ ] **Step 1: Unity エディタを起動**
+
+```bash
+uloop launch --project-path ./moorestech_client
+```
+
+- [ ] **Step 2: Unity エディタ内でメインメニュー → ローカルゲーム開始**
+
+InitializeScenePipeline が走るシーンで動かす。
+
+- [ ] **Step 3: ログ確認**
+
+```bash
+uloop get-logs --project-path ./moorestech_client --log-type Log | grep WebUiHost
+```
+
+Expected:
+```
+[WebUiHost] Kestrel started at http://127.0.0.1:5050
+[WebUiHost] spawned Vite (pid=XXXX)
+[Vite] ...Local: http://127.0.0.1:5173/
+[WebUiHost] ready. Open http://localhost:5173/
+```
+
+- [ ] **Step 4: ブラウザで `http://localhost:5173/` を開く**
+
+Expected: "moorestech Web UI / bootstrapping..." が表示される。
+
+- [ ] **Step 5: `http://localhost:5173/api/ping` を叩いて疎通確認**
+
+```bash
+curl -s http://localhost:5173/api/ping
+```
+
+Expected: `{"ok":true}`
+
+- [ ] **Step 6: ゲームをメインメニューに戻す → Vite プロセスが kill されていることを ps で確認**
+
+```bash
+# macOS / Linux
+ps aux | grep -i vite | grep -v grep
+```
+
+Expected: Vite プロセスが存在しない。
+
+- [ ] **Step 7: エラーが出ていない場合は **Task 14 完了** とマーク。出た場合はログを debug して Task 9 / Task 10 に戻る**
+
+この検証で通らない代表パターン:
+- Node バイナリが見つからない → setup.sh 再実行
+- `pnpm install` が失敗 → ネットワーク確認、pnpm/node バージョン確認
+- Vite が 5173 にバインドできない → 他プロセスとの衝突、`lsof -i :5173`
+- `/api/ping` が Vite 経由で届かない → `vite.config.ts` の proxy 設定確認
+- ブラウザでコンソールエラー → React scaffold の記述確認
+
+---
+
+## Task 15: WebSocket クライアント基盤（webSocketClient.ts + useTopic.ts）
+
+**Files:**
+- Create: `moorestech_web/webui/src/bridge/webSocketClient.ts`
+- Create: `moorestech_web/webui/src/bridge/useTopic.ts`
+
+- [ ] **Step 1: `src/bridge/webSocketClient.ts` を作成**
+
+```ts
+// Unity 側 Web UI ホストと通信する WebSocket クライアント。
+// 購読モデル: subscribe / unsubscribe / snapshot の 3 種類を送り、
+// snapshot / event / error の 3 種類を受ける。
+// WebSocket client that talks to the Unity-side Web UI host.
+// Subscribe-model protocol: sends subscribe / unsubscribe / snapshot,
+// receives snapshot / event / error.
+
+export type ServerMsg =
+  | { op: "snapshot"; topic: string; data: unknown }
+  | { op: "event"; topic: string; data: unknown }
+  | { op: "error"; message: string };
+
+type Listener = (data: unknown) => void;
+
+class WebSocketClient {
+  private ws: WebSocket | null = null;
+  private readonly url: string;
+  private readonly listeners = new Map<string, Set<Listener>>();
+  private readonly pendingSubscribes = new Set<string>();
+  private reconnectDelayMs = 100;
+  private closedByUs = false;
+
+  constructor(url: string) {
+    this.url = url;
+  }
+
+  connect() {
+    this.closedByUs = false;
+    this.openSocket();
+  }
+
+  close() {
+    this.closedByUs = true;
+    this.ws?.close();
+    this.ws = null;
+  }
+
+  subscribe(topic: string, listener: Listener): () => void {
+    let set = this.listeners.get(topic);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(topic, set);
+    }
+    set.add(listener);
+
+    this.sendSubscribe(topic);
+
+    return () => {
+      set!.delete(listener);
+      if (set!.size === 0) {
+        this.listeners.delete(topic);
+        this.sendRaw({ op: "unsubscribe", topics: [topic] });
+      }
+    };
+  }
+
+  private sendSubscribe(topic: string) {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.sendRaw({ op: "subscribe", topics: [topic] });
+    } else {
+      this.pendingSubscribes.add(topic);
+    }
+  }
+
+  private sendRaw(obj: unknown) {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify(obj));
+    }
+  }
+
+  private openSocket() {
+    const ws = new WebSocket(this.url);
+    this.ws = ws;
+
+    ws.onopen = () => {
+      this.reconnectDelayMs = 100;
+      // 保留中の subscribe と、再接続時は listener が登録済みのトピックを全て再購読
+      // On (re)connect, flush pending subscribes and re-subscribe known topics
+      const toSub = new Set<string>();
+      this.pendingSubscribes.forEach((t) => toSub.add(t));
+      this.listeners.forEach((_, t) => toSub.add(t));
+      this.pendingSubscribes.clear();
+      if (toSub.size > 0) {
+        this.sendRaw({ op: "subscribe", topics: Array.from(toSub) });
+      }
+    };
+
+    ws.onmessage = (ev) => {
+      const msg = JSON.parse(String(ev.data)) as ServerMsg;
+      if (msg.op === "snapshot" || msg.op === "event") {
+        const set = this.listeners.get(msg.topic);
+        if (set) set.forEach((l) => l(msg.data));
+      } else if (msg.op === "error") {
+        console.error("[ws] server error:", msg.message);
+      }
+    };
+
+    ws.onerror = () => {
+      // onerror 後は onclose が続くので特に何もしない
+      // onerror is followed by onclose, no action needed here
+    };
+
+    ws.onclose = () => {
+      this.ws = null;
+      if (this.closedByUs) return;
+      // 指数バックオフで再接続（上限 5 秒）
+      // Exponential backoff reconnect (capped at 5s)
+      const delay = Math.min(this.reconnectDelayMs, 5000);
+      this.reconnectDelayMs = Math.min(this.reconnectDelayMs * 2, 5000);
+      setTimeout(() => this.openSocket(), delay);
+    };
+  }
+}
+
+// モジュール内シングルトンで接続を保持
+// Keep the connection as a module-level singleton
+const client = new WebSocketClient(`ws://${location.host}/ws`);
+client.connect();
+
+export function subscribeTopic<T>(topic: string, listener: (data: T) => void) {
+  return client.subscribe(topic, (d) => listener(d as T));
+}
+```
+
+- [ ] **Step 2: `src/bridge/useTopic.ts` を作成**
+
+```ts
+import { useEffect, useState } from "react";
+import { subscribeTopic } from "./webSocketClient";
+
+// 指定トピックを購読して最新の値を返す React フック
+// React hook that subscribes to a topic and returns the latest value
+export function useTopic<T>(topic: string): T | null {
+  const [value, setValue] = useState<T | null>(null);
+  useEffect(() => {
+    const unsub = subscribeTopic<T>(topic, (data) => setValue(data));
+    return unsub;
+  }, [topic]);
+  return value;
+}
+```
+
+- [ ] **Step 3: TS チェック**
+
+```bash
+cd moorestech_web/webui
+../node/mac-arm64/pnpm exec tsc --noEmit
+```
+
+Expected: エラーなし。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add moorestech_web/webui/src/bridge/
+git commit -m "webSocketClient と useTopic: 購読モデル WS クライアント"
+```
+
+---
+
+## Task 16: InventoryView（実データ表示）
+
+**Files:**
+- Create: `moorestech_web/webui/src/components/InventoryView.tsx`
+- Modify: `moorestech_web/webui/src/App.tsx`
+
+- [ ] **Step 1: `src/components/InventoryView.tsx` を作成**
+
+```tsx
+import { useTopic } from "../bridge/useTopic";
+
+type InventoryData = {
+  mainSlots: Array<{ itemId: number; count: number }>;
+  hotBarSlots: Array<{ itemId: number; count: number }>;
+};
+
+// ローカルプレイヤーのインベントリを WS 購読して表示
+// Subscribe to the local player's inventory over WS and render it
+export default function InventoryView() {
+  const inventory = useTopic<InventoryData>("local_player.inventory");
+
+  if (!inventory) {
+    return <div className="text-sm text-gray-400">connecting...</div>;
+  }
+
+  return (
+    <div>
+      <h2 className="text-lg font-semibold mb-2">Main Inventory</h2>
+      <div className="grid grid-cols-9 gap-1">
+        {inventory.mainSlots.map((s, i) => (
+          <div
+            key={i}
+            className="border border-gray-700 rounded p-2 min-h-[48px] text-xs flex flex-col justify-between bg-gray-900"
+          >
+            <div className="text-gray-400">#{i}</div>
+            {s.count > 0 ? (
+              <div>
+                <div className="text-white">id:{s.itemId}</div>
+                <div className="text-green-400">×{s.count}</div>
+              </div>
+            ) : null}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: `src/App.tsx` を更新**
+
+```tsx
+import InventoryView from "./components/InventoryView";
+
+export default function App() {
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">moorestech Web UI</h1>
+      <InventoryView />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: TS チェック**
+
+```bash
+cd moorestech_web/webui
+../node/mac-arm64/pnpm exec tsc --noEmit
+```
+
+Expected: エラーなし。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add moorestech_web/webui/src/
+git commit -m "InventoryView: local_player.inventory を購読して表示"
+```
+
+---
+
+## Task 17: エンドツーエンド動作確認
+
+**Files:** なし（動作確認のみ）
+
+- [ ] **Step 1: Unity エディタ再起動（最新コードを反映）**
+
+```bash
+uloop launch --project-path ./moorestech_client
+```
+
+- [ ] **Step 2: ローカルゲームを開始（InitializeScenePipeline が走るフロー）**
+
+- [ ] **Step 3: ブラウザで `http://localhost:5173/` を開く**
+
+Expected: インベントリスロットのグリッドが表示される。全スロット空（`count: 0`）の場合はスロット番号 `#0` `#1` ... のみが見える。
+
+- [ ] **Step 4: Chrome DevTools の Network タブで WS 接続を確認**
+
+Expected:
+- `ws://localhost:5173/ws` が 101 Switching Protocols
+- フレーム: 送信 `{"op":"subscribe","topics":["local_player.inventory"]}`、受信 `{"op":"snapshot","topic":"local_player.inventory","data":{"mainSlots":[...],"hotBarSlots":[]}}`
+
+- [ ] **Step 5: ゲーム内でアイテムを取得または消費**
+
+Expected: ブラウザ側の表示が即時更新される。DevTools に受信 `{"op":"event","topic":"local_player.inventory","data":{...}}` が追記される。
+
+- [ ] **Step 6: ゲームをメインメニューに戻す**
+
+Expected:
+- Unity ログ: `[WebUiHost] Kestrel stopped`、`[WebUiHost] Vite process killed`
+- ブラウザ側: WS が切断され、再接続を試行するがサーバー停止中は失敗し続ける
+- `ps` コマンド: Vite プロセス残存なし
+
+- [ ] **Step 7: 再度ローカルゲーム開始**
+
+Expected: ブラウザ側の WS が自動再接続し、インベントリが snapshot で再同期される。
+
+- [ ] **Step 8: すべて通った場合、完了コミットを作る**
+
+```bash
+git commit --allow-empty -m "Web UI 基盤 3 タスクのエンドツーエンド動作確認完了"
+```
+
+---
+
+## Task 18: Unity 生成 .meta ファイルを取り込み
+
+Unity を起動すると、新規作成した .cs / .asmdef ファイルに対応する .meta が自動生成される。この .meta を commit しないと他環境で asmdef 認識されない。
+
+**Files:** 自動生成された `.meta` 群
+
+- [ ] **Step 1: Unity を一度起動して .meta を自動生成させる**
+
+Task 14 / 17 で既に起動済みなら OK。
+
+- [ ] **Step 2: git status で .meta が出ていることを確認**
+
+```bash
+git status --short | grep "\.meta$"
+```
+
+Expected: 新規追加された `.cs` / asmdef ごとに `.meta` が ?? で表示される。
+
+- [ ] **Step 3: .meta を追加 commit**
+
+```bash
+git add moorestech_client/Assets/Scripts/Client.WebUiHost/
+git add moorestech_client/Assets/Scripts/Client.Game/Common/GameShutdownEvent.cs.meta
+git commit -m "Unity 自動生成の .meta を取り込み"
+```
+
+---
+
+## Self-Review チェック
+
+### Spec coverage
+
+| Spec セクション | カバーするタスク |
+|---|---|
+| 1. スコープと完了条件 | Task 17 が完了条件を検証 |
+| 2. リポジトリ構成 | Task 1 (moorestech_web scaffold) + Task 4 (Client.WebUiHost asmdef) + Task 2 (webui) |
+| 3. アーキテクチャ（プロセス・ポート） | Task 8 (Kestrel 5050) + Task 9 (Vite 5173) + Task 2 (vite.config proxy) |
+| 4.1 起動シーケンス | Task 10 (WebUiHost facade) + Task 13 (InitializeScenePipeline 統合) |
+| 4.2 終了シーケンス | Task 3 (GameShutdownEvent + BackToMainMenu fire) + Task 13 (subscribe → Stop) |
+| 4.3 失敗時挙動 | Task 9 (ViteProcess のバイナリ不在時 LogError) |
+| 5.1 Boot 層 | Task 5/6/7/8/9/10 |
+| 5.2 Game 層 | Task 11/12 |
+| 6. WebSocket プロトコル | Task 6 (WebSocketHub envelope) + Task 15 (クライアント側) |
+| 7. インベントリトピック | Task 11 (InventoryTopic) + Task 16 (InventoryView) |
+| 8. Main Thread Dispatch | （本プランではシンプル化のため、`OnItemChange` は Unity main thread から発火されると想定。必要になれば ViteProcess/Kestrel ハンドラ内で `UniTask.SwitchToMainThread()` を足す。本スペック範囲での追加なし） |
+| 9. セキュリティ最低線 | Task 2 (Vite fs.allow + 127.0.0.1) + Task 7 (WS Origin 検査) + Task 8 (Kestrel 127.0.0.1) |
+| 10. 後続スペック | 本プラン範囲外、スコープアウト記述済み |
+| 11. 変更対象ファイル | Task 3 (BackToMainMenu + GameShutdownEvent) + Task 13 (InitializeScenePipeline) + 各新規 |
+
+### Placeholder scan
+
+- 「TBD」「TODO」「fill in later」なし
+- 「add appropriate error handling」なし（nullチェック・条件分岐で具体化）
+- 「similar to Task N」なし（各タスクのコードを完全記述）
+- 「write tests for the above」なし
+
+### Type consistency
+
+- `ItemId.AsPrimitive()` は int を返す前提（server 側のテストコードで `new ItemId(1)` が通るため）
+- WS envelope は C# 側（`WebSocketHub`）と TS 側（`webSocketClient.ts`）で `op` / `topic` / `data` キー命名が揃っている
+- トピック名 `"local_player.inventory"` は C# 側 `InventoryTopic.TopicName` と TS 側 `InventoryView` の `useTopic` 引数で完全一致
+- `WebUiHost.Hub` は `WebSocketHub` 型で統一
+
+### 注意点（実装者向け）
+
+1. `System.Threading.Channels.Channel` が netstandard2.1 で見つからない場合は `BlockingCollection<string>` で書き換える（Task 6）。
+2. `Client.WebUiHost.asmdef` の `references` に実際のアセンブリ名が一致しているか、Unity でコンパイル後に要確認（Task 4）。
+3. `ItemId.AsPrimitive()` がもし int 以外（long / Guid 等）を返していた場合、`InventoryTopic.BuildJson()` の数値直書きを文字列化に変更する必要あり（Task 11）。
+4. Vite の proxy 設定の `ws: true` は WebSocket を透過させる必須オプション。外すと `/ws` が 404 になる（Task 2）。
+5. `InitializeScenePipeline` の `WebUiHost.StartAsync()` は Addressables 初期化より前に置くため、Addressables 側の挙動を阻害しないか初回検証で観察する（Task 13, 14）。
+
+---
+
+## 実行ハンドオフ
+
+**Plan complete and saved to `docs/superpowers/plans/2026-04-22-web-ui-foundation.md`.**
+
+2 つの実行モードから選んでください:
+
+**1. Subagent-Driven（推奨）** — タスクごとに fresh subagent を dispatch、タスク間でレビュー、高速イテレーション
+
+**2. Inline Execution** — このセッション内で executing-plans を使い、バッチ実行 + チェックポイントでレビュー
+
+どちらで進めますか?

--- a/docs/superpowers/specs/2026-04-22-web-ui-foundation-design.md
+++ b/docs/superpowers/specs/2026-04-22-web-ui-foundation-design.md
@@ -1,0 +1,403 @@
+# moorestech Web UI 基盤 設計仕様
+
+**作成日:** 2026-04-22
+**対象タスク:** CEF Web UI 導入計画 の先頭3タスク
+- ASP.NET（HTTP/WS サーバー）の導入
+- pnpm / TypeScript / React の導入
+- Unity ↔ Web の初期化パイプライン構築
+
+**参照:** `docs/cef-webui-plan.md`
+
+---
+
+## 1. スコープと完了条件
+
+### 対象
+- Unity クライアントに HTTP + WebSocket サーバー（ASP.NET Core 2.3 / Kestrel）を同居
+- TypeScript + React + Vite の Web UI プロジェクトを新設
+- Unity プロセスから Node.js (Vite dev server) を spawn し、両サーバーの起動・終了を一貫管理
+- WebSocket 上でトピック購読モデルのプロトコルを定義
+- デモ対象としてプレイヤーインベントリを WS 配信し、React 側で一覧表示
+
+### 非対象（後続スペックに委譲）
+- CEF 統合（本スペック完了時点ではユーザーが Chrome 等で `http://localhost:5173/` を開いて確認する）
+- C# → TS の型生成 SourceGenerator
+- アイテムアイコン配信
+- インベントリ以外の UI 移植
+- 本番ビルド時の挙動（`vite build` 成果物の配信、Node バイナリのプラットフォーム別配布など）
+- CSRF トークン等の本格ハードニング
+- ポート衝突時のフォールバック
+- Node orphan プロセスの OS 別対処（Windows Job Object 等）
+
+### 完了条件
+Unity クライアントを起動すると、内部で Kestrel と Vite dev server が自動起動し、ブラウザで `http://localhost:5173/` を開くと React 製の画面にローカルプレイヤーのインベントリがリアルタイム表示される。アイテムを取得・消費するとブラウザ側の表示が即時更新される。
+
+---
+
+## 2. リポジトリ構成
+
+```
+moorestech/
+├── moorestech_client/                          (既存 Unity クライアント)
+│   └── Assets/Scripts/Client.WebUiHost/
+│       ├── Client.WebUiHost.asmdef
+│       ├── WebUiHostBehaviour.cs               (仮コード、feature/webui-host-code ブランチ上に存在。本スペックでは触らない)
+│       │
+│       ├── Boot/                               ← 初期化系・ゲームデータ非依存
+│       │   ├── WebUiHost.cs                    外向き Facade（静的）
+│       │   ├── KestrelServer.cs                Kestrel 起動/停止
+│       │   ├── ViteProcess.cs                  Node spawn / ready 監視 / kill
+│       │   ├── WebSocketHub.cs                 WS 接続管理・トピックレジストリ
+│       │   ├── WebUiEndpoints.cs               /ws, /api ルーティング
+│       │   └── WebUiPaths.cs                   moorestech_web/ 絶対パス解決
+│       │
+│       └── Game/                               ← ゲーム系・ClientContext 依存
+│           ├── WebUiGameBinder.cs              外向き Facade（静的）
+│           └── Topics/
+│               └── InventoryTopic.cs           インベントリ → WS 配信
+│
+│   └── Assets/Scripts/Client.Game/Common/
+│       ├── GameInitializedEvent.cs             (既存)
+│       └── GameShutdownEvent.cs                ← 新規（本スペックで追加）
+│
+│   └── Assets/Scripts/Client.Starter/
+│       └── InitializeScenePipeline.cs          (既存・hook 追加)
+│
+│   └── Assets/Scripts/Client.Game/InGame/Presenter/PauseMenu/
+│       └── BackToMainMenu.cs                   (既存・1行追加)
+│
+├── moorestech_server/                          (既存、本スペックでは変更なし)
+│
+├── moorestech_web/                             ← 新規
+│   ├── webui/                                  TS/React プロジェクト
+│   │   ├── package.json
+│   │   ├── pnpm-lock.yaml
+│   │   ├── .npmrc                              node-linker=hoisted
+│   │   ├── vite.config.ts
+│   │   ├── tsconfig.json
+│   │   ├── index.html
+│   │   ├── src/
+│   │   │   ├── main.tsx
+│   │   │   ├── App.tsx
+│   │   │   ├── bridge/
+│   │   │   │   ├── webSocketClient.ts          WS 接続・再接続・envelope 送受信
+│   │   │   │   └── useTopic.ts                 React フック
+│   │   │   └── components/
+│   │   │       └── InventoryView.tsx           インベントリ表示
+│   │   └── node_modules/                       (.gitignore)
+│   │
+│   └── node/                                   Node.js バイナリ同梱
+│       ├── mac-arm64/node
+│       ├── mac-x64/node
+│       ├── win-x64/node.exe
+│       └── linux-x64/node
+│
+└── docs/
+    ├── cef-webui-plan.md                       (既存)
+    └── superpowers/specs/
+        └── 2026-04-22-web-ui-foundation-design.md  (本ドキュメント)
+```
+
+---
+
+## 3. アーキテクチャ
+
+### 3.1 プロセス・ポート構成
+
+```
+[ Unity Client プロセス (moorestech_client) ]
+  │
+  ├── Kestrel (ASP.NET Core 2.3 / netstandard2.0)
+  │     └── 127.0.0.1:5050
+  │           ├── HTTP:  /api/*     (本スペックでは未使用、枠のみ確保)
+  │           └── WS:    /ws        (トピック購読・配信)
+  │
+  └── Process.Start → Node (同梱) → Vite dev server
+                                        └── 127.0.0.1:5173
+                                              ├── /        → React アプリ
+                                              ├── /src/*   → TSX on-the-fly transform
+                                              ├── /api/*   → proxy → 127.0.0.1:5050
+                                              └── /ws      → proxy → 127.0.0.1:5050/ws
+
+[ ユーザー ] → Chrome → http://127.0.0.1:5173/
+```
+
+### 3.2 採用技術
+
+| 領域 | 選択 | 理由 |
+|---|---|---|
+| HTTP/WS サーバー | ASP.NET Core 2.3 (Kestrel, netstandard2.0 LTS) | 既存 `WebUiHostBehaviour` で動作確認済み。Unity 6 + NuGetForUnity で利用可能 |
+| JS ランタイム同梱 | Node.js LTS バイナリ | `moorestech_web/node/<platform>/`。公式バイナリをそのまま同梱 |
+| パッケージマネージャ | pnpm（`node-linker=hoisted`） | 厳格な依存解決。hoisted 指定で symlink / ジャンクションを作らず配布互換性を確保。pnpm 本体は `@pnpm/exe` 相当のスタンドアロンバイナリを `moorestech_web/node/<platform>/pnpm` として同梱する前提（`node` と同じ階層） |
+| ビルドツール | Vite（dev server 常時運用） | 本スペック γ 方針に従い、本番相当環境でも `pnpm dev` を走らせる |
+| フレームワーク | React 18 + TypeScript 5 | 試作で確認済み |
+| スタイル | Tailwind CSS | 試作で確認済み（`cn()` + Tailwind クラス） |
+| 状態管理 | React hooks（useState / useEffect） | 本スペックでは追加ライブラリ不要 |
+| WS クライアント | ブラウザ標準 `WebSocket` + 薄いラッパ | 追加ライブラリ不要 |
+
+### 3.3 なぜ γ（本番でも `pnpm dev`）を選んだか
+
+CEF Web UI 導入計画の根幹に「mod が HTML/CSS/TS で UI を差し替えられる」という要件がある。配布環境でも Vite dev server を走らせていれば、mod は `.tsx` を投げ込むだけで Vite がその場で変換して配信できる。本スペックでは mod 機能までは実装しないが、将来 mod 対応を素直に載せられる基盤にするため `pnpm dev` 常時運用を採用する。
+
+**リスクの受け入れ:**
+- Mod が C# で任意コード実行できる以上、TS 動的実行による追加攻撃面はない（=既存の mod モデルと同じ信頼境界）
+- `node_modules` サイズ・Node バイナリ同梱による配布サイズ増は PC ターゲットでは許容
+- pnpm の symlink 問題は `node-linker=hoisted` で回避
+- orphan プロセス対処は後続スペックに委譲
+
+---
+
+## 4. ライフサイクル（Unity マスター）
+
+Unity を親プロセスとして扱い、Kestrel と Vite のライフタイムを Unity セッションに同期させる。ライフサイクルの発火点は既存のゲームイベント（`GameInitializedEvent`、`GameShutdownEvent`）にあわせ、`Application.quitting` には依存しない。
+
+### 4.1 起動シーケンス
+
+```
+InitializeScenePipeline.Initialize()
+  │
+  ├─ [新規] WebUiHost.StartAsync()
+  │    ├─ KestrelServer.Start()        → 127.0.0.1:5050 bind、/ws WebSocket accept ready
+  │    └─ ViteProcess.Start()
+  │         ├─ platform 判定 → moorestech_web/node/<platform>/node を選択
+  │         ├─ cwd = moorestech_web/webui
+  │         ├─ node_modules 不在なら pnpm install を先に実行
+  │         ├─ spawn: node <vite-cli> --port 5173 --strictPort
+  │         └─ stdout を監視し "ready in" を検出するまで await
+  │
+  ├─ [新規] GameShutdownEvent.OnGameShutdown.Subscribe(_ => WebUiHost.Stop())
+  │
+  ├─ （既存）Addressables.InitializeAsync
+  ├─ （既存）WhenAll(VanillaApi, ModAssets, SceneLoad)
+  ├─ （既存）new ClientContext(...)
+  │
+  ├─ [新規] WebUiGameBinder.BindTopics()
+  │    └─ InventoryTopic.Register(WebUiHost.Hub)
+  │         └─ LocalPlayerInventoryController の変更通知を購読
+  │
+  └─ （既存）シーン遷移 → MainGameStarter.StartGame → GameInitializedEvent.FireGameInitialized()
+```
+
+**ポイント:**
+- `WebUiHost.StartAsync()` は `Initialize()` の最序盤に置く。ローディング中でもブラウザで `http://localhost:5173/` が開ける
+- `WebUiGameBinder.BindTopics()` は `ClientContext` 生成後に呼ぶ。トピックハンドラが `ClientContext` 経由のゲーム状態にアクセスできる必要があるため
+- 新規処理は MonoBehaviour を導入しない。pure C# で `InitializeScenePipeline` から呼び出す
+
+### 4.2 終了シーケンス
+
+ゲーム終了の単一窓口は既存の `BackToMainMenu.Disconnect()`（ボタン / `OnDestroy` / `OnApplicationQuit` の 3 経路すべてが通る）。
+
+**新規イベント `GameShutdownEvent`**（`GameInitializedEvent` と対称）:
+```csharp
+namespace Client.Game.Common
+{
+    public static class GameShutdownEvent
+    {
+        private static readonly Subject<Unit> _onGameShutdown = new();
+        public static IObservable<Unit> OnGameShutdown => _onGameShutdown;
+        public static void FireGameShutdown()
+        {
+            _onGameShutdown.OnNext(Unit.Default);
+        }
+    }
+}
+```
+
+**発火点:** `BackToMainMenu.Disconnect()` の末尾に `GameShutdownEvent.FireGameShutdown()` を追加。
+
+**購読側の動作（`WebUiHost.Stop()`）:**
+```
+WebUiHost.Stop()
+  ├─ WebSocketHub.CloseAll()        全接続に close フレーム送信
+  ├─ KestrelServer.StopAsync(2s)    graceful shutdown、最大 2 秒待機
+  └─ ViteProcess.Kill()             Node プロセスに SIGTERM（失敗時は強制終了）
+```
+
+### 4.3 失敗時の挙動（本スペック範囲）
+
+- Node バイナリが存在しない / 起動失敗 → `Debug.LogError` を出し、Unity 本体の初期化は続行する（Web UI は死ぬがゲームは動く）
+- Kestrel の bind 失敗（ポート競合等）→ 同上。後続スペックでフォールバック採番を実装する
+- `pnpm install` 失敗 → 同上
+- Vite の ready 出力が一定時間来ない（タイムアウト 30 秒）→ 同上
+
+いずれもゲーム本体の起動は止めない。エラーはログに出すだけ。
+
+---
+
+## 5. Client.WebUiHost の責務分割
+
+`Client.WebUiHost` は 2 つのサブ領域に分割する。両者とも pure C#（MonoBehaviour 不使用）。
+
+### 5.1 Boot 層（`Client.WebUiHost/Boot/`）
+
+ゲームデータに依存しない。Kestrel・Vite・WebSocket インフラだけを扱う。
+
+- **`WebUiHost`（static facade）**: 起動・停止の入口。`StartAsync()`、`Stop()`、および `Hub`（`WebSocketHub` インスタンス）プロパティを公開
+- **`KestrelServer`**: Kestrel の `IWebHost` 起動・停止ラッパ。ルーティング設定は `WebUiEndpoints` に委譲
+- **`ViteProcess`**: Node プロセスの spawn、stdout の ready 検出、kill を担当。プラットフォーム別バイナリパスの選別も含む
+- **`WebSocketHub`**: WebSocket 接続ごとの購読 topic set を保持。トピックハンドラを名前で登録 / 配信
+- **`WebUiEndpoints`**: `/ws` と `/api` のルーティング定義。`UseWebSockets()` の有効化と `HttpContext.WebSockets.AcceptWebSocketAsync()` による接続受付
+- **`WebUiPaths`**: `Application.dataPath` から `moorestech_web/` への絶対パスを解決するユーティリティ
+
+### 5.2 Game 層（`Client.WebUiHost/Game/`）
+
+`ClientContext` 生成後に初めて使える。ゲーム状態を読み取って WS に流す責務を持つ。
+
+- **`WebUiGameBinder`（static facade）**: `BindTopics()` を公開。内部で各トピックを `WebUiHost.Hub` に登録
+- **`Topics/InventoryTopic`**: `LocalPlayerInventoryController` の変更通知を購読し、`WebSocketHub` 経由で `"local_player.inventory"` トピックの購読者に `snapshot` / `event` メッセージを配信
+
+---
+
+## 6. WebSocket プロトコル
+
+### 6.1 エンドポイント
+
+- URL: `ws://localhost:5173/ws`（Vite proxy 経由で Kestrel `ws://localhost:5050/ws` に転送）
+- オリジン検査: `Origin` ヘッダが `http://localhost:5173` または `http://127.0.0.1:5173` 以外の場合は WebSocket upgrade を拒否（HTTP 403）
+- サブプロトコル: 指定なし
+
+### 6.2 メッセージ envelope
+
+すべて UTF-8 JSON テキストフレーム。
+
+**Web → Unity（クライアント発信）:**
+```ts
+type ClientMsg =
+  | { op: "subscribe";   topics: string[] }
+  | { op: "unsubscribe"; topics: string[] }
+  | { op: "snapshot";    topic: string }
+```
+
+**Unity → Web（サーバー発信）:**
+```ts
+type ServerMsg =
+  | { op: "snapshot"; topic: string; data: unknown }
+  | { op: "event";    topic: string; data: unknown }
+  | { op: "error";    message: string }
+```
+
+### 6.3 購読セマンティクス
+
+- クライアントが `subscribe` を送ると、サーバーは即座に該当トピックの現在値を `snapshot` として返す
+- 以降、そのトピックに変化が起きるたびにサーバーは `event` を push する
+- `unsubscribe` で停止。接続が切れたら自動 unsubscribe
+- `snapshot` op（request 型）は「現在値を1回だけ再取得」したい場合の明示要求
+
+### 6.4 再接続（クライアント側）
+
+- WebSocket が closed になったら指数バックオフで再接続（100ms → 200ms → 400ms → ... 上限 5s）
+- 再接続成功後、直前の購読トピックを自動で再 subscribe
+- 再接続後の最初の `snapshot` で React 側の状態は上書きされる
+
+---
+
+## 7. デモ対象トピック: インベントリ
+
+### 7.1 トピック名
+
+`"local_player.inventory"`
+
+### 7.2 Payload 型
+
+```ts
+type InventoryData = {
+  mainSlots:   Array<{ itemId: string; count: number }>
+  hotBarSlots: Array<{ itemId: string; count: number }>
+}
+```
+
+- `itemId` は Guid 文字列（空スロットは空 Guid `"00000000-0000-0000-0000-000000000000"` と `count: 0`）
+- `mainSlots` / `hotBarSlots` の長さはインベントリ仕様に準ずる
+
+### 7.3 配信ポリシー
+
+- `subscribe` 到着時 → `InventoryTopic` が現在のインベントリ全体を `snapshot` で返す
+- `LocalPlayerInventoryController` の変更通知に反応して `event` で全量 push（差分最適化は本スペック対象外）
+
+### 7.4 React 側
+
+```tsx
+// components/InventoryView.tsx（概念コード）
+const inventory = useTopic<InventoryData>("local_player.inventory");
+if (!inventory) return <div>loading...</div>;
+return (
+  <div className="grid grid-cols-9 gap-1">
+    {inventory.mainSlots.map((s, i) => (
+      <div key={i} className="border p-2 text-xs">
+        {s.count > 0 ? `${s.itemId.slice(0, 8)}... × ${s.count}` : ""}
+      </div>
+    ))}
+  </div>
+);
+```
+
+アイテムアイコン画像は後続スペックに委譲。本スペックでは Guid 文字列先頭 8 文字と個数のみ表示。
+
+---
+
+## 8. Main Thread Dispatch
+
+Kestrel のリクエストハンドラは ThreadPool で動作する。Unity API（`ClientContext`、`LocalPlayerInventoryController` 等）は main thread からのアクセスを前提とするため、スレッド境界の marshalling が必要。
+
+**採用手段:** UniTask の `UniTask.SwitchToMainThread()`。既存プロジェクトで広く使われており、独自の Dispatcher を追加しない。
+
+**典型パターン:**
+```csharp
+// Kestrel ハンドラ内（ThreadPool で実行中）
+await UniTask.SwitchToMainThread();
+var inventory = ClientContext.LocalPlayerInventory;  // Unity API を main thread で呼ぶ
+await UniTask.SwitchToThreadPool();                  // WS 送信は ThreadPool に戻す
+await webSocket.SendAsync(payload, ...);
+```
+
+---
+
+## 9. セキュリティ最低線
+
+本スペック範囲での必須対応。
+
+- **Bind アドレス:** Kestrel・Vite ともに `127.0.0.1` 厳守（`0.0.0.0` 禁止）
+- **Vite `server.fs.allow`:** `['./src', './public']` に制限し、リポジトリ外や `node_modules` の流出を防ぐ
+- **WS Origin 検査:** `Origin` ヘッダが `http://localhost:5173` または `http://127.0.0.1:5173` のみ許可
+- **CSRF トークン等の本格的な保険は本スペック対象外**（γ 方針で受け入れ、mod 配布時に再検討）
+
+---
+
+## 10. 後続スペックに委譲する項目
+
+本スペック完了後、以下を順次別スペックで扱う。
+
+| 項目 | 内容 |
+|---|---|
+| CEF 統合 | moorestech_client に CEF を同梱し、ゲーム内で Web UI をテクスチャ合成 |
+| C# → TS 型生成 SourceGenerator | 既存の Mooresmaster SourceGenerator と同系統で、API シグネチャとデータ型を TS へ |
+| アイテムアイコン配信 | Kestrel の `/api/assets/icons/{itemId}` で PNG を返す経路 |
+| 本番ビルド挙動 | `vite build` 成果物の静的配信、Unity Build Post-Processor での同梱、Node バイナリのプラットフォーム別選別、`pnpm install` の事前実行による初回起動短縮 |
+| ポート衝突対処 | 固定 + フォールバック、または OS 採番（port 0）+ `runtime.json` による動的配布 |
+| Node orphan 対処 | Windows Job Object、macOS の親 PID 監視、Linux `PR_SET_PDEATHSIG` |
+| CSRF トークン | localhost バインドに対する追加の保険 |
+| HMR / エラーオーバーレイの本番無効化 | 配布時の情報露出を抑える設定 |
+| UI 移植（インベントリ以降） | 既存 uGUI の React 置き換え |
+| 双方向 API 策定 | CEF の JS↔Native ブリッジに載せる RPC/イベント体系 |
+
+---
+
+## 11. 変更対象の既存ファイル（サマリ）
+
+- `moorestech_client/Assets/Scripts/Client.Starter/InitializeScenePipeline.cs`
+  - `Initialize()` の最序盤に `WebUiHost.StartAsync()` と `GameShutdownEvent` 購読を追加
+  - `new ClientContext(...)` 直後に `WebUiGameBinder.BindTopics()` を追加
+- `moorestech_client/Assets/Scripts/Client.Game/InGame/Presenter/PauseMenu/BackToMainMenu.cs`
+  - `Disconnect()` 末尾に `GameShutdownEvent.FireGameShutdown()` を追加
+- `moorestech_client/Assets/Scripts/Client.Game/Common/GameShutdownEvent.cs`
+  - 新規作成
+- `moorestech_client/Assets/Scripts/Client.WebUiHost/Boot/*.cs`
+  - 新規作成（6 ファイル、`WebUiHost` facade ほか）
+- `moorestech_client/Assets/Scripts/Client.WebUiHost/Game/*.cs`
+  - 新規作成（`WebUiGameBinder` と `InventoryTopic`）
+- `moorestech_client/Assets/Scripts/Client.WebUiHost/WebUiHostBehaviour.cs`
+  - **触らない**（仮コード、将来削除）
+  - 現在 `feature/webui-host-code` ブランチにのみ存在。本スペックの実装ブランチで統合戦略（rebase / cherry-pick / 既存ブランチを捨てて再実装）を決める
+- `moorestech_web/`（新規ディレクトリ、リポジトリルート直下）
+  - `webui/` サブディレクトリに TS/React/Vite 一式
+  - `node/` サブディレクトリに Node.js プラットフォーム別バイナリ

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/Util/PlaceSystemUtil.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/Util/PlaceSystemUtil.cs
@@ -84,62 +84,54 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.Util
         
         public static Vector3Int CalcPlacePoint(BlockMasterElement holdingBlock ,Vector3 hitPoint, int heightOffset, BlockDirection currentBlockDirection, BlockPreviewBoundingBoxSurface boundingBoxSurface)
         {
+            PreviewSurfaceType? surfaceType = boundingBoxSurface == null ? (PreviewSurfaceType?)null : boundingBoxSurface.PreviewSurfaceType;
+            return CalcPlacePoint(holdingBlock, hitPoint, heightOffset, currentBlockDirection, surfaceType);
+        }
+
+        public static Vector3Int CalcPlacePoint(BlockMasterElement holdingBlock, Vector3 hitPoint, int heightOffset, BlockDirection currentBlockDirection, PreviewSurfaceType? surfaceType)
+        {
             var rotateAction = currentBlockDirection.GetCoordinateConvertAction();
             var rotatedSize = rotateAction(holdingBlock.BlockSize).Abs();
-            
-            if (boundingBoxSurface == null)
+
+            if (surfaceType == null)
             {
                 var point = Vector3Int.zero;
                 point.x = Mathf.FloorToInt(hitPoint.x + (rotatedSize.x % 2 == 0 ? 0.5f : 0));
                 point.z = Mathf.FloorToInt(hitPoint.z + (rotatedSize.z % 2 == 0 ? 0.5f : 0));
                 point.y = Mathf.FloorToInt(hitPoint.y);
-                
+
                 point += new Vector3Int(0, heightOffset, 0);
                 point -= new Vector3Int(rotatedSize.x, 0, rotatedSize.z) / 2;
-                
+
                 return point;
             }
-            
-            switch (boundingBoxSurface.PreviewSurfaceType)
+
+            // 面に平行な軸（=面上のヒット位置）は偶数/奇数サイズで中央寄せスナップ
+            // Axes parallel to the face snap with size-parity center alignment
+            int SnapParallelX() => Mathf.FloorToInt(hitPoint.x + (rotatedSize.x % 2 == 0 ? 0.5f : 0)) - rotatedSize.x / 2;
+            int SnapParallelY() => Mathf.FloorToInt(hitPoint.y + (rotatedSize.y % 2 == 0 ? 0.5f : 0)) - rotatedSize.y / 2;
+            int SnapParallelZ() => Mathf.FloorToInt(hitPoint.z + (rotatedSize.z % 2 == 0 ? 0.5f : 0)) - rotatedSize.z / 2;
+
+            // 面に垂直な軸は面が整数グリッド上にあるためRoundToIntで浮動小数点誤差を吸収
+            // Axis perpendicular to the face uses RoundToInt to absorb floating-point imprecision (face is on integer grid)
+            switch (surfaceType.Value)
             {
                 case PreviewSurfaceType.YX_Origin:
-                    return new Vector3Int(
-                        Mathf.FloorToInt(hitPoint.x) - Mathf.FloorToInt(rotatedSize.x / 2f),
-                        Mathf.FloorToInt(hitPoint.y),
-                        Mathf.FloorToInt(hitPoint.z) - Mathf.RoundToInt(rotatedSize.z / 2f)
-                    );
+                    // 既存ブロックの-Z面 → 新ブロックは-Z方向へ、原点は face - size
+                    // -Z face → new block origin = face - size
+                    return new Vector3Int(SnapParallelX(), SnapParallelY(), Mathf.RoundToInt(hitPoint.z) - rotatedSize.z);
                 case PreviewSurfaceType.YX_Z:
-                    return new Vector3Int(
-                        Mathf.FloorToInt(hitPoint.x) - Mathf.FloorToInt(rotatedSize.x / 2f),
-                        Mathf.FloorToInt(hitPoint.y),
-                        Mathf.FloorToInt(hitPoint.z)
-                    );
+                    // 既存ブロックの+Z面 → 新ブロックは+Z方向へ、原点は face
+                    // +Z face → new block origin = face
+                    return new Vector3Int(SnapParallelX(), SnapParallelY(), Mathf.RoundToInt(hitPoint.z));
                 case PreviewSurfaceType.YZ_Origin:
-                    return new Vector3Int(
-                        Mathf.FloorToInt(hitPoint.x) - Mathf.RoundToInt(rotatedSize.x / 2f),
-                        Mathf.FloorToInt(hitPoint.y),
-                        Mathf.FloorToInt(hitPoint.z) - Mathf.FloorToInt(rotatedSize.z / 2f)
-                    );
+                    return new Vector3Int(Mathf.RoundToInt(hitPoint.x) - rotatedSize.x, SnapParallelY(), SnapParallelZ());
                 case PreviewSurfaceType.YZ_X:
-                    return new Vector3Int(
-                        Mathf.FloorToInt(hitPoint.x),
-                        Mathf.FloorToInt(hitPoint.y),
-                        Mathf.FloorToInt(hitPoint.z) - Mathf.FloorToInt(rotatedSize.z / 2f)
-                    );
-                
+                    return new Vector3Int(Mathf.RoundToInt(hitPoint.x), SnapParallelY(), SnapParallelZ());
                 case PreviewSurfaceType.XZ_Origin:
-                    return new Vector3Int(
-                        Mathf.FloorToInt(hitPoint.x) - Mathf.FloorToInt(rotatedSize.x / 2f),
-                        Mathf.FloorToInt(hitPoint.y) - rotatedSize.y,
-                        Mathf.FloorToInt(hitPoint.z) - Mathf.FloorToInt(rotatedSize.z / 2f)
-                    );
+                    return new Vector3Int(SnapParallelX(), Mathf.RoundToInt(hitPoint.y) - rotatedSize.y, SnapParallelZ());
                 case PreviewSurfaceType.XZ_Y:
-                    return new Vector3Int(
-                        Mathf.FloorToInt(hitPoint.x) - Mathf.FloorToInt(rotatedSize.x / 2f),
-                        Mathf.FloorToInt(hitPoint.y),
-                        Mathf.FloorToInt(hitPoint.z) - Mathf.FloorToInt(rotatedSize.z / 2f)
-                    );
-                
+                    return new Vector3Int(SnapParallelX(), Mathf.RoundToInt(hitPoint.y), SnapParallelZ());
                 default:
                     throw new ArgumentOutOfRangeException();
             }

--- a/moorestech_client/Assets/Scripts/Client.Tests/PlaceSystemUtilCalcPlacePointTest.cs
+++ b/moorestech_client/Assets/Scripts/Client.Tests/PlaceSystemUtilCalcPlacePointTest.cs
@@ -1,0 +1,203 @@
+using System;
+using Client.Game.InGame.BlockSystem.PlaceSystem.Common.PreviewObject;
+using Client.Game.InGame.BlockSystem.PlaceSystem.Util;
+using Game.Block.Interface;
+using Mooresmaster.Model.BlocksModule;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Client.Tests
+{
+    // 既存ブロックの各面にカーソルを合わせて隣接設置する際のプレビュー座標計算テスト
+    // Tests for preview coordinate calculation when placing adjacent to an existing block
+    public class PlaceSystemUtilCalcPlacePointTest
+    {
+        // 既存ブロックを world (5,5,5)〜(6,6,6) に1x1x1で置いた想定
+        // Assume existing 1x1x1 block occupies world (5,5,5)-(6,6,6)
+
+        private static BlockMasterElement MakeUnitBlock()
+        {
+            return new BlockMasterElement(
+                0,
+                Guid.Empty,
+                "TestBlock",
+                "TestBlockType",
+                Guid.Empty,
+                new Vector3Int(1, 1, 1),
+                null,
+                null,
+                null,
+                null,
+                true
+            );
+        }
+
+        [Test]
+        public void YX_Origin_北面_に隣接設置_Z方向に重ならないこと()
+        {
+            // 既存ブロックの-Z面 (z=5) にヒット → 新ブロックは z=4 に置かれるべき
+            // Hit on -Z face of existing block → new block origin should be z=4
+            var hitPoint = new Vector3(5.5f, 5.5f, 5.0f);
+
+            var pos = PlaceSystemUtil.CalcPlacePoint(MakeUnitBlock(), hitPoint, 0, BlockDirection.North, PreviewSurfaceType.YX_Origin);
+
+            Assert.AreEqual(new Vector3Int(5, 5, 4), pos);
+        }
+
+        [Test]
+        public void YX_Z_南面_に隣接設置()
+        {
+            // 既存ブロックの+Z面 (z=6) にヒット → 新ブロックは z=6 に置かれるべき
+            // Hit on +Z face → new block origin at z=6
+            var hitPoint = new Vector3(5.5f, 5.5f, 6.0f);
+
+            var pos = PlaceSystemUtil.CalcPlacePoint(MakeUnitBlock(), hitPoint, 0, BlockDirection.North, PreviewSurfaceType.YX_Z);
+
+            Assert.AreEqual(new Vector3Int(5, 5, 6), pos);
+        }
+
+        [Test]
+        public void YZ_Origin_西面_に隣接設置_X方向に重ならないこと()
+        {
+            // 既存ブロックの-X面 (x=5) にヒット → 新ブロックは x=4 に置かれるべき
+            // Hit on -X face → new block origin at x=4
+            var hitPoint = new Vector3(5.0f, 5.5f, 5.5f);
+
+            var pos = PlaceSystemUtil.CalcPlacePoint(MakeUnitBlock(), hitPoint, 0, BlockDirection.North, PreviewSurfaceType.YZ_Origin);
+
+            Assert.AreEqual(new Vector3Int(4, 5, 5), pos);
+        }
+
+        [Test]
+        public void YZ_X_東面_に隣接設置()
+        {
+            // 既存ブロックの+X面 (x=6) にヒット → 新ブロックは x=6 に置かれるべき
+            var hitPoint = new Vector3(6.0f, 5.5f, 5.5f);
+
+            var pos = PlaceSystemUtil.CalcPlacePoint(MakeUnitBlock(), hitPoint, 0, BlockDirection.North, PreviewSurfaceType.YZ_X);
+
+            Assert.AreEqual(new Vector3Int(6, 5, 5), pos);
+        }
+
+        [Test]
+        public void XZ_Y_上面_に隣接設置()
+        {
+            // 既存ブロックの+Y面 (y=6) にヒット → 新ブロックは y=6 に置かれるべき
+            var hitPoint = new Vector3(5.5f, 6.0f, 5.5f);
+
+            var pos = PlaceSystemUtil.CalcPlacePoint(MakeUnitBlock(), hitPoint, 0, BlockDirection.North, PreviewSurfaceType.XZ_Y);
+
+            Assert.AreEqual(new Vector3Int(5, 6, 5), pos);
+        }
+
+        [Test]
+        public void XZ_Origin_下面_に隣接設置_Y方向に隙間が空かないこと()
+        {
+            // 既存ブロックの-Y面 (y=5) にヒット → 新ブロックは y=4 に置かれるべき
+            // Hit on -Y face → new block origin at y=4
+            var hitPoint = new Vector3(5.5f, 5.0f, 5.5f);
+
+            var pos = PlaceSystemUtil.CalcPlacePoint(MakeUnitBlock(), hitPoint, 0, BlockDirection.North, PreviewSurfaceType.XZ_Origin);
+
+            Assert.AreEqual(new Vector3Int(5, 4, 5), pos);
+        }
+
+        [Test]
+        public void XZ_Origin_下面_浮動小数点誤差_4_9999_でもギャップが出ないこと()
+        {
+            // 下から当てたレイは浮動小数点精度により hit.y が 5.0 ではなく 4.9999... を返すことがある
+            // → FloorToIntで切り捨てると1ブロック下にズレてしまうバグの再現
+            // Ray from below may return hit.y slightly under 5.0 due to floating point imprecision
+            // → FloorToInt would drop it one block too low
+            var hitPoint = new Vector3(5.5f, 4.9999f, 5.5f);
+
+            var pos = PlaceSystemUtil.CalcPlacePoint(MakeUnitBlock(), hitPoint, 0, BlockDirection.North, PreviewSurfaceType.XZ_Origin);
+
+            Assert.AreEqual(new Vector3Int(5, 4, 5), pos);
+        }
+
+        [Test]
+        public void YX_Origin_北面_浮動小数点誤差_でもオーバーラップしないこと()
+        {
+            // -Z側から当てたレイは hit.z が 4.9999... を返すことがある
+            var hitPoint = new Vector3(5.5f, 5.5f, 4.9999f);
+
+            var pos = PlaceSystemUtil.CalcPlacePoint(MakeUnitBlock(), hitPoint, 0, BlockDirection.North, PreviewSurfaceType.YX_Origin);
+
+            Assert.AreEqual(new Vector3Int(5, 5, 4), pos);
+        }
+
+        [Test]
+        public void YZ_Origin_西面_浮動小数点誤差_でもオーバーラップしないこと()
+        {
+            // -X側から当てたレイは hit.x が 4.9999... を返すことがある
+            var hitPoint = new Vector3(4.9999f, 5.5f, 5.5f);
+
+            var pos = PlaceSystemUtil.CalcPlacePoint(MakeUnitBlock(), hitPoint, 0, BlockDirection.North, PreviewSurfaceType.YZ_Origin);
+
+            Assert.AreEqual(new Vector3Int(4, 5, 5), pos);
+        }
+
+        // 境界ケース: RoundToIntの±0.5仮定を、面座標を挟んだ両側でチェック
+        // Boundary cases: verify the RoundToInt ±0.5 assumption on both sides of the face coordinate
+
+        [Test]
+        public void XZ_Origin_下面_hit_5_0001_でも境界を超えないこと()
+        {
+            // 面座標+ε側(hit=5.0001)でも正しく y=4 に落ちること
+            var hitPoint = new Vector3(5.5f, 5.0001f, 5.5f);
+
+            var pos = PlaceSystemUtil.CalcPlacePoint(MakeUnitBlock(), hitPoint, 0, BlockDirection.North, PreviewSurfaceType.XZ_Origin);
+
+            Assert.AreEqual(new Vector3Int(5, 4, 5), pos);
+        }
+
+        [Test]
+        public void XZ_Y_上面_hit_5_9999_でも境界を超えないこと()
+        {
+            // 上面 y=6 の面座標-ε側(hit=5.9999)でも y=6 に落ちること
+            // Upper face at y=6, hit just below (5.9999) should still resolve to y=6
+            var hitPoint = new Vector3(5.5f, 5.9999f, 5.5f);
+
+            var pos = PlaceSystemUtil.CalcPlacePoint(MakeUnitBlock(), hitPoint, 0, BlockDirection.North, PreviewSurfaceType.XZ_Y);
+
+            Assert.AreEqual(new Vector3Int(5, 6, 5), pos);
+        }
+
+        [Test]
+        public void YX_Z_南面_hit_5_9999_でも境界を超えないこと()
+        {
+            // 南面 z=6 の -ε側(hit=5.9999) でも z=6 に解決すること
+            var hitPoint = new Vector3(5.5f, 5.5f, 5.9999f);
+
+            var pos = PlaceSystemUtil.CalcPlacePoint(MakeUnitBlock(), hitPoint, 0, BlockDirection.North, PreviewSurfaceType.YX_Z);
+
+            Assert.AreEqual(new Vector3Int(5, 5, 6), pos);
+        }
+
+        [Test]
+        public void YZ_X_東面_hit_5_9999_でも境界を超えないこと()
+        {
+            // 東面 x=6 の -ε側(hit=5.9999) でも x=6 に解決すること
+            var hitPoint = new Vector3(5.9999f, 5.5f, 5.5f);
+
+            var pos = PlaceSystemUtil.CalcPlacePoint(MakeUnitBlock(), hitPoint, 0, BlockDirection.North, PreviewSurfaceType.YZ_X);
+
+            Assert.AreEqual(new Vector3Int(6, 5, 5), pos);
+        }
+
+        // surfaceType==null (地面ヒット) のフォールバック経路もテスト
+        // Ground-hit fallback path where surfaceType is null
+        [Test]
+        public void surfaceType_null_地面ヒット時_中央寄せスナップ()
+        {
+            // 1x1x1ブロック(奇数サイズ)ではheightOffset=0でhit位置をそのまま使う
+            // For unit block (odd size), heightOffset=0 uses hit position as-is
+            var hitPoint = new Vector3(5.3f, 4.0f, 5.7f);
+
+            var pos = PlaceSystemUtil.CalcPlacePoint(MakeUnitBlock(), hitPoint, 0, BlockDirection.North, (PreviewSurfaceType?)null);
+
+            Assert.AreEqual(new Vector3Int(5, 4, 5), pos);
+        }
+    }
+}

--- a/moorestech_client/Assets/Scripts/Client.Tests/PlaceSystemUtilCalcPlacePointTest.cs.meta
+++ b/moorestech_client/Assets/Scripts/Client.Tests/PlaceSystemUtilCalcPlacePointTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a3832480e3f2b4379b504e9a4a6a9bb3

--- a/moorestech_server/Assets/Scripts/Core.Master/_CompileRequester.cs
+++ b/moorestech_server/Assets/Scripts/Core.Master/_CompileRequester.cs
@@ -5,5 +5,5 @@ public class CompileRequester
 {
 // スキーマを更新したら、こちらの更新もコミットしてください。
 // If you update the schema, please also commit this update.
-    private const string dummyText = "2026/04/22 12:33:05";
+    private const string dummyText = "2026/04/22 16:40:55";
 }


### PR DESCRIPTION
## Summary
- ブロック隣接設置時の `CalcPlacePoint` を面軸ごとに分離し、浮動小数点誤差で1ブロックずれる問題を修正（面に平行な軸は中央寄せスナップ、垂直な軸は `RoundToInt` で整数グリッド吸収）
- `PreviewSurfaceType?` を受け取るオーバーロードを追加してテスト容易性を向上
- `PlaceSystemUtilCalcPlacePointTest` を新規追加し、6面 + 浮動小数点±ε境界 + ground-hitフォールバックをカバー
- Web UI 基盤の設計仕様（e21fb4fdc）と実装プラン（074ffa77f）をドキュメントとして追加

## Test plan
- [ ] `uloop run-tests --project-path ./moorestech_client --filter-type regex --filter-value "PlaceSystemUtilCalcPlacePointTest"` が全ケース通過すること
- [ ] 既存ブロックの6面（±X/±Y/±Z）にカーソルを合わせて隣接設置し、重なり・隙間なく配置されること
- [ ] 下から上面レイ（hit.y≒4.9999）で下面に隣接設置しても期待座標に入ること
- [ ] 地面ヒット（surfaceType null）経路の通常設置が従来どおり動作すること

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced block placement accuracy and precision handling when placing blocks on adjacent surfaces. Improved floating-point rounding calculations for consistent placement behavior across different block orientations and surface types.

* **Tests**
  * Added comprehensive test coverage for block placement validation across various scenarios and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->