### PR TITLE
レール消費プロパティを railLengthPerItem に改名

### DIFF
--- a/VanillaSchema/train.yml
+++ b/VanillaSchema/train.yml
@@ -83,7 +83,7 @@ properties:
         schemaId: items
         foreignKeyIdPath: /data/[*]/itemGuid
         displayElementPath: /data/[*]/name
-    - key: consumptionPerUnitLength
+    - key: railLengthPerItem
       type: integer
 - key: itemContainer
   type: object

--- a/moorestech_server/Assets/Scripts/Core.Master/_CompileRequester.cs
+++ b/moorestech_server/Assets/Scripts/Core.Master/_CompileRequester.cs
@@ -5,5 +5,5 @@ public class CompileRequester
 {
 // スキーマを更新したら、こちらの更新もコミットしてください。
 // If you update the schema, please also commit this update.
-    private const string dummyText = "2026/05/15 14:36:42";
+    private const string dummyText = "2026/05/18 18:59:27";
 }

--- a/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/RailConnectionEditProtocol.cs
+++ b/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/RailConnectionEditProtocol.cs
@@ -239,7 +239,9 @@ namespace Server.Protocol.PacketResponse
         
         private static int CalculateRailItemRequiredCount(float railLength, RailItemMasterElement railMasterElement)
         {
-            return Mathf.CeilToInt(railLength * railMasterElement.ConsumptionPerUnitLength);
+            // 1アイテムで敷ける長さ(m)で割って必要個数を算出
+            // Divide by meters layable per item to compute required count
+            return Mathf.CeilToInt(railLength / railMasterElement.RailLengthPerItem);
         }
 
         [MessagePackObject]

--- a/moorestech_server/Assets/Scripts/Tests.Module/TestMod/ForUnitTest/mods/forUnitTest/master/train.json
+++ b/moorestech_server/Assets/Scripts/Tests.Module/TestMod/ForUnitTest/mods/forUnitTest/master/train.json
@@ -21,7 +21,7 @@
   "railItems": [
     {
       "itemGuid": "1b72541e-0896-43bb-91fa-0b3fef137dcf",
-      "consumptionPerUnitLength": 1
+      "railLengthPerItem": 1
     }
   ],
   "itemContainer": {


### PR DESCRIPTION
## Summary
- `consumptionPerUnitLength`（単位長あたりの消費数）を `railLengthPerItem`（1アイテムあたりに敷ける長さ）に改名し、意味を反転
- `CalculateRailItemRequiredCount` の式を `railLength * Consumption` から `railLength / RailLengthPerItem` に修正
- VanillaSchema / テスト用 train.json / `_CompileRequester` のタイムスタンプも合わせて更新

## Test plan
- [ ] `uloop compile --project-path ./moorestech_client` でコンパイル通過
- [ ] レール敷設時の必要アイテム数計算が想定どおりであることを確認（`railLengthPerItem = 1` で 1m あたり 1 個）
- [ ] 既存の Rail 関連テスト（RailConnectionEditProtocol 周辺）が緑

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rail item requirement calculation for placement and connections to use proper length-based calculations instead of previous logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moorestech/moorestech/pull/898?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->