### PR TITLE
Feature/station block del validation

### DIFF
--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/Block/BlockGameObjectChild.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/Block/BlockGameObjectChild.cs
@@ -56,6 +56,9 @@ namespace Client.Game.InGame.Block
             var response = await ClientContext.VanillaApi.Response.BlockRemove(blockPosition, this.GetCancellationTokenOnDestroy());
             _isDeleteRequesting = false;
 
+
+            // TODO 基盤通知システムができたらそちらの方に移行する
+
             // 削除拒否理由を既存の削除UIツールチップに渡す
             // Pass the denial reason to the existing delete UI tooltip flow.
             if (response == null || response.Success) return;

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/Block/BlockGameObjectChild.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/Block/BlockGameObjectChild.cs
@@ -1,12 +1,19 @@
 using Client.Game.InGame.Context;
 using Client.Game.InGame.UI.UIState.State;
+using Cysharp.Threading.Tasks;
+using Server.Protocol.PacketResponse;
 using UnityEngine;
 
 namespace Client.Game.InGame.Block
 {
     public class BlockGameObjectChild : MonoBehaviour, IDeleteTarget
     {
+        private const float RemoveDeniedReasonDisplaySeconds = 2f;
+
         public BlockGameObject BlockGameObject { get; private set; }
+        private bool _isDeleteRequesting;
+        private string _removeDeniedReason;
+        private float _removeDeniedReasonUntil;
         
         public void Init(BlockGameObject blockGameObject)
         {
@@ -25,14 +32,55 @@ namespace Client.Game.InGame.Block
         
         public bool IsRemovable(out string reason)
         {
+            if (!string.IsNullOrEmpty(_removeDeniedReason) && Time.time < _removeDeniedReasonUntil)
+            {
+                reason = _removeDeniedReason;
+                return false;
+            }
+
             reason = null;
             return true;
         }
         
         public void Delete()
         {
+            if (_isDeleteRequesting) return;
+
+            DeleteAsync().Forget();
+        }
+
+        private async UniTask DeleteAsync()
+        {
+            _isDeleteRequesting = true;
             var blockPosition = BlockGameObject.BlockPosInfo.OriginalPos;
-            ClientContext.VanillaApi.SendOnly.BlockRemove(blockPosition);
+            var response = await ClientContext.VanillaApi.Response.BlockRemove(blockPosition, this.GetCancellationTokenOnDestroy());
+            _isDeleteRequesting = false;
+
+            // 削除拒否理由を既存の削除UIツールチップに渡す
+            // Pass the denial reason to the existing delete UI tooltip flow.
+            if (response == null || response.Success) return;
+            SetRemoveDeniedReason(response.FailureReason);
+        }
+
+        private void SetRemoveDeniedReason(RemoveBlockProtocol.RemoveBlockFailureReason failureReason)
+        {
+            var message = GetRemoveDeniedReasonMessage(failureReason);
+            if (message == null) return;
+
+            // 一定時間だけIsRemovableから理由を返して表示する
+            // Return the reason from IsRemovable for a short display window.
+            _removeDeniedReason = message;
+            _removeDeniedReasonUntil = Time.time + RemoveDeniedReasonDisplaySeconds;
+        }
+
+        private static string GetRemoveDeniedReasonMessage(RemoveBlockProtocol.RemoveBlockFailureReason failureReason)
+        {
+            return failureReason switch
+            {
+                RemoveBlockProtocol.RemoveBlockFailureReason.NodeInUseByTrain => "レール上に車両があります。",
+                RemoveBlockProtocol.RemoveBlockFailureReason.Unknown => "ブロックを削除できませんでした。",
+                _ => null,
+            };
         }
     }
 }

--- a/moorestech_client/Assets/Scripts/Client.Network/API/VanillaApiSendOnly.cs
+++ b/moorestech_client/Assets/Scripts/Client.Network/API/VanillaApiSendOnly.cs
@@ -44,12 +44,6 @@ namespace Client.Network.API
             _packetSender.Send(request);
         }
         
-        public void BlockRemove(Vector3Int pos)
-        {
-            var request = new RemoveBlockProtocol.RemoveBlockProtocolMessagePack(_playerId, pos);
-            _packetSender.Send(request);
-        }
-        
         public void SendPlayerPosition(Vector3 pos)
         {
             var request = new SetPlayerCoordinateProtocol.PlayerCoordinateSendProtocolMessagePack(_playerId, pos);

--- a/moorestech_client/Assets/Scripts/Client.Network/API/VanillaApiWithResponse.cs
+++ b/moorestech_client/Assets/Scripts/Client.Network/API/VanillaApiWithResponse.cs
@@ -196,6 +196,12 @@ namespace Client.Network.API
             
             return response.State;
         }
+
+        public async UniTask<RemoveBlockProtocol.RemoveBlockResponseMessagePack> BlockRemove(Vector3Int pos, CancellationToken ct)
+        {
+            var request = new RemoveBlockProtocol.RemoveBlockProtocolMessagePack(_playerConnectionSetting.PlayerId, pos);
+            return await _packetExchangeManager.GetPacketResponse<RemoveBlockProtocol.RemoveBlockResponseMessagePack>(request, ct);
+        }
         
         // Renamed method to reflect its broader scope
         public async UniTask<UnlockStateResponse> GetUnlockState(CancellationToken ct)

--- a/moorestech_server/Assets/Scripts/Game.Train/RailPositions/TrainRailPositionManager.cs
+++ b/moorestech_server/Assets/Scripts/Game.Train/RailPositions/TrainRailPositionManager.cs
@@ -45,18 +45,20 @@ namespace Game.Train.RailPositions
             }
         }
         // 全てのrailpositionに対して削除したいノードが1つもなかったらtrue
+        // Return true only when no registered rail position contains the node.
         public bool CanRemoveNode(RailNode nodeToRemove) 
         {
-            bool found = false;
             foreach (var position in _list)
             {
+                // 対象ノードを列車が保持しているなら削除不可にする
+                // Reject removal when any train position keeps the target node.
                 if (position.ContainsNode(nodeToRemove))
                 {
-                    found = true;
-                    break;
+                    return false;
                 }
             }
-            return found;
+
+            return true;
         }
         // 全てのrailpositionに対して削除したい辺が1つもなかったらtrue
         public bool CanRemoveEdge(RailNode from, RailNode to)

--- a/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/RemoveBlockProtocol.cs
+++ b/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/RemoveBlockProtocol.cs
@@ -2,10 +2,12 @@
 using System.Collections.Generic;
 using Core.Item.Interface;
 using Core.Master;
+using Game.Block.Blocks.TrainRail;
 using Game.Block.Interface;
 using Game.Block.Interface.Component;
 using Game.Context;
 using Game.PlayerInventory.Interface;
+using Game.Train.RailPositions;
 using Game.World.Interface.DataStore;
 using MessagePack;
 using Microsoft.Extensions.DependencyInjection;
@@ -19,11 +21,13 @@ namespace Server.Protocol.PacketResponse
         public const string ProtocolTag = "va:removeBlock";
         
         private readonly IPlayerInventoryDataStore _playerInventoryDataStore;
+        private readonly TrainRailPositionManager _railPositionManager;
         
         
         public RemoveBlockProtocol(ServiceProvider serviceProvider)
         {
             _playerInventoryDataStore = serviceProvider.GetService<IPlayerInventoryDataStore>();
+            _railPositionManager = serviceProvider.GetService<TrainRailPositionManager>();
         }
         
         public ProtocolMessagePackBase GetResponse(byte[] payload)
@@ -33,6 +37,7 @@ namespace Server.Protocol.PacketResponse
             var block = ServerContext.WorldBlockDatastore.GetBlock(data.Pos);
             if (block == null) return null;
             var itemId = MasterHolder.BlockMaster.GetBlockMaster(block.BlockId).ItemGuid;
+            if (!CanManualRemoveBlock(block)) return null;
                 
             // 破壊した後のアイテムをインベントリに挿入できるかチェック
             // Check if items after destruction can be inserted into inventory
@@ -47,6 +52,31 @@ namespace Server.Protocol.PacketResponse
             return null;
             
             #region Internal
+
+            bool CanManualRemoveBlock(IBlock targetBlock)
+            {
+                var railComponents = targetBlock.ComponentManager.GetComponents<RailComponent>();
+                if (railComponents.Count == 0) return true;
+
+                // レール系ブロックは列車位置が保持するノードを壊せない
+                // Rail blocks cannot remove nodes currently held by train positions.
+                for (var i = 0; i < railComponents.Count; i++)
+                {
+                    if (!CanManualRemoveRailComponent(railComponents[i])) return false;
+                }
+
+                return true;
+            }
+
+            bool CanManualRemoveRailComponent(RailComponent railComponent)
+            {
+                // 橋脚削除はFront/Back両ノードの削除と同義として扱う
+                // Removing a pier is equivalent to removing both front and back nodes.
+                if (!_railPositionManager.CanRemoveNode(railComponent.FrontNode)) return false;
+                if (!_railPositionManager.CanRemoveNode(railComponent.BackNode)) return false;
+
+                return true;
+            }
             
             bool TryInsertRefundItems(out List<IItemStack> items)
             {

--- a/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/RemoveBlockProtocol.cs
+++ b/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/RemoveBlockProtocol.cs
@@ -35,21 +35,20 @@ namespace Server.Protocol.PacketResponse
             var data = MessagePackSerializer.Deserialize<RemoveBlockProtocolMessagePack>(payload);
             
             var block = ServerContext.WorldBlockDatastore.GetBlock(data.Pos);
-            if (block == null) return null;
+            if (block == null) return RemoveBlockResponseMessagePack.CreateFailure(RemoveBlockFailureReason.Unknown);
             var itemId = MasterHolder.BlockMaster.GetBlockMaster(block.BlockId).ItemGuid;
-            if (!CanManualRemoveBlock(block)) return null;
+            if (!CanManualRemoveBlock(block)) return RemoveBlockResponseMessagePack.CreateFailure(RemoveBlockFailureReason.NodeInUseByTrain);
                 
             // 破壊した後のアイテムをインベントリに挿入できるかチェック
             // Check if items after destruction can be inserted into inventory
-            if (!TryInsertRefundItems(out var refundItems)) return null;
+            if (!TryInsertRefundItems(out var refundItems)) return RemoveBlockResponseMessagePack.CreateFailure(RemoveBlockFailureReason.Unknown);
             
             // 削除処理
             // Deletion process
             ServerContext.WorldBlockDatastore.RemoveBlock(data.Pos, BlockRemoveReason.ManualRemove);
             InsertItemsToPlayerInventory(refundItems);
             
-            
-            return null;
+            return RemoveBlockResponseMessagePack.CreateSuccess();
             
             #region Internal
 
@@ -139,6 +138,40 @@ namespace Server.Protocol.PacketResponse
                 PlayerId = playerId;
                 Pos = new Vector3IntMessagePack(pos);
             }
+        }
+
+        [MessagePackObject]
+        public class RemoveBlockResponseMessagePack : ProtocolMessagePackBase
+        {
+            [Key(2)] public bool Success { get; set; }
+            [Key(3)] public RemoveBlockFailureReason FailureReason { get; set; }
+
+            [Obsolete("デシリアライズ用のコンストラクタです。基本的に使用しないでください。")]
+            public RemoveBlockResponseMessagePack() { Tag = ProtocolTag; }
+
+            public RemoveBlockResponseMessagePack(bool success, RemoveBlockFailureReason failureReason)
+            {
+                Tag = ProtocolTag;
+                Success = success;
+                FailureReason = failureReason;
+            }
+
+            public static RemoveBlockResponseMessagePack CreateSuccess()
+            {
+                return new RemoveBlockResponseMessagePack(true, RemoveBlockFailureReason.None);
+            }
+
+            public static RemoveBlockResponseMessagePack CreateFailure(RemoveBlockFailureReason failureReason)
+            {
+                return new RemoveBlockResponseMessagePack(false, failureReason);
+            }
+        }
+
+        public enum RemoveBlockFailureReason
+        {
+            None,
+            NodeInUseByTrain,
+            Unknown,
         }
     }
 }

--- a/moorestech_server/Assets/Scripts/Tests/CombinedTest/Server/PacketTest/RemoveBlockProtocolTest.cs
+++ b/moorestech_server/Assets/Scripts/Tests/CombinedTest/Server/PacketTest/RemoveBlockProtocolTest.cs
@@ -1,17 +1,22 @@
 using System.Collections.Generic;
 using System.Linq;
 using Core.Master;
+using Game.Block.Blocks.TrainRail;
 using Game.Block.Interface;
 using Game.Block.Interface.Component;
 using Game.Block.Interface.Extension;
 using Game.Context;
 using Game.PlayerInventory.Interface;
+using Game.Train.RailGraph;
+using Game.Train.RailPositions;
+using Game.Train.Unit;
 using Game.World.Interface.DataStore;
 using MessagePack;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using Server.Boot;
 using Tests.Module.TestMod;
+using Tests.Util;
 using UnityEngine;
 using static Server.Protocol.PacketResponse.RemoveBlockProtocol;
 using System;
@@ -143,11 +148,74 @@ namespace Tests.CombinedTest.Server.PacketTest
             //ブロックが削除できていないことを検証
             Assert.True(worldBlock.Exists(new Vector3Int(0, 0)));
         }
+
+        [Test]
+        public void TrainRailBlockInUseByTrainCannotBeRemovedTest()
+        {
+            var environment = TrainTestHelper.CreateEnvironment();
+            var worldBlock = environment.WorldBlockDatastore;
+            var railPos = new Vector3Int(0, 0, 0);
+
+            // 列車が保持するノードを含む橋脚を準備する
+            // Prepare a pier whose node is held by a train position.
+            var railA = TrainTestHelper.PlaceRail(environment, railPos, BlockDirection.East, out _);
+            var railB = TrainTestHelper.PlaceRail(environment, new Vector3Int(1, 0, 0), BlockDirection.East);
+            ConnectBidirectional(railA, railB, 100);
+
+            // RailPositionを登録して手動削除ガードの監視対象にする
+            // Register a RailPosition so the manual removal guard can observe it.
+            CreateTrainOnNode(environment, railA.FrontNode);
+            environment.PacketResponseCreator.GetPacketResponse(RemoveBlock(railPos, PlayerId));
+
+            // ブロックとレール接続が残り、橋脚削除で列車位置が壊れないことを確認する
+            // Verify the block and rail connection remain so train position is preserved.
+            Assert.True(worldBlock.Exists(railPos));
+            Assert.AreNotEqual(-1, railA.FrontNode.GetDistanceToNode(railB.FrontNode));
+        }
+
+        [Test]
+        public void TrainRailBlockWithoutTrainCanBeRemovedTest()
+        {
+            var environment = TrainTestHelper.CreateEnvironment();
+            var worldBlock = environment.WorldBlockDatastore;
+            var railPos = new Vector3Int(0, 0, 0);
+
+            // 列車に使われていない橋脚は通常どおり削除できる
+            // A pier unused by trains can still be removed normally.
+            TrainTestHelper.PlaceRail(environment, railPos, BlockDirection.East);
+            environment.PacketResponseCreator.GetPacketResponse(RemoveBlock(railPos, PlayerId));
+
+            Assert.False(worldBlock.Exists(railPos));
+        }
         
         
         private byte[] RemoveBlock(Vector3Int pos, int playerId)
         {
             return MessagePackSerializer.Serialize(new RemoveBlockProtocolMessagePack(playerId, pos));
+        }
+
+        private static void ConnectBidirectional(RailComponent from, RailComponent to, int distance)
+        {
+            // 表裏の方向ペアを接続し、通常のレール接続と同じ形にする
+            // Connect both directional pairs to mirror normal rail connection shape.
+            from.FrontNode.ConnectNode(to.FrontNode, distance);
+            to.FrontNode.ConnectNode(from.FrontNode, distance);
+            to.BackNode.ConnectNode(from.BackNode, distance);
+            from.BackNode.ConnectNode(to.BackNode, distance);
+        }
+
+        private static TrainUnit CreateTrainOnNode(TrainTestEnvironment environment, IRailNode node)
+        {
+            var (trainCar, _) = TrainTestCarFactory.CreateTrainCarWithItemContainer(0, 0, 1, 0, true);
+            var railPosition = new RailPosition(new List<IRailNode> { node }, trainCar.Length, 0);
+
+            // TrainUnit生成時にTrainRailPositionManagerへRailPositionが登録される
+            // TrainUnit construction registers the RailPosition with TrainRailPositionManager.
+            return new TrainUnit(
+                railPosition,
+                new List<TrainCar> { trainCar },
+                environment.GetTrainRailPositionManager(),
+                environment.GetTrainDiagramManager());
         }
     }
 }

--- a/moorestech_server/Assets/Scripts/Tests/CombinedTest/Server/PacketTest/RemoveBlockProtocolTest.cs
+++ b/moorestech_server/Assets/Scripts/Tests/CombinedTest/Server/PacketTest/RemoveBlockProtocolTest.cs
@@ -46,7 +46,9 @@ namespace Tests.CombinedTest.Server.PacketTest
 
             // プロトコルを使ってブロックを削除
             // Remove block using protocol
-            packet.GetPacketResponse(RemoveBlock(new Vector3Int(0, 0), PlayerId));
+            var response = GetRemoveBlockResponse(packet.GetPacketResponse(RemoveBlock(new Vector3Int(0, 0), PlayerId)));
+            Assert.True(response.Success);
+            Assert.AreEqual(RemoveBlockFailureReason.None, response.FailureReason);
 
             // 削除したブロックがワールドに存在しないことを確認
             // Verify removed block no longer exists in world
@@ -103,7 +105,9 @@ namespace Tests.CombinedTest.Server.PacketTest
 
             // プロトコルを使ってブロックを削除
             // Try to remove block using protocol
-            packet.GetPacketResponse(RemoveBlock(new Vector3Int(0, 0), PlayerId));
+            var response = GetRemoveBlockResponse(packet.GetPacketResponse(RemoveBlock(new Vector3Int(0, 0), PlayerId)));
+            Assert.False(response.Success);
+            Assert.AreEqual(RemoveBlockFailureReason.Unknown, response.FailureReason);
 
             // 新しい仕様：全てのアイテムが入らない場合はブロックは削除されない
             // New spec: Block is not removed if not all items can fit
@@ -142,7 +146,9 @@ namespace Tests.CombinedTest.Server.PacketTest
             
             
             //プロトコルを使ってブロックを削除
-            packet.GetPacketResponse(RemoveBlock(new Vector3Int(0, 0), PlayerId));
+            var response = GetRemoveBlockResponse(packet.GetPacketResponse(RemoveBlock(new Vector3Int(0, 0), PlayerId)));
+            Assert.False(response.Success);
+            Assert.AreEqual(RemoveBlockFailureReason.Unknown, response.FailureReason);
             
             
             //ブロックが削除できていないことを検証
@@ -165,7 +171,9 @@ namespace Tests.CombinedTest.Server.PacketTest
             // RailPositionを登録して手動削除ガードの監視対象にする
             // Register a RailPosition so the manual removal guard can observe it.
             CreateTrainOnNode(environment, railA.FrontNode);
-            environment.PacketResponseCreator.GetPacketResponse(RemoveBlock(railPos, PlayerId));
+            var response = GetRemoveBlockResponse(environment.PacketResponseCreator.GetPacketResponse(RemoveBlock(railPos, PlayerId)));
+            Assert.False(response.Success);
+            Assert.AreEqual(RemoveBlockFailureReason.NodeInUseByTrain, response.FailureReason);
 
             // ブロックとレール接続が残り、橋脚削除で列車位置が壊れないことを確認する
             // Verify the block and rail connection remain so train position is preserved.
@@ -183,7 +191,9 @@ namespace Tests.CombinedTest.Server.PacketTest
             // 列車に使われていない橋脚は通常どおり削除できる
             // A pier unused by trains can still be removed normally.
             TrainTestHelper.PlaceRail(environment, railPos, BlockDirection.East);
-            environment.PacketResponseCreator.GetPacketResponse(RemoveBlock(railPos, PlayerId));
+            var response = GetRemoveBlockResponse(environment.PacketResponseCreator.GetPacketResponse(RemoveBlock(railPos, PlayerId)));
+            Assert.True(response.Success);
+            Assert.AreEqual(RemoveBlockFailureReason.None, response.FailureReason);
 
             Assert.False(worldBlock.Exists(railPos));
         }
@@ -192,6 +202,12 @@ namespace Tests.CombinedTest.Server.PacketTest
         private byte[] RemoveBlock(Vector3Int pos, int playerId)
         {
             return MessagePackSerializer.Serialize(new RemoveBlockProtocolMessagePack(playerId, pos));
+        }
+
+        private static RemoveBlockResponseMessagePack GetRemoveBlockResponse(List<byte[]> responsePackets)
+        {
+            Assert.AreEqual(1, responsePackets.Count);
+            return MessagePackSerializer.Deserialize<RemoveBlockResponseMessagePack>(responsePackets[0]);
         }
 
         private static void ConnectBidirectional(RailComponent from, RailComponent to, int distance)


### PR DESCRIPTION
橋脚を消すとチェックをすり抜けて消せないレールを消せる　の対処とレスポンスあり応答

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Block removal now displays reasons when denial occurs.
  * Blocks actively used by trains on rails cannot be removed.

* **Bug Fixes**
  * Block removal now properly awaits server responses, ensuring reliable feedback instead of fire-and-forget behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moorestech/moorestech/pull/886)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->