### PR TITLE
列車プラットフォームのインベントリ更新イベントをコンテナObservable経由に統合

### DIFF
--- a/moorestech_server/Assets/Scripts/Game.Block/Blocks/TrainRail/ContainerComponents/TrainPlatformItemContainerComponent.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Blocks/TrainRail/ContainerComponents/TrainPlatformItemContainerComponent.cs
@@ -8,9 +8,11 @@ using Game.Block.Event;
 using Game.Block.Interface;
 using Game.Block.Interface.Component;
 using Game.Block.Interface.Event;
+using Game.Context;
 using Game.Train.Unit.Containers;
 using JetBrains.Annotations;
 using MessagePack;
+using UniRx;
 
 namespace Game.Block.Blocks.TrainRail.ContainerComponents
 {
@@ -25,7 +27,7 @@ namespace Game.Block.Blocks.TrainRail.ContainerComponents
         private readonly IBlockInventoryInserter _blockInventoryInserter;
         private readonly BlockOpenableInventoryUpdateEvent _blockInventoryUpdateEvent;
         private readonly int _slotsCount;
-        private IItemStack[] _previousInventorySnapshot;
+        private IDisposable _slotChangedSubscription;
 
         public TrainPlatformItemContainerComponent(BlockInstanceId blockInstanceId, BlockOpenableInventoryUpdateEvent blockInventoryUpdateEvent, TrainPlatformDockingComponent dockingComponent, TrainPlatformTransferComponent transferComponent, int slotsCount, IBlockInventoryInserter blockInventoryInserter)
         {
@@ -36,7 +38,7 @@ namespace Game.Block.Blocks.TrainRail.ContainerComponents
             _slotsCount = slotsCount;
             _blockInventoryInserter = blockInventoryInserter;
             Container = ItemTrainCarContainer.CreateWithEmptySlots(_slotsCount);
-            InitializeSnapshot();
+            SubscribeContainerSlotChanges();
         }
 
         public TrainPlatformItemContainerComponent(BlockInstanceId blockInstanceId, BlockOpenableInventoryUpdateEvent blockInventoryUpdateEvent, TrainPlatformDockingComponent dockingComponent, TrainPlatformTransferComponent transferComponent, int slotsCount, IBlockInventoryInserter blockInventoryInserter, Dictionary<string, string> componentStates)
@@ -50,9 +52,9 @@ namespace Game.Block.Blocks.TrainRail.ContainerComponents
             Container = ItemTrainCarContainer.CreateWithEmptySlots(_slotsCount);
 
             LoadContainer();
-            // 保存データ復元時はイベント発火不要なのでスナップショットだけ取り直す
-            // Loading from save data must not raise events; only re-seed the snapshot
-            InitializeSnapshot();
+            // 復元後のコンテナを購読し直す。ロード経路はSetItemWithoutEventで埋まるので発火しない
+            // Re-subscribe to the restored container; load path uses SetItemWithoutEvent so no events fire
+            SubscribeContainerSlotChanges();
 
             #region Internal
 
@@ -75,195 +77,149 @@ namespace Game.Block.Blocks.TrainRail.ContainerComponents
             PushItemsToAdjacentBlocks();
 
             var dockedCar = _dockingComponent.DockedTrainCar;
-            if (dockedCar == null)
-            {
-                EmitChangedSlots();
-                return;
-            }
-
-            if (!IsTargetContainer(out var targetContainer))
-            {
-                EmitChangedSlots();
-                return;
-            }
+            if (dockedCar == null) return;
+            if (!IsTargetContainer(out var targetContainer)) return;
 
             switch (_transferComponent.Mode)
             {
                 case TrainPlatformTransferComponent.TransferMode.LoadToTrain:
-                    {
-                        if (!CanTransfer(targetContainer, Container))
-                        {
-                            _dockingComponent.StartRetracting();
-                            break;
-                        }
-
-                        _dockingComponent.StartExtending();
-
-                        if (_dockingComponent.ArmState != ArmState.Extended) break;
-
-                        if (Container.IsEmpty())
-                        {
-                            _dockingComponent.StartRetracting();
-                            break;
-                        }
-
-                        if (targetContainer == null)
-                        {
-                            dockedCar.SetContainer(Container);
-                            Container = ItemTrainCarContainer.CreateWithEmptySlots(_slotsCount);
-                            _dockingComponent.StartRetracting();
-                            break;
-                        }
-
-                        targetContainer.MergeFrom(Container);
-
-                        _dockingComponent.StartRetracting();
-                        break;
-                    }
+                    HandleLoadToTrain();
+                    break;
                 case TrainPlatformTransferComponent.TransferMode.UnloadToPlatform:
-                    {
-                        if (!CanTransfer(Container, targetContainer))
-                        {
-                            _dockingComponent.StartRetracting();
-                            break;
-                        }
-
-                        _dockingComponent.StartExtending();
-
-                        if (_dockingComponent.ArmState != ArmState.Extended) break;
-
-                        if (targetContainer == null || targetContainer.IsEmpty())
-                        {
-                            _dockingComponent.StartRetracting();
-                            break;
-                        }
-
-                        Container.MergeFrom(targetContainer);
-
-                        _dockingComponent.StartRetracting();
-                        break;
-                    }
+                    HandleUnloadToPlatform();
+                    break;
                 default:
                     throw new ArgumentOutOfRangeException();
             }
 
-            // 列車との転送やコンテナ差し替えで起こったスロット変化を通知
-            // Emit slot changes caused by train transfer or container swap
-            EmitChangedSlots();
-        }
+            #region Internal
 
-        public IItemStack InsertItem(IItemStack itemStack, InsertItemContext context) { var r = Container.InsertItem(itemStack); EmitChangedSlots(); return r; }
-
-        public IItemStack InsertItem(IItemStack itemStack) { var r = Container.InsertItem(itemStack); EmitChangedSlots(); return r; }
-
-        public IItemStack InsertItem(ItemId itemId, int count) { var r = Container.InsertItem(itemId, count); EmitChangedSlots(); return r; }
-
-        public List<IItemStack> InsertItem(List<IItemStack> itemStacks) { var r = Container.InsertItem(itemStacks); EmitChangedSlots(); return r; }
-
-        public bool InsertionCheck(List<IItemStack> itemStacks) { return Container.InsertionCheck(itemStacks); }
-
-        public IItemStack GetItem(int slot) { return Container.GetItem(slot); }
-
-        public void SetItem(int slot, IItemStack stack) { Container.SetItem(slot, stack); EmitChangedSlots(); }
-
-        public void SetItem(int slot, ItemId itemId, int count) { Container.SetItem(slot, itemId, count); EmitChangedSlots(); }
-
-        public IItemStack ReplaceItem(int slot, IItemStack itemStack) { var r = Container.ReplaceItem(slot, itemStack); EmitChangedSlots(); return r; }
-
-        public IItemStack ReplaceItem(int slot, ItemId itemId, int count) { var r = Container.ReplaceItem(slot, itemId, count); EmitChangedSlots(); return r; }
-
-        public int GetSlotSize() { return Container.GetSlotSize(); }
-
-        public ReadOnlyCollection<IItemStack> CreateCopiedItems() { return Container.CreateCopiedItems(); }
-
-        private bool IsTargetContainer([CanBeNull] out ItemTrainCarContainer trainCarContainer)
-        {
-            var trainContainer = _dockingComponent.DockedTrainCar?.Container;
-            if (trainContainer is ItemTrainCarContainer itemTrainCarContainer)
+            void PushItemsToAdjacentBlocks()
             {
-                trainCarContainer = itemTrainCarContainer;
-                return true;
-            }
-
-            if (trainContainer is null)
-            {
-                trainCarContainer = null;
-                return true;
-            }
-
-            trainCarContainer = null;
-            return false;
-        }
-
-        private bool CanTransfer(ItemTrainCarContainer to, ItemTrainCarContainer from)
-        {
-            // 移行元が存在しないか空なら転送しない
-            // Do not transfer when the source is missing or empty
-            if (from is null || from.IsEmpty()) return false;
-
-            // 移行先が未装着ならコンテナごと移せる
-            // A missing destination can receive the whole container
-            if (to is null) return true;
-
-            if (!to.CanInsert(from)) return false;
-            return true;
-        }
-
-        private void PushItemsToAdjacentBlocks()
-        {
-            var slots = Container.InventoryItems;
-            for (var i = 0; i < slots.Count; i++)
-            {
-                var setItem = _blockInventoryInserter.InsertItem(slots[i]);
-                Container.SetItem(i, setItem);
-            }
-        }
-
-        private void InitializeSnapshot()
-        {
-            // スナップショットは現在のコンテナ状態と完全に一致させる
-            // Snapshot must exactly match the current container state
-            var items = Container.InventoryItems;
-            _previousInventorySnapshot = new IItemStack[items.Count];
-            for (var i = 0; i < items.Count; i++)
-            {
-                _previousInventorySnapshot[i] = items[i];
-            }
-        }
-
-        private void EmitChangedSlots()
-        {
-            // コンテナ差し替えでスロット数が変わった場合はスナップショットを作り直す
-            // If the container was swapped and the slot count changed, rebuild the snapshot
-            var items = Container.InventoryItems;
-            if (_previousInventorySnapshot == null || _previousInventorySnapshot.Length != items.Count)
-            {
-                var rebuilt = new IItemStack[items.Count];
-                for (var i = 0; i < items.Count; i++) rebuilt[i] = items[i];
-                _previousInventorySnapshot = rebuilt;
-                // 差分が不明なので全スロットを通知
-                // We have no prior diff baseline, so notify every slot
-                for (var i = 0; i < items.Count; i++)
+                var slots = Container.InventoryItems;
+                for (var i = 0; i < slots.Count; i++)
                 {
-                    _blockInventoryUpdateEvent.OnInventoryUpdateInvoke(new BlockOpenableInventoryUpdateEventProperties(BlockInstanceId, i, items[i]));
+                    var setItem = _blockInventoryInserter.InsertItem(slots[i]);
+                    Container.SetItem(i, setItem);
                 }
-                return;
             }
 
-            for (var i = 0; i < items.Count; i++)
+            bool IsTargetContainer([CanBeNull] out ItemTrainCarContainer trainCarContainer)
             {
-                var previous = _previousInventorySnapshot[i];
-                var current = items[i];
-                if (previous.Id == current.Id && previous.Count == current.Count) continue;
-                _previousInventorySnapshot[i] = current;
-                _blockInventoryUpdateEvent.OnInventoryUpdateInvoke(new BlockOpenableInventoryUpdateEventProperties(BlockInstanceId, i, current));
+                var trainContainer = _dockingComponent.DockedTrainCar?.Container;
+                if (trainContainer is ItemTrainCarContainer itemTrainCarContainer)
+                {
+                    trainCarContainer = itemTrainCarContainer;
+                    return true;
+                }
+
+                if (trainContainer is null)
+                {
+                    trainCarContainer = null;
+                    return true;
+                }
+
+                trainCarContainer = null;
+                return false;
             }
+
+            bool CanTransfer(ItemTrainCarContainer to, ItemTrainCarContainer from)
+            {
+                // 移行元が存在しないか空なら転送しない
+                // Do not transfer when the source is missing or empty
+                if (from is null || from.IsEmpty()) return false;
+
+                // 移行先が未装着ならコンテナごと移せる
+                // A missing destination can receive the whole container
+                if (to is null) return true;
+
+                if (!to.CanInsert(from)) return false;
+                return true;
+            }
+
+            void HandleLoadToTrain()
+            {
+                if (!CanTransfer(targetContainer, Container)) { _dockingComponent.StartRetracting(); return; }
+
+                _dockingComponent.StartExtending();
+                if (_dockingComponent.ArmState != ArmState.Extended) return;
+
+                if (Container.IsEmpty()) { _dockingComponent.StartRetracting(); return; }
+
+                if (targetContainer == null)
+                {
+                    // 旧コンテナを列車車両へ渡し、プラットフォームは新しい空コンテナへ差し替える
+                    // Hand the populated container to the train car and replace the platform with a fresh empty one
+                    var handedOff = SwapWithEmptyContainerAndEmitClearedEvents();
+                    dockedCar.SetContainer(handedOff);
+                    _dockingComponent.StartRetracting();
+                    return;
+                }
+
+                targetContainer.MergeFrom(Container);
+                _dockingComponent.StartRetracting();
+            }
+
+            void HandleUnloadToPlatform()
+            {
+                if (!CanTransfer(Container, targetContainer)) { _dockingComponent.StartRetracting(); return; }
+
+                _dockingComponent.StartExtending();
+                if (_dockingComponent.ArmState != ArmState.Extended) return;
+
+                if (targetContainer == null || targetContainer.IsEmpty()) { _dockingComponent.StartRetracting(); return; }
+
+                Container.MergeFrom(targetContainer);
+                _dockingComponent.StartRetracting();
+            }
+
+            ItemTrainCarContainer SwapWithEmptyContainerAndEmitClearedEvents()
+            {
+                var handedOff = Container;
+                Container = ItemTrainCarContainer.CreateWithEmptySlots(_slotsCount);
+                SubscribeContainerSlotChanges();
+
+                // 旧コンテナの中身は車両側へ移譲済みなのでプラットフォーム視点では全スロットが空になる
+                // Old contents now belong to the train car; from the platform's view all slots are empty
+                var emptyStack = ServerContext.ItemStackFactory.CreatEmpty();
+                for (var i = 0; i < handedOff.InventoryItems.Count; i++)
+                {
+                    _blockInventoryUpdateEvent.OnInventoryUpdateInvoke(new BlockOpenableInventoryUpdateEventProperties(BlockInstanceId, i, emptyStack));
+                }
+
+                return handedOff;
+            }
+
+            #endregion
+        }
+
+        public IItemStack InsertItem(IItemStack itemStack, InsertItemContext context) => Container.InsertItem(itemStack);
+        public IItemStack InsertItem(IItemStack itemStack) => Container.InsertItem(itemStack);
+        public IItemStack InsertItem(ItemId itemId, int count) => Container.InsertItem(itemId, count);
+        public List<IItemStack> InsertItem(List<IItemStack> itemStacks) => Container.InsertItem(itemStacks);
+        public bool InsertionCheck(List<IItemStack> itemStacks) => Container.InsertionCheck(itemStacks);
+        public IItemStack GetItem(int slot) => Container.GetItem(slot);
+        public void SetItem(int slot, IItemStack stack) => Container.SetItem(slot, stack);
+        public void SetItem(int slot, ItemId itemId, int count) => Container.SetItem(slot, itemId, count);
+        public IItemStack ReplaceItem(int slot, IItemStack itemStack) => Container.ReplaceItem(slot, itemStack);
+        public IItemStack ReplaceItem(int slot, ItemId itemId, int count) => Container.ReplaceItem(slot, itemId, count);
+        public int GetSlotSize() => Container.GetSlotSize();
+        public ReadOnlyCollection<IItemStack> CreateCopiedItems() => Container.CreateCopiedItems();
+
+        private void SubscribeContainerSlotChanges()
+        {
+            _slotChangedSubscription?.Dispose();
+            _slotChangedSubscription = Container.OnSlotChanged.Subscribe(change =>
+                _blockInventoryUpdateEvent.OnInventoryUpdateInvoke(new BlockOpenableInventoryUpdateEventProperties(BlockInstanceId, change.slot, change.stack)));
         }
 
         public void Destroy()
         {
             IsDestroy = true;
+            _slotChangedSubscription?.Dispose();
+            _slotChangedSubscription = null;
         }
+
         public string SaveKey { get; } = typeof(TrainPlatformItemContainerComponent).FullName;
 
         public string GetSaveState()

--- a/moorestech_server/Assets/Scripts/Game.Block/Blocks/TrainRail/ContainerComponents/TrainPlatformItemContainerComponent.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Blocks/TrainRail/ContainerComponents/TrainPlatformItemContainerComponent.cs
@@ -4,7 +4,10 @@ using System.Collections.ObjectModel;
 using Core.Item.Interface;
 using Core.Master;
 using Game.Block.Blocks.Connector;
+using Game.Block.Event;
+using Game.Block.Interface;
 using Game.Block.Interface.Component;
+using Game.Block.Interface.Event;
 using Game.Train.Unit.Containers;
 using JetBrains.Annotations;
 using MessagePack;
@@ -14,24 +17,32 @@ namespace Game.Block.Blocks.TrainRail.ContainerComponents
     public class TrainPlatformItemContainerComponent : IUpdatableBlockComponent, IOpenableBlockInventoryComponent, IBlockSaveState
     {
         public IReadOnlyList<IItemStack> InventoryItems => Container.InventoryItems;
+        public BlockInstanceId BlockInstanceId { get; }
         public bool IsDestroy { get; private set; }
         public ItemTrainCarContainer Container { get; private set; }
         private readonly TrainPlatformDockingComponent _dockingComponent;
         private readonly TrainPlatformTransferComponent _transferComponent;
         private readonly IBlockInventoryInserter _blockInventoryInserter;
+        private readonly BlockOpenableInventoryUpdateEvent _blockInventoryUpdateEvent;
         private readonly int _slotsCount;
+        private IItemStack[] _previousInventorySnapshot;
 
-        public TrainPlatformItemContainerComponent(TrainPlatformDockingComponent dockingComponent, TrainPlatformTransferComponent transferComponent, int slotsCount, IBlockInventoryInserter blockInventoryInserter)
+        public TrainPlatformItemContainerComponent(BlockInstanceId blockInstanceId, BlockOpenableInventoryUpdateEvent blockInventoryUpdateEvent, TrainPlatformDockingComponent dockingComponent, TrainPlatformTransferComponent transferComponent, int slotsCount, IBlockInventoryInserter blockInventoryInserter)
         {
+            BlockInstanceId = blockInstanceId;
+            _blockInventoryUpdateEvent = blockInventoryUpdateEvent;
             _dockingComponent = dockingComponent;
             _transferComponent = transferComponent;
             _slotsCount = slotsCount;
             _blockInventoryInserter = blockInventoryInserter;
             Container = ItemTrainCarContainer.CreateWithEmptySlots(_slotsCount);
+            InitializeSnapshot();
         }
 
-        public TrainPlatformItemContainerComponent(TrainPlatformDockingComponent dockingComponent, TrainPlatformTransferComponent transferComponent, int slotsCount, IBlockInventoryInserter blockInventoryInserter, Dictionary<string, string> componentStates)
+        public TrainPlatformItemContainerComponent(BlockInstanceId blockInstanceId, BlockOpenableInventoryUpdateEvent blockInventoryUpdateEvent, TrainPlatformDockingComponent dockingComponent, TrainPlatformTransferComponent transferComponent, int slotsCount, IBlockInventoryInserter blockInventoryInserter, Dictionary<string, string> componentStates)
         {
+            BlockInstanceId = blockInstanceId;
+            _blockInventoryUpdateEvent = blockInventoryUpdateEvent;
             _dockingComponent = dockingComponent;
             _transferComponent = transferComponent;
             _slotsCount = slotsCount;
@@ -39,31 +50,42 @@ namespace Game.Block.Blocks.TrainRail.ContainerComponents
             Container = ItemTrainCarContainer.CreateWithEmptySlots(_slotsCount);
 
             LoadContainer();
-            
+            // 保存データ復元時はイベント発火不要なのでスナップショットだけ取り直す
+            // Loading from save data must not raise events; only re-seed the snapshot
+            InitializeSnapshot();
+
             #region Internal
-            
+
             void LoadContainer()
             {
                 if (!componentStates.TryGetValue(SaveKey, out var serialized)) return;
-                
+
                 var serializedBytes = MessagePackSerializer.ConvertFromJson(serialized);
                 var saveData = MessagePackSerializer.Deserialize<TrainPlatformItemContainerComponentSaveData>(serializedBytes);
                 if (saveData?.Container is not ItemTrainCarContainer loadedContainer) return;
-                
+
                 Container = loadedContainer;
             }
-            
+
             #endregion
         }
-        
+
         public void Update()
         {
             PushItemsToAdjacentBlocks();
 
             var dockedCar = _dockingComponent.DockedTrainCar;
-            if (dockedCar == null) return;
+            if (dockedCar == null)
+            {
+                EmitChangedSlots();
+                return;
+            }
 
-            if (!IsTargetContainer(out var targetContainer)) return;
+            if (!IsTargetContainer(out var targetContainer))
+            {
+                EmitChangedSlots();
+                return;
+            }
 
             switch (_transferComponent.Mode)
             {
@@ -72,29 +94,29 @@ namespace Game.Block.Blocks.TrainRail.ContainerComponents
                         if (!CanTransfer(targetContainer, Container))
                         {
                             _dockingComponent.StartRetracting();
-                            return;
+                            break;
                         }
-                        
+
                         _dockingComponent.StartExtending();
-                        
-                        if (_dockingComponent.ArmState != ArmState.Extended) return;
-                        
+
+                        if (_dockingComponent.ArmState != ArmState.Extended) break;
+
                         if (Container.IsEmpty())
                         {
                             _dockingComponent.StartRetracting();
-                            return;
+                            break;
                         }
-                        
+
                         if (targetContainer == null)
                         {
                             dockedCar.SetContainer(Container);
                             Container = ItemTrainCarContainer.CreateWithEmptySlots(_slotsCount);
                             _dockingComponent.StartRetracting();
-                            return;
+                            break;
                         }
-                        
+
                         targetContainer.MergeFrom(Container);
-                        
+
                         _dockingComponent.StartRetracting();
                         break;
                     }
@@ -103,53 +125,57 @@ namespace Game.Block.Blocks.TrainRail.ContainerComponents
                         if (!CanTransfer(Container, targetContainer))
                         {
                             _dockingComponent.StartRetracting();
-                            return;
+                            break;
                         }
-                        
+
                         _dockingComponent.StartExtending();
-                        
-                        if (_dockingComponent.ArmState != ArmState.Extended) return;
-                        
+
+                        if (_dockingComponent.ArmState != ArmState.Extended) break;
+
                         if (targetContainer == null || targetContainer.IsEmpty())
                         {
                             _dockingComponent.StartRetracting();
-                            return;
+                            break;
                         }
-                        
+
                         Container.MergeFrom(targetContainer);
-                        
+
                         _dockingComponent.StartRetracting();
                         break;
                     }
                 default:
                     throw new ArgumentOutOfRangeException();
             }
+
+            // 列車との転送やコンテナ差し替えで起こったスロット変化を通知
+            // Emit slot changes caused by train transfer or container swap
+            EmitChangedSlots();
         }
-        
-        public IItemStack InsertItem(IItemStack itemStack, InsertItemContext context) { return Container.InsertItem(itemStack); }
 
-        public IItemStack InsertItem(IItemStack itemStack) { return Container.InsertItem(itemStack); }
+        public IItemStack InsertItem(IItemStack itemStack, InsertItemContext context) { var r = Container.InsertItem(itemStack); EmitChangedSlots(); return r; }
 
-        public IItemStack InsertItem(ItemId itemId, int count) { return Container.InsertItem(itemId, count); }
+        public IItemStack InsertItem(IItemStack itemStack) { var r = Container.InsertItem(itemStack); EmitChangedSlots(); return r; }
 
-        public List<IItemStack> InsertItem(List<IItemStack> itemStacks) { return Container.InsertItem(itemStacks); }
+        public IItemStack InsertItem(ItemId itemId, int count) { var r = Container.InsertItem(itemId, count); EmitChangedSlots(); return r; }
+
+        public List<IItemStack> InsertItem(List<IItemStack> itemStacks) { var r = Container.InsertItem(itemStacks); EmitChangedSlots(); return r; }
 
         public bool InsertionCheck(List<IItemStack> itemStacks) { return Container.InsertionCheck(itemStacks); }
 
         public IItemStack GetItem(int slot) { return Container.GetItem(slot); }
 
-        public void SetItem(int slot, IItemStack stack) { Container.SetItem(slot, stack); }
+        public void SetItem(int slot, IItemStack stack) { Container.SetItem(slot, stack); EmitChangedSlots(); }
 
-        public void SetItem(int slot, ItemId itemId, int count) { Container.SetItem(slot, itemId, count); }
+        public void SetItem(int slot, ItemId itemId, int count) { Container.SetItem(slot, itemId, count); EmitChangedSlots(); }
 
-        public IItemStack ReplaceItem(int slot, IItemStack itemStack) { return Container.ReplaceItem(slot, itemStack); }
+        public IItemStack ReplaceItem(int slot, IItemStack itemStack) { var r = Container.ReplaceItem(slot, itemStack); EmitChangedSlots(); return r; }
 
-        public IItemStack ReplaceItem(int slot, ItemId itemId, int count) { return Container.ReplaceItem(slot, itemId, count); }
+        public IItemStack ReplaceItem(int slot, ItemId itemId, int count) { var r = Container.ReplaceItem(slot, itemId, count); EmitChangedSlots(); return r; }
 
         public int GetSlotSize() { return Container.GetSlotSize(); }
 
         public ReadOnlyCollection<IItemStack> CreateCopiedItems() { return Container.CreateCopiedItems(); }
-        
+
         private bool IsTargetContainer([CanBeNull] out ItemTrainCarContainer trainCarContainer)
         {
             var trainContainer = _dockingComponent.DockedTrainCar?.Container;
@@ -158,7 +184,7 @@ namespace Game.Block.Blocks.TrainRail.ContainerComponents
                 trainCarContainer = itemTrainCarContainer;
                 return true;
             }
-            
+
             if (trainContainer is null)
             {
                 trainCarContainer = null;
@@ -168,21 +194,21 @@ namespace Game.Block.Blocks.TrainRail.ContainerComponents
             trainCarContainer = null;
             return false;
         }
-        
+
         private bool CanTransfer(ItemTrainCarContainer to, ItemTrainCarContainer from)
         {
             // 移行元が存在しないか空なら転送しない
             // Do not transfer when the source is missing or empty
             if (from is null || from.IsEmpty()) return false;
-            
+
             // 移行先が未装着ならコンテナごと移せる
             // A missing destination can receive the whole container
             if (to is null) return true;
-            
+
             if (!to.CanInsert(from)) return false;
             return true;
         }
-        
+
         private void PushItemsToAdjacentBlocks()
         {
             var slots = Container.InventoryItems;
@@ -193,22 +219,63 @@ namespace Game.Block.Blocks.TrainRail.ContainerComponents
             }
         }
 
+        private void InitializeSnapshot()
+        {
+            // スナップショットは現在のコンテナ状態と完全に一致させる
+            // Snapshot must exactly match the current container state
+            var items = Container.InventoryItems;
+            _previousInventorySnapshot = new IItemStack[items.Count];
+            for (var i = 0; i < items.Count; i++)
+            {
+                _previousInventorySnapshot[i] = items[i];
+            }
+        }
+
+        private void EmitChangedSlots()
+        {
+            // コンテナ差し替えでスロット数が変わった場合はスナップショットを作り直す
+            // If the container was swapped and the slot count changed, rebuild the snapshot
+            var items = Container.InventoryItems;
+            if (_previousInventorySnapshot == null || _previousInventorySnapshot.Length != items.Count)
+            {
+                var rebuilt = new IItemStack[items.Count];
+                for (var i = 0; i < items.Count; i++) rebuilt[i] = items[i];
+                _previousInventorySnapshot = rebuilt;
+                // 差分が不明なので全スロットを通知
+                // We have no prior diff baseline, so notify every slot
+                for (var i = 0; i < items.Count; i++)
+                {
+                    _blockInventoryUpdateEvent.OnInventoryUpdateInvoke(new BlockOpenableInventoryUpdateEventProperties(BlockInstanceId, i, items[i]));
+                }
+                return;
+            }
+
+            for (var i = 0; i < items.Count; i++)
+            {
+                var previous = _previousInventorySnapshot[i];
+                var current = items[i];
+                if (previous.Id == current.Id && previous.Count == current.Count) continue;
+                _previousInventorySnapshot[i] = current;
+                _blockInventoryUpdateEvent.OnInventoryUpdateInvoke(new BlockOpenableInventoryUpdateEventProperties(BlockInstanceId, i, current));
+            }
+        }
+
         public void Destroy()
         {
             IsDestroy = true;
         }
         public string SaveKey { get; } = typeof(TrainPlatformItemContainerComponent).FullName;
-        
+
         public string GetSaveState()
         {
             return MessagePackSerializer.ConvertToJson(MessagePackSerializer.Serialize(new TrainPlatformItemContainerComponentSaveData(Container)));
         }
-        
+
         [MessagePackObject]
         public class TrainPlatformItemContainerComponentSaveData
         {
             [Key(0)] public ItemTrainCarContainer Container;
-            
+
             public TrainPlatformItemContainerComponentSaveData(ItemTrainCarContainer container)
             {
                 Container = container;

--- a/moorestech_server/Assets/Scripts/Game.Block/Factory/BlockTemplate/VanillaTrainItemPlatformTemplate.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Factory/BlockTemplate/VanillaTrainItemPlatformTemplate.cs
@@ -4,6 +4,7 @@ using Game.Block.Blocks.Chest;
 using Game.Block.Blocks.Service;
 using Game.Block.Blocks.TrainRail;
 using Game.Block.Blocks.TrainRail.ContainerComponents;
+using Game.Block.Event;
 using Game.Block.Factory.BlockTemplate.Utility;
 using Game.Block.Interface;
 using Game.Block.Interface.Component;
@@ -15,9 +16,11 @@ namespace Game.Block.Factory.BlockTemplate
     public class VanillaTrainItemPlatformTemplate : IBlockTemplate
     {
         private readonly IRailGraphDatastore _railGraphDatastore;
+        private readonly BlockOpenableInventoryUpdateEvent _blockInventoryUpdateEvent;
 
-        public VanillaTrainItemPlatformTemplate(IRailGraphDatastore railGraphDatastore)
+        public VanillaTrainItemPlatformTemplate(BlockOpenableInventoryUpdateEvent blockInventoryUpdateEvent, IRailGraphDatastore railGraphDatastore)
         {
+            _blockInventoryUpdateEvent = blockInventoryUpdateEvent;
             _railGraphDatastore = railGraphDatastore;
         }
         /// <summary>
@@ -37,7 +40,7 @@ namespace Game.Block.Factory.BlockTemplate
             var trainPlatformTransferComponent = new TrainPlatformTransferComponent(TrainPlatformTransferComponent.TransferMode.LoadToTrain);
             var inputConnectorComponent = BlockTemplateUtil.CreateInventoryConnector(stationParam.InventoryConnectors, positionInfo);
             var inserter = new ConnectingInventoryListPriorityInsertItemService(instanceId, inputConnectorComponent);
-            var trainPlatformItemTransferComponent = new TrainPlatformItemContainerComponent(trainPlatformDockingComponent, trainPlatformTransferComponent, stationParam.ItemSlotCount, inserter);
+            var trainPlatformItemTransferComponent = new TrainPlatformItemContainerComponent(instanceId, _blockInventoryUpdateEvent, trainPlatformDockingComponent, trainPlatformTransferComponent, stationParam.ItemSlotCount, inserter);
 
             // 生成したコンポーネントをブロックに登録する
             var blockComponents = new List<IBlockComponent>();
@@ -74,7 +77,7 @@ namespace Game.Block.Factory.BlockTemplate
             var trainPlatformTransferComponent = new TrainPlatformTransferComponent(componentStates);
             var inputConnectorComponent = BlockTemplateUtil.CreateInventoryConnector(stationParam.InventoryConnectors, positionInfo);
             var inserter = new ConnectingInventoryListPriorityInsertItemService(instanceId, inputConnectorComponent);
-            var trainPlatformItemTransferComponent = new TrainPlatformItemContainerComponent(trainPlatformDockingComponent, trainPlatformTransferComponent, stationParam.ItemSlotCount, inserter, componentStates);
+            var trainPlatformItemTransferComponent = new TrainPlatformItemContainerComponent(instanceId, _blockInventoryUpdateEvent, trainPlatformDockingComponent, trainPlatformTransferComponent, stationParam.ItemSlotCount, inserter, componentStates);
             
             // 復元したコンポーネントをブロックに登録する
             var blockComponents = new List<IBlockComponent>();

--- a/moorestech_server/Assets/Scripts/Game.Block/Factory/BlockTemplate/VanillaTrainStationTemplate.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Factory/BlockTemplate/VanillaTrainStationTemplate.cs
@@ -4,6 +4,7 @@ using Game.Block.Blocks.Chest;
 using Game.Block.Blocks.Service;
 using Game.Block.Blocks.TrainRail;
 using Game.Block.Blocks.TrainRail.ContainerComponents;
+using Game.Block.Event;
 using Game.Block.Factory.BlockTemplate.Utility;
 using Game.Block.Interface;
 using Game.Block.Interface.Component;
@@ -15,9 +16,11 @@ namespace Game.Block.Factory.BlockTemplate
     public class VanillaTrainStationTemplate : IBlockTemplate
     {
         private readonly IRailGraphDatastore _railGraphDatastore;
+        private readonly BlockOpenableInventoryUpdateEvent _blockInventoryUpdateEvent;
 
-        public VanillaTrainStationTemplate(IRailGraphDatastore railGraphDatastore)
+        public VanillaTrainStationTemplate(BlockOpenableInventoryUpdateEvent blockInventoryUpdateEvent, IRailGraphDatastore railGraphDatastore)
         {
+            _blockInventoryUpdateEvent = blockInventoryUpdateEvent;
             _railGraphDatastore = railGraphDatastore;
         }
         /// <summary>
@@ -38,7 +41,7 @@ namespace Game.Block.Factory.BlockTemplate
             var trainPlatformTransferComponent = new TrainPlatformTransferComponent(TrainPlatformTransferComponent.TransferMode.LoadToTrain);
             var inputConnectorComponent = BlockTemplateUtil.CreateInventoryConnector(stationParam.InventoryConnectors, positionInfo);
             var inserter = new ConnectingInventoryListPriorityInsertItemService(instanceId, inputConnectorComponent);
-            var trainPlatformItemTransferComponent = new TrainPlatformItemContainerComponent(trainPlatformDockingComponent, trainPlatformTransferComponent, stationParam.ItemSlotCount, inserter);
+            var trainPlatformItemTransferComponent = new TrainPlatformItemContainerComponent(instanceId, _blockInventoryUpdateEvent, trainPlatformDockingComponent, trainPlatformTransferComponent, stationParam.ItemSlotCount, inserter);
 
             // 生成したコンポーネントをブロックに登録する
             var blockComponents = new List<IBlockComponent>();
@@ -77,7 +80,7 @@ namespace Game.Block.Factory.BlockTemplate
             var trainPlatformTransferComponent = new TrainPlatformTransferComponent(componentStates);
             var inputConnectorComponent = BlockTemplateUtil.CreateInventoryConnector(stationParam.InventoryConnectors, positionInfo);
             var inserter = new ConnectingInventoryListPriorityInsertItemService(instanceId, inputConnectorComponent);
-            var trainPlatformItemTransferComponent = new TrainPlatformItemContainerComponent(trainPlatformDockingComponent, trainPlatformTransferComponent, stationParam.ItemSlotCount, inserter, componentStates);
+            var trainPlatformItemTransferComponent = new TrainPlatformItemContainerComponent(instanceId, _blockInventoryUpdateEvent, trainPlatformDockingComponent, trainPlatformTransferComponent, stationParam.ItemSlotCount, inserter, componentStates);
 
             // 復元したコンポーネントをブロックに登録する
             var blockComponents = new List<IBlockComponent>();

--- a/moorestech_server/Assets/Scripts/Game.Block/Factory/VanillaIBlockTemplates.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Factory/VanillaIBlockTemplates.cs
@@ -41,8 +41,8 @@ namespace Game.Block.Factory
             BlockTypesDictionary.Add(BlockTypeConst.GearBeltConveyor, new VanillaGearBeltConveyorTemplate());
             BlockTypesDictionary.Add(BlockTypeConst.TrainRail, new VanillaTrainRailTemplate(railGraphDatastore));
             BlockTypesDictionary.Add(BlockTypeConst.FluidPipe, new VanillaFluidBlockTemplate());
-            BlockTypesDictionary.Add(BlockTypeConst.TrainStation, new VanillaTrainStationTemplate(railGraphDatastore));
-            BlockTypesDictionary.Add(BlockTypeConst.TrainItemPlatform, new VanillaTrainItemPlatformTemplate(railGraphDatastore));
+            BlockTypesDictionary.Add(BlockTypeConst.TrainStation, new VanillaTrainStationTemplate(blockInventoryEvent, railGraphDatastore));
+            BlockTypesDictionary.Add(BlockTypeConst.TrainItemPlatform, new VanillaTrainItemPlatformTemplate(blockInventoryEvent, railGraphDatastore));
             BlockTypesDictionary.Add(BlockTypeConst.TrainFluidPlatform, new VanillaTrainFluidPlatformTemplate(railGraphDatastore));
             BlockTypesDictionary.Add(BlockTypeConst.BaseCamp, new BaseCampBlockTemplate());
             BlockTypesDictionary.Add(BlockTypeConst.GearPump, new VanillaGearPumpTemplate());

--- a/moorestech_server/Assets/Scripts/Game.Train/Unit/Containers/ItemTrainCarContainer.cs
+++ b/moorestech_server/Assets/Scripts/Game.Train/Unit/Containers/ItemTrainCarContainer.cs
@@ -7,18 +7,22 @@ using Core.Item.Interface;
 using Core.Master;
 using Game.Context;
 using Mooresmaster.Model.TrainModule;
+using UniRx;
 
 namespace Game.Train.Unit.Containers
 {
     public class ItemTrainCarContainer : IOpenableInventory, IFuelProviderTrainCarContainer
     {
         public IReadOnlyList<IItemStack> InventoryItems => _itemDataStoreService.InventoryItems;
+        private readonly OpenableInventoryItemDataStoreService _itemDataStoreService;
 
         // 通知の宛先は装着中の列車。Attach/Detach経由でのみ更新される
         // The current owning car; populated only through Attach/Detach lifecycle hooks.
         private TrainCar _attachedCar;
 
-        private readonly OpenableInventoryItemDataStoreService _itemDataStoreService;
+        public IObservable<(int slot, IItemStack stack)> OnSlotChanged => _onSlotChangedSubject;
+        private readonly Subject<(int slot, IItemStack stack)> _onSlotChangedSubject = new();
+
 
         private ItemTrainCarContainer(int slotNumber)
         {
@@ -26,6 +30,7 @@ namespace Game.Train.Unit.Containers
                 (slot, itemStack) =>
                 {
                     _attachedCar?.NotifyInventoryUpdate(slot, itemStack);
+                    _onSlotChangedSubject.OnNext((slot, itemStack));
                 }, ServerContext.ItemStackFactory, slotNumber);
         }
 

--- a/moorestech_server/Assets/Scripts/Tests/UnitTest/Game/TrainPlatformInventoryUpdateEventTest.cs
+++ b/moorestech_server/Assets/Scripts/Tests/UnitTest/Game/TrainPlatformInventoryUpdateEventTest.cs
@@ -1,0 +1,170 @@
+using System.Collections.Generic;
+using Core.Item.Interface;
+using Core.Master;
+using Core.Update;
+using Game.Block.Blocks.TrainRail;
+using Game.Block.Blocks.TrainRail.ContainerComponents;
+using Game.Block.Interface;
+using Game.Block.Interface.Component;
+using Game.Block.Interface.Event;
+using Game.Block.Interface.Extension;
+using Game.Context;
+using Game.Train.RailGraph;
+using Game.Train.RailPositions;
+using Game.Train.Unit;
+using Game.Train.Unit.Containers;
+using Mooresmaster.Model.BlocksModule;
+using NUnit.Framework;
+using Tests.Module.TestMod;
+using Tests.Util;
+using UniRx;
+using UnityEngine;
+
+namespace Tests.UnitTest.Game
+{
+    /// <summary>
+    /// 駅・アイテムプラットフォームの内部インベントリが変化したとき
+    /// BlockOpenableInventoryUpdateEvent が正しく発火するかを検証する
+    /// Verify that BlockOpenableInventoryUpdateEvent is raised when the
+    /// internal inventory of a station / item platform changes
+    /// </summary>
+    public class TrainPlatformInventoryUpdateEventTest
+    {
+        [Test]
+        public void CargoPlatformSetItemRaisesInventoryUpdateEvent()
+        {
+            // 環境とプラットフォームを準備
+            // Prepare environment and a cargo item platform
+            var env = TrainTestHelper.CreateEnvironment();
+            var platformBlock = TrainTestHelper.PlaceBlock(env, ForUnitTestModBlockId.TestTrainItemPlatform, Vector3Int.zero, BlockDirection.North);
+            Assert.IsNotNull(platformBlock, "貨物プラットフォームの設置に失敗しました。");
+
+            var blockInventory = platformBlock.GetComponent<IBlockInventory>();
+            var receivedEvents = SubscribeBlockInventoryEvents(platformBlock.BlockInstanceId);
+
+            // インベントリへSetItemし、対応するイベントが発火することを確認
+            // SetItem into inventory and confirm the matching update event fires
+            var stack = ServerContext.ItemStackFactory.Create(ForUnitTestItemId.ItemId1, 4);
+            blockInventory.SetItem(0, stack);
+
+            Assert.AreEqual(1, receivedEvents.Count, "プラットフォームのスロット更新イベントが発火していません。");
+            Assert.AreEqual(0, receivedEvents[0].Slot);
+            Assert.AreEqual(ForUnitTestItemId.ItemId1, receivedEvents[0].ItemStack.Id);
+            Assert.AreEqual(4, receivedEvents[0].ItemStack.Count);
+            Assert.AreEqual(platformBlock.BlockInstanceId, receivedEvents[0].BlockInstanceId);
+        }
+
+        [Test]
+        public void StationSetItemRaisesInventoryUpdateEvent()
+        {
+            // 駅ブロック側も同じ経路で発火することを確認
+            // The same event path must also work for the station block
+            var env = TrainTestHelper.CreateEnvironment();
+            var stationBlock = TrainTestHelper.PlaceBlock(env, ForUnitTestModBlockId.TestTrainStation, Vector3Int.zero, BlockDirection.North);
+            Assert.IsNotNull(stationBlock, "駅ブロックの設置に失敗しました。");
+
+            var blockInventory = stationBlock.GetComponent<IBlockInventory>();
+            var receivedEvents = SubscribeBlockInventoryEvents(stationBlock.BlockInstanceId);
+
+            var stack = ServerContext.ItemStackFactory.Create(ForUnitTestItemId.ItemId1, 3);
+            blockInventory.SetItem(2, stack);
+
+            Assert.AreEqual(1, receivedEvents.Count, "駅ブロックのスロット更新イベントが発火していません。");
+            Assert.AreEqual(2, receivedEvents[0].Slot);
+            Assert.AreEqual(ForUnitTestItemId.ItemId1, receivedEvents[0].ItemStack.Id);
+            Assert.AreEqual(3, receivedEvents[0].ItemStack.Count);
+            Assert.AreEqual(stationBlock.BlockInstanceId, receivedEvents[0].BlockInstanceId);
+        }
+
+        [Test]
+        public void CargoPlatformInsertItemRaisesInventoryUpdateEvent()
+        {
+            // InsertItem経由でも発火する（ベルト等からの挿入経路）
+            // InsertItem path (used by belts etc.) must also raise the event
+            var env = TrainTestHelper.CreateEnvironment();
+            var platformBlock = TrainTestHelper.PlaceBlock(env, ForUnitTestModBlockId.TestTrainItemPlatform, Vector3Int.zero, BlockDirection.North);
+
+            var blockInventory = platformBlock.GetComponent<IBlockInventory>();
+            var receivedEvents = SubscribeBlockInventoryEvents(platformBlock.BlockInstanceId);
+
+            var inserted = blockInventory.InsertItem(ServerContext.ItemStackFactory.Create(ForUnitTestItemId.ItemId1, 7), InsertItemContext.Empty);
+
+            Assert.AreEqual(0, inserted.Count, "プラットフォームの空スロットへ挿入できていません。");
+            Assert.AreEqual(1, receivedEvents.Count, "InsertItem経由でイベントが発火していません。");
+            Assert.AreEqual(ForUnitTestItemId.ItemId1, receivedEvents[0].ItemStack.Id);
+            Assert.AreEqual(7, receivedEvents[0].ItemStack.Count);
+        }
+
+        [Test]
+        public void LoadingToTrainEmitsClearingEventsForEmptiedSlots()
+        {
+            // 駅 → 列車への一括積み込み時、駅側のスロットが空になることをイベントで通知する
+            // When the platform hands its container off to the docked train, slots must be reported as empty
+            var env = TrainTestHelper.CreateEnvironment();
+            var (cargoPlatformBlock, railComponents) = TrainTestHelper.PlaceBlockWithRailComponents(
+                env,
+                ForUnitTestModBlockId.TestTrainItemPlatform,
+                Vector3Int.zero,
+                BlockDirection.North);
+
+            var trainPlatformItemTransferComponent = cargoPlatformBlock.GetComponent<TrainPlatformItemContainerComponent>();
+            var trainPlatformDockingComponent = cargoPlatformBlock.GetComponent<TrainPlatformDockingComponent>();
+            var cargoInventory = cargoPlatformBlock.GetComponent<IBlockInventory>();
+
+            // 事前に積んでおく（SetItem時点で1回イベントが出るが、ここでは別の検証）
+            // Pre-load one slot (this raises one event but we re-create the receiver right after)
+            var maxStack = MasterHolder.ItemMaster.GetItemMaster(ForUnitTestItemId.ItemId1).MaxStack;
+            cargoInventory.SetItem(0, ServerContext.ItemStackFactory.Create(ForUnitTestItemId.ItemId1, maxStack));
+
+            var entryNode = railComponents[0].FrontNode;
+            var exitNode = railComponents[1].FrontNode;
+            var platformSegmentLength = cargoPlatformBlock.BlockPositionInfo.BlockSize.z;
+
+            var railNodes = new List<IRailNode> { exitNode, entryNode };
+            var railPosition = new RailPosition(railNodes, platformSegmentLength, 0);
+
+            var (trainCar, _) = TrainTestCarFactory.CreateTrainCarWithItemContainer(0, 400000, 1, platformSegmentLength, true);
+            var trainUnit = new TrainUnit(railPosition, new List<TrainCar> { trainCar }, env.GetTrainRailPositionManager(), env.GetTrainDiagramManager());
+
+            trainUnit.trainUnitStationDocking.TryDockWhenStopped();
+            Assert.IsTrue(trainCar.IsDocked, "列車貨車が貨物プラットフォームにドッキングしていません。");
+
+            // ここから新しい受信者でイベントを記録する
+            // Now start recording events with a fresh receiver
+            var receivedEvents = SubscribeBlockInventoryEvents(cargoPlatformBlock.BlockInstanceId);
+
+            // 転送完了までUpdateを回す
+            // Run Update until the transfer completes
+            var transferTicks = GetCargoTransferTicks();
+            for (var i = 0; i < transferTicks; i++)
+            {
+                trainPlatformItemTransferComponent.Update();
+                trainPlatformDockingComponent.Update();
+            }
+
+            Assert.AreEqual(ItemMaster.EmptyItemId, cargoInventory.GetItem(0).Id, "積み込み後にプラットフォームのスロットが空になっていません。");
+
+            // 0番スロットが空になったことを通知するイベントが少なくとも1件あること
+            // At least one event must report slot 0 becoming empty
+            var clearingEvent = receivedEvents.Find(e => e.Slot == 0 && e.ItemStack.Id == ItemMaster.EmptyItemId);
+            Assert.IsNotNull(clearingEvent, "積み込み後の空化を通知するイベントが発火していません。");
+        }
+
+        private static List<BlockOpenableInventoryUpdateEventProperties> SubscribeBlockInventoryEvents(BlockInstanceId targetInstanceId)
+        {
+            var captured = new List<BlockOpenableInventoryUpdateEventProperties>();
+            ServerContext.BlockOpenableInventoryUpdateEvent.OnInventoryUpdated
+                .Where(properties => properties.BlockInstanceId == targetInstanceId)
+                .Subscribe(captured.Add);
+            return captured;
+        }
+
+        private static int GetCargoTransferTicks()
+        {
+            var cargoParam = (TrainItemPlatformBlockParam)
+                MasterHolder.BlockMaster.GetBlockMaster(ForUnitTestModBlockId.TestTrainItemPlatform).BlockParam;
+            var ticks = GameUpdater.SecondsToTicks(cargoParam.LoadingAnimeSpeed);
+            return (ticks > int.MaxValue ? int.MaxValue : (int)ticks) + 1;
+        }
+    }
+}

--- a/moorestech_server/Assets/Scripts/Tests/UnitTest/Game/TrainPlatformInventoryUpdateEventTest.cs
+++ b/moorestech_server/Assets/Scripts/Tests/UnitTest/Game/TrainPlatformInventoryUpdateEventTest.cs
@@ -164,7 +164,7 @@ namespace Tests.UnitTest.Game
             var cargoParam = (TrainItemPlatformBlockParam)
                 MasterHolder.BlockMaster.GetBlockMaster(ForUnitTestModBlockId.TestTrainItemPlatform).BlockParam;
             var ticks = GameUpdater.SecondsToTicks(cargoParam.LoadingAnimeSpeed);
-            return (ticks > int.MaxValue ? int.MaxValue : (int)ticks) + 1;
+            return (int.MaxValue < ticks ? int.MaxValue : (int)ticks) + 1;
         }
     }
 }

--- a/moorestech_server/Assets/Scripts/Tests/UnitTest/Game/TrainPlatformInventoryUpdateEventTest.cs
+++ b/moorestech_server/Assets/Scripts/Tests/UnitTest/Game/TrainPlatformInventoryUpdateEventTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Core.Item.Interface;
 using Core.Master;
@@ -40,18 +41,20 @@ namespace Tests.UnitTest.Game
             Assert.IsNotNull(platformBlock, "貨物プラットフォームの設置に失敗しました。");
 
             var blockInventory = platformBlock.GetComponent<IBlockInventory>();
-            var receivedEvents = SubscribeBlockInventoryEvents(platformBlock.BlockInstanceId);
+            var (receivedEvents, subscription) = SubscribeBlockInventoryEvents(platformBlock.BlockInstanceId);
+            using (subscription)
+            {
+                // インベントリへSetItemし、対応するイベントが発火することを確認
+                // SetItem into inventory and confirm the matching update event fires
+                var stack = ServerContext.ItemStackFactory.Create(ForUnitTestItemId.ItemId1, 4);
+                blockInventory.SetItem(0, stack);
 
-            // インベントリへSetItemし、対応するイベントが発火することを確認
-            // SetItem into inventory and confirm the matching update event fires
-            var stack = ServerContext.ItemStackFactory.Create(ForUnitTestItemId.ItemId1, 4);
-            blockInventory.SetItem(0, stack);
-
-            Assert.AreEqual(1, receivedEvents.Count, "プラットフォームのスロット更新イベントが発火していません。");
-            Assert.AreEqual(0, receivedEvents[0].Slot);
-            Assert.AreEqual(ForUnitTestItemId.ItemId1, receivedEvents[0].ItemStack.Id);
-            Assert.AreEqual(4, receivedEvents[0].ItemStack.Count);
-            Assert.AreEqual(platformBlock.BlockInstanceId, receivedEvents[0].BlockInstanceId);
+                Assert.AreEqual(1, receivedEvents.Count, "プラットフォームのスロット更新イベントが発火していません。");
+                Assert.AreEqual(0, receivedEvents[0].Slot);
+                Assert.AreEqual(ForUnitTestItemId.ItemId1, receivedEvents[0].ItemStack.Id);
+                Assert.AreEqual(4, receivedEvents[0].ItemStack.Count);
+                Assert.AreEqual(platformBlock.BlockInstanceId, receivedEvents[0].BlockInstanceId);
+            }
         }
 
         [Test]
@@ -64,16 +67,18 @@ namespace Tests.UnitTest.Game
             Assert.IsNotNull(stationBlock, "駅ブロックの設置に失敗しました。");
 
             var blockInventory = stationBlock.GetComponent<IBlockInventory>();
-            var receivedEvents = SubscribeBlockInventoryEvents(stationBlock.BlockInstanceId);
+            var (receivedEvents, subscription) = SubscribeBlockInventoryEvents(stationBlock.BlockInstanceId);
+            using (subscription)
+            {
+                var stack = ServerContext.ItemStackFactory.Create(ForUnitTestItemId.ItemId1, 3);
+                blockInventory.SetItem(2, stack);
 
-            var stack = ServerContext.ItemStackFactory.Create(ForUnitTestItemId.ItemId1, 3);
-            blockInventory.SetItem(2, stack);
-
-            Assert.AreEqual(1, receivedEvents.Count, "駅ブロックのスロット更新イベントが発火していません。");
-            Assert.AreEqual(2, receivedEvents[0].Slot);
-            Assert.AreEqual(ForUnitTestItemId.ItemId1, receivedEvents[0].ItemStack.Id);
-            Assert.AreEqual(3, receivedEvents[0].ItemStack.Count);
-            Assert.AreEqual(stationBlock.BlockInstanceId, receivedEvents[0].BlockInstanceId);
+                Assert.AreEqual(1, receivedEvents.Count, "駅ブロックのスロット更新イベントが発火していません。");
+                Assert.AreEqual(2, receivedEvents[0].Slot);
+                Assert.AreEqual(ForUnitTestItemId.ItemId1, receivedEvents[0].ItemStack.Id);
+                Assert.AreEqual(3, receivedEvents[0].ItemStack.Count);
+                Assert.AreEqual(stationBlock.BlockInstanceId, receivedEvents[0].BlockInstanceId);
+            }
         }
 
         [Test]
@@ -85,14 +90,16 @@ namespace Tests.UnitTest.Game
             var platformBlock = TrainTestHelper.PlaceBlock(env, ForUnitTestModBlockId.TestTrainItemPlatform, Vector3Int.zero, BlockDirection.North);
 
             var blockInventory = platformBlock.GetComponent<IBlockInventory>();
-            var receivedEvents = SubscribeBlockInventoryEvents(platformBlock.BlockInstanceId);
+            var (receivedEvents, subscription) = SubscribeBlockInventoryEvents(platformBlock.BlockInstanceId);
+            using (subscription)
+            {
+                var inserted = blockInventory.InsertItem(ServerContext.ItemStackFactory.Create(ForUnitTestItemId.ItemId1, 7), InsertItemContext.Empty);
 
-            var inserted = blockInventory.InsertItem(ServerContext.ItemStackFactory.Create(ForUnitTestItemId.ItemId1, 7), InsertItemContext.Empty);
-
-            Assert.AreEqual(0, inserted.Count, "プラットフォームの空スロットへ挿入できていません。");
-            Assert.AreEqual(1, receivedEvents.Count, "InsertItem経由でイベントが発火していません。");
-            Assert.AreEqual(ForUnitTestItemId.ItemId1, receivedEvents[0].ItemStack.Id);
-            Assert.AreEqual(7, receivedEvents[0].ItemStack.Count);
+                Assert.AreEqual(0, inserted.Count, "プラットフォームの空スロットへ挿入できていません。");
+                Assert.AreEqual(1, receivedEvents.Count, "InsertItem経由でイベントが発火していません。");
+                Assert.AreEqual(ForUnitTestItemId.ItemId1, receivedEvents[0].ItemStack.Id);
+                Assert.AreEqual(7, receivedEvents[0].ItemStack.Count);
+            }
         }
 
         [Test]
@@ -131,32 +138,34 @@ namespace Tests.UnitTest.Game
 
             // ここから新しい受信者でイベントを記録する
             // Now start recording events with a fresh receiver
-            var receivedEvents = SubscribeBlockInventoryEvents(cargoPlatformBlock.BlockInstanceId);
-
-            // 転送完了までUpdateを回す
-            // Run Update until the transfer completes
-            var transferTicks = GetCargoTransferTicks();
-            for (var i = 0; i < transferTicks; i++)
+            var (receivedEvents, subscription) = SubscribeBlockInventoryEvents(cargoPlatformBlock.BlockInstanceId);
+            using (subscription)
             {
-                trainPlatformItemTransferComponent.Update();
-                trainPlatformDockingComponent.Update();
+                // 転送完了までUpdateを回す
+                // Run Update until the transfer completes
+                var transferTicks = GetCargoTransferTicks();
+                for (var i = 0; i < transferTicks; i++)
+                {
+                    trainPlatformItemTransferComponent.Update();
+                    trainPlatformDockingComponent.Update();
+                }
+
+                Assert.AreEqual(ItemMaster.EmptyItemId, cargoInventory.GetItem(0).Id, "積み込み後にプラットフォームのスロットが空になっていません。");
+
+                // 0番スロットが空になったことを通知するイベントが少なくとも1件あること
+                // At least one event must report slot 0 becoming empty
+                var clearingEvent = receivedEvents.Find(e => e.Slot == 0 && e.ItemStack.Id == ItemMaster.EmptyItemId);
+                Assert.IsNotNull(clearingEvent, "積み込み後の空化を通知するイベントが発火していません。");
             }
-
-            Assert.AreEqual(ItemMaster.EmptyItemId, cargoInventory.GetItem(0).Id, "積み込み後にプラットフォームのスロットが空になっていません。");
-
-            // 0番スロットが空になったことを通知するイベントが少なくとも1件あること
-            // At least one event must report slot 0 becoming empty
-            var clearingEvent = receivedEvents.Find(e => e.Slot == 0 && e.ItemStack.Id == ItemMaster.EmptyItemId);
-            Assert.IsNotNull(clearingEvent, "積み込み後の空化を通知するイベントが発火していません。");
         }
 
-        private static List<BlockOpenableInventoryUpdateEventProperties> SubscribeBlockInventoryEvents(BlockInstanceId targetInstanceId)
+        private static (List<BlockOpenableInventoryUpdateEventProperties> events, IDisposable subscription) SubscribeBlockInventoryEvents(BlockInstanceId targetInstanceId)
         {
             var captured = new List<BlockOpenableInventoryUpdateEventProperties>();
-            ServerContext.BlockOpenableInventoryUpdateEvent.OnInventoryUpdated
+            var subscription = ServerContext.BlockOpenableInventoryUpdateEvent.OnInventoryUpdated
                 .Where(properties => properties.BlockInstanceId == targetInstanceId)
                 .Subscribe(captured.Add);
-            return captured;
+            return (captured, subscription);
         }
 
         private static int GetCargoTransferTicks()

--- a/moorestech_server/Assets/Scripts/Tests/UnitTest/Game/TrainPlatformInventoryUpdateEventTest.cs.meta
+++ b/moorestech_server/Assets/Scripts/Tests/UnitTest/Game/TrainPlatformInventoryUpdateEventTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6d72310076d8b4a62ae9941b654a9b5d


### PR DESCRIPTION
## Summary
- `ItemTrainCarContainer` に UniRx `Subject` の `OnSlotChanged` を追加し、`TrainPlatformItemContainerComponent` が購読して `BlockOpenableInventoryUpdateEvent` を発火するよう経路を統一
- 駅/アイテムプラットフォーム側でスナップショット差分検知をやめ、コンテナ自体を購読する形に変更。車両へコンテナを渡し替える経路でだけ、新しい空コンテナへ差し替えつつ全スロット空化イベントを手動発火
- `BlockInstanceId` とイベント発火経路をテンプレート (`VanillaTrainItemPlatformTemplate` / `VanillaTrainStationTemplate`) からコンポーネントに伝搬。クライアントのインベントリUIがプラットフォーム内コンテナの変更で更新されない問題を修正
- `TrainPlatformInventoryUpdateEventTest` を追加し、列車↔プラットフォーム移送および直接コンテナ操作で `BlockOpenableInventoryUpdateEvent` が正しく飛ぶことを検証

## Test plan
- [ ] `uloop run-tests --project-path ./moorestech_client --filter-type regex --filter-value "TrainPlatformInventoryUpdateEvent"` がパスする
- [ ] 既存の列車プラットフォーム/駅関連テスト (`TrainItemPlatformTransferModeSaveLoadTest`, `TrainStationDockingItemTransferTest` 等) がリグレッションなくパスする
- [ ] 実プレイで列車プラットフォームを開いた状態でアイテム搬入/搬出が走ったとき、クライアントUIがリアルタイムに更新される

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Train platforms and cars now publish per-slot inventory change events for real-time cargo tracking.
  * Containers expose slot-change notifications so UI and systems can react immediately to inventory updates.

* **Bug Fixes**
  * Robust handling when a train container is missing during load: platform correctly swaps/clears slots and emits cleared-slot events.

* **Tests**
  * Added unit tests verifying inventory update events for platforms, stations, inserts, and loading behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moorestech/moorestech/pull/894?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->