### PR TITLE
TrainRail: maxConnectableRailLength 追加と EvaluatePlacement 統合

### DIFF
--- a/VanillaSchema/blocks.yml
+++ b/VanillaSchema/blocks.yml
@@ -558,6 +558,9 @@ properties:
         - key: controlPointLength
           type: number
           default: 0.5
+        - key: maxConnectableRailLength
+          type: number
+          default: 100
       - when: TrainStation
         type: object
         implementationInterface:
@@ -587,6 +590,9 @@ properties:
         - key: loadingAnimeSpeed
           type: number
           default: 1
+        - key: maxConnectableRailLength
+          type: number
+          default: 100
         - key: inventoryConnectors
           ref: inventoryConnects
       - when: TrainItemPlatform
@@ -619,6 +625,9 @@ properties:
         - key: loadingAnimeSpeed
           type: number
           default: 1
+        - key: maxConnectableRailLength
+          type: number
+          default: 100
         - key: inventoryConnectors
           ref: inventoryConnects
       - when: TrainFluidPlatform
@@ -646,6 +655,9 @@ properties:
           type: number
           default: 1
         - key: capacity
+          type: number
+          default: 100
+        - key: maxConnectableRailLength
           type: number
           default: 100
         - key: fluidInventoryConnectors

--- a/VanillaSchema/blocks.yml
+++ b/VanillaSchema/blocks.yml
@@ -26,6 +26,11 @@ defineInterface:
   properties:
   - key: itemSlotCount
     type: integer
+- interfaceName: IRailEndpointBlockParam
+  properties:
+  - key: maxConnectableRailLength
+    type: number
+    default: 100
 - interfaceName: IMinerParam
   properties:
   - key: outputItemSlotCount
@@ -548,6 +553,8 @@ properties:
           ref: gear
       - when: TrainRail
         type: object
+        implementationInterface:
+        - IRailEndpointBlockParam
         properties:
         - key: railPosition
           type: vector3
@@ -566,6 +573,7 @@ properties:
         implementationInterface:
         - IChestParam
         - IInventoryConnectors
+        - IRailEndpointBlockParam
         properties:
         - key: entryRailPosition
           type: vector3
@@ -600,6 +608,7 @@ properties:
         implementationInterface:
         - IChestParam
         - IInventoryConnectors
+        - IRailEndpointBlockParam
         properties:
         - key: entryRailPosition
           type: vector3
@@ -632,6 +641,8 @@ properties:
           ref: inventoryConnects
       - when: TrainFluidPlatform
         type: object
+        implementationInterface:
+        - IRailEndpointBlockParam
         properties:
         - key: entryRailPosition
           type: vector3

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/TrainRailConnect/RailConnectPreviewObject.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/TrainRailConnect/RailConnectPreviewObject.cs
@@ -38,7 +38,8 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.TrainRailConnect
                 // プレビュー内容が変わった時だけ更新する
                 // Update only when preview data changes
                 _railChain.SetControlPoints(data.StartPoint, data.StartControlPoint, data.EndControlPoint, data.EndPoint);
-                _railChain.SetPreviewColor(data.HasEnoughRailItem ? MaterialConst.PlaceableColor : MaterialConst.NotPlaceableColor);
+                var placeable = data.HasEnoughRailItem && data.IsLengthValid;
+                _railChain.SetPreviewColor(placeable ? MaterialConst.PlaceableColor : MaterialConst.NotPlaceableColor);
                 _railChain.Rebuild();
                 _previewDataCache = data;
             }

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/TrainRailConnect/RailConnectPreviewObject.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/TrainRailConnect/RailConnectPreviewObject.cs
@@ -38,8 +38,7 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.TrainRailConnect
                 // プレビュー内容が変わった時だけ更新する
                 // Update only when preview data changes
                 _railChain.SetControlPoints(data.StartPoint, data.StartControlPoint, data.EndControlPoint, data.EndPoint);
-                var placeable = data.HasEnoughRailItem && data.IsLengthValid;
-                _railChain.SetPreviewColor(placeable ? MaterialConst.PlaceableColor : MaterialConst.NotPlaceableColor);
+                _railChain.SetPreviewColor(data.IsPlaceable ? MaterialConst.PlaceableColor : MaterialConst.NotPlaceableColor);
                 _railChain.Rebuild();
                 _previewDataCache = data;
             }

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/TrainRailConnect/TrainRailConnectPreviewCalculator.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/TrainRailConnect/TrainRailConnectPreviewCalculator.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using Client.Game.InGame.Block;
 using Client.Game.InGame.BlockSystem.PlaceSystem.TrainRail;
 using Client.Game.InGame.Train.RailGraph;
@@ -7,7 +6,6 @@ using Client.Game.InGame.UI.Inventory.Main;
 using Game.Train.RailCalc;
 using Game.Train.SaveLoad;
 using Mooresmaster.Model.BlocksModule;
-using Mooresmaster.Model.TrainModule;
 using Server.Protocol.PacketResponse;
 using UnityEngine;
 
@@ -39,22 +37,17 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.TrainRailConnect
                 return TrainRailConnectPreviewData.Invalid;
             }
 
-            // レール長から設置可能なレールを判定
-            // Determine placeable rail items from curve length
+            // 両端ブロックから最大レール長を解決し、サーバーと同じ判定を共有する
+            // Resolve both endpoints' max length and share the server-side judgement
             var length = BezierUtility.GetBezierCurveLength(fromNode, toNode, 64);
-            (RailItemMasterElement element, int requiredCount)[] placeableRailItems = RailConnectionEditProtocol.GetPlaceableRailItems(playerInventory, length);
-            var railTypeGuid = placeableRailItems.Length > 0 ? placeableRailItems[0].element.ItemGuid : Guid.Empty;
-
-            // 両端ブロックから最大レール長を解決し、短い方を上限として比較
-            // Resolve max rail length from both endpoint blocks and compare against the shorter one
             var fromMax = ResolveMaxConnectableRailLength(from, blockGameObjectDataStore);
             var toMax = ResolveMaxConnectableRailLength(to, blockGameObjectDataStore);
-            var isLengthValid = length <= Mathf.Min(fromMax, toMax);
+            var judgement = RailConnectionEditProtocol.EvaluatePlacement(length, fromMax, toMax, playerInventory);
 
             // 描画用の制御点を生成
             // Build render control points
             BezierUtility.BuildRenderControlPoints(fromNode.FrontControlPoint, toNode.BackControlPoint, out var p0, out var p1, out var p2, out var p3);
-            return new TrainRailConnectPreviewData(p0, p1, p2, p3, railTypeGuid, placeableRailItems.Any(), isLengthValid);
+            return new TrainRailConnectPreviewData(p0, p1, p2, p3, judgement);
         }
 
         public static TrainRailConnectPreviewData CalculatePreviewData(ConnectionDestination from, Vector3 placePosition, RailComponentDirection direction, RailGraphClientCache cache, ILocalPlayerInventory playerInventory, BlockGameObjectDataStore blockGameObjectDataStore, float placingBlockMaxConnectableRailLength)
@@ -83,16 +76,14 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.TrainRailConnect
             // 描画用の制御点を生成
             // Build render control points
             BezierUtility.BuildRenderControlPoints(startPosition, endPosition, startDirection, endDirection, out var p0, out var p1, out var p2, out var p3);
+
+            // 始点側ブロックの上限と配置予定ブロックの上限でサーバーと同じ判定を共有する
+            // Share server-side judgement using source block limit and placing block limit
             var length = BezierUtility.GetBezierCurveLength(p0, p1, p2, p3, 64);
-            (RailItemMasterElement element, int requiredCount)[] placeableRailItems = RailConnectionEditProtocol.GetPlaceableRailItems(playerInventory, length);
-            var railTypeGuid = placeableRailItems.Length > 0 ? placeableRailItems[0].element.ItemGuid : Guid.Empty;
-
-            // 始点側のブロックと配置予定ブロックの上限を比較
-            // Compare limit between source block and the block to be placed
             var fromMax = ResolveMaxConnectableRailLength(from, blockGameObjectDataStore);
-            var isLengthValid = length <= Mathf.Min(fromMax, placingBlockMaxConnectableRailLength);
+            var judgement = RailConnectionEditProtocol.EvaluatePlacement(length, fromMax, placingBlockMaxConnectableRailLength, playerInventory);
 
-            return new TrainRailConnectPreviewData(p0, p1, p2, p3, railTypeGuid, placeableRailItems.Any(), isLengthValid);
+            return new TrainRailConnectPreviewData(p0, p1, p2, p3, judgement);
         }
 
         // ConnectionDestination が指すブロックから MaxConnectableRailLength を解決する
@@ -113,17 +104,22 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.TrainRailConnect
 
     public struct TrainRailConnectPreviewData : IEquatable<TrainRailConnectPreviewData>
     {
-        public static TrainRailConnectPreviewData Invalid => new(Vector3.zero, Vector3.zero, Vector3.zero, Vector3.zero, Guid.Empty, false, false, false);
+        public static TrainRailConnectPreviewData Invalid => new(Vector3.zero, Vector3.zero, Vector3.zero, Vector3.zero, Guid.Empty, false, false);
+        
         public Vector3 StartPoint;
         public Vector3 StartControlPoint;
         public Vector3 EndControlPoint;
         public Vector3 EndPoint;
         public Guid RailTypeGuid;
         public bool IsValid;
-        public bool HasEnoughRailItem;
-        public bool IsLengthValid;
+        public bool IsPlaceable;
 
-        public TrainRailConnectPreviewData(Vector3 startPoint, Vector3 startControlPoint, Vector3 endControlPoint, Vector3 endPoint, Guid railTypeGuid, bool hasEnoughRailItem, bool isLengthValid, bool isValid = true)
+        public TrainRailConnectPreviewData(Vector3 startPoint, Vector3 startControlPoint, Vector3 endControlPoint, Vector3 endPoint, RailPlacementJudgement judgement)
+            : this(startPoint, startControlPoint, endControlPoint, endPoint, judgement.FirstPlaceableRailTypeGuid, judgement.IsPlaceable, true)
+        {
+        }
+
+        private TrainRailConnectPreviewData(Vector3 startPoint, Vector3 startControlPoint, Vector3 endControlPoint, Vector3 endPoint, Guid railTypeGuid, bool isPlaceable, bool isValid)
         {
             StartPoint = startPoint;
             StartControlPoint = startControlPoint;
@@ -131,12 +127,11 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.TrainRailConnect
             EndPoint = endPoint;
             IsValid = isValid;
             RailTypeGuid = railTypeGuid;
-            HasEnoughRailItem = hasEnoughRailItem;
-            IsLengthValid = isLengthValid;
+            IsPlaceable = isPlaceable;
         }
         public bool Equals(TrainRailConnectPreviewData other)
         {
-            return StartPoint.Equals(other.StartPoint) && StartControlPoint.Equals(other.StartControlPoint) && EndControlPoint.Equals(other.EndControlPoint) && EndPoint.Equals(other.EndPoint) && RailTypeGuid.Equals(other.RailTypeGuid) && IsLengthValid == other.IsLengthValid;
+            return StartPoint.Equals(other.StartPoint) && StartControlPoint.Equals(other.StartControlPoint) && EndControlPoint.Equals(other.EndControlPoint) && EndPoint.Equals(other.EndPoint) && RailTypeGuid.Equals(other.RailTypeGuid) && IsPlaceable == other.IsPlaceable;
         }
         public override bool Equals(object obj)
         {
@@ -144,7 +139,7 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.TrainRailConnect
         }
         public override int GetHashCode()
         {
-            return HashCode.Combine(StartPoint, StartControlPoint, EndControlPoint, EndPoint, RailTypeGuid, IsLengthValid);
+            return HashCode.Combine(StartPoint, StartControlPoint, EndControlPoint, EndPoint, RailTypeGuid, IsPlaceable);
         }
         public override string ToString()
         {

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/TrainRailConnect/TrainRailConnectPreviewCalculator.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/TrainRailConnect/TrainRailConnectPreviewCalculator.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Linq;
+using Client.Game.InGame.Block;
 using Client.Game.InGame.BlockSystem.PlaceSystem.TrainRail;
 using Client.Game.InGame.Train.RailGraph;
 using Client.Game.InGame.UI.Inventory.Main;
 using Game.Train.RailCalc;
 using Game.Train.SaveLoad;
+using Mooresmaster.Model.BlocksModule;
 using Mooresmaster.Model.TrainModule;
 using Server.Protocol.PacketResponse;
 using UnityEngine;
@@ -21,7 +23,7 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.TrainRailConnect
         /// 終点がノードの場合
         /// When the endpoint is a node
         /// </summary>
-        public static TrainRailConnectPreviewData CalculatePreviewData(ConnectionDestination from, ConnectionDestination to, RailGraphClientCache cache, ILocalPlayerInventory playerInventory)
+        public static TrainRailConnectPreviewData CalculatePreviewData(ConnectionDestination from, ConnectionDestination to, RailGraphClientCache cache, ILocalPlayerInventory playerInventory, BlockGameObjectDataStore blockGameObjectDataStore)
         {
             // 始点ノードを取得
             // Get the start node
@@ -29,27 +31,33 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.TrainRailConnect
             {
                 return TrainRailConnectPreviewData.Invalid;
             }
-            
+
             // 終点ノードを取得
             // Get the end node
             if (!cache.TryGetNodeId(to, out var toNodeId) || !cache.TryGetNode(toNodeId, out var toNode))
             {
                 return TrainRailConnectPreviewData.Invalid;
             }
-            
+
             // レール長から設置可能なレールを判定
             // Determine placeable rail items from curve length
             var length = BezierUtility.GetBezierCurveLength(fromNode, toNode, 64);
             (RailItemMasterElement element, int requiredCount)[] placeableRailItems = RailConnectionEditProtocol.GetPlaceableRailItems(playerInventory, length);
             var railTypeGuid = placeableRailItems.Length > 0 ? placeableRailItems[0].element.ItemGuid : Guid.Empty;
-            
+
+            // 両端ブロックから最大レール長を解決し、短い方を上限として比較
+            // Resolve max rail length from both endpoint blocks and compare against the shorter one
+            var fromMax = ResolveMaxConnectableRailLength(from, blockGameObjectDataStore);
+            var toMax = ResolveMaxConnectableRailLength(to, blockGameObjectDataStore);
+            var isLengthValid = length <= Mathf.Min(fromMax, toMax);
+
             // 描画用の制御点を生成
             // Build render control points
             BezierUtility.BuildRenderControlPoints(fromNode.FrontControlPoint, toNode.BackControlPoint, out var p0, out var p1, out var p2, out var p3);
-            return new TrainRailConnectPreviewData(p0, p1, p2, p3, railTypeGuid, placeableRailItems.Any());
+            return new TrainRailConnectPreviewData(p0, p1, p2, p3, railTypeGuid, placeableRailItems.Any(), isLengthValid);
         }
-        
-        public static TrainRailConnectPreviewData CalculatePreviewData(ConnectionDestination from, Vector3 placePosition, RailComponentDirection direction, RailGraphClientCache cache, ILocalPlayerInventory playerInventory)
+
+        public static TrainRailConnectPreviewData CalculatePreviewData(ConnectionDestination from, Vector3 placePosition, RailComponentDirection direction, RailGraphClientCache cache, ILocalPlayerInventory playerInventory, BlockGameObjectDataStore blockGameObjectDataStore, float placingBlockMaxConnectableRailLength)
         {
             // 始点ノードを取得
             // Get the start node
@@ -57,7 +65,7 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.TrainRailConnect
             {
                 return TrainRailConnectPreviewData.Invalid;
             }
-            
+
             // 制御点計算に必要な位置と方向を取得
             // Get positions and directions for control points
             var startPosition = fromNode.FrontControlPoint.OriginalPosition;
@@ -78,13 +86,42 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.TrainRailConnect
             var length = BezierUtility.GetBezierCurveLength(p0, p1, p2, p3, 64);
             (RailItemMasterElement element, int requiredCount)[] placeableRailItems = RailConnectionEditProtocol.GetPlaceableRailItems(playerInventory, length);
             var railTypeGuid = placeableRailItems.Length > 0 ? placeableRailItems[0].element.ItemGuid : Guid.Empty;
-            return new TrainRailConnectPreviewData(p0, p1, p2, p3, railTypeGuid, placeableRailItems.Any());
+
+            // 始点側のブロックと配置予定ブロックの上限を比較
+            // Compare limit between source block and the block to be placed
+            var fromMax = ResolveMaxConnectableRailLength(from, blockGameObjectDataStore);
+            var isLengthValid = length <= Mathf.Min(fromMax, placingBlockMaxConnectableRailLength);
+
+            return new TrainRailConnectPreviewData(p0, p1, p2, p3, railTypeGuid, placeableRailItems.Any(), isLengthValid);
+        }
+
+        // ConnectionDestination が指すブロックから MaxConnectableRailLength を解決する
+        // Resolve MaxConnectableRailLength from the block referenced by ConnectionDestination
+        public static float ResolveMaxConnectableRailLength(ConnectionDestination dest, BlockGameObjectDataStore blockGameObjectDataStore)
+        {
+            if (blockGameObjectDataStore == null) return float.MaxValue;
+            if (!blockGameObjectDataStore.TryGetBlockGameObject((Vector3Int)dest.blockPosition, out var blockGameObject)) return float.MaxValue;
+            return GetMaxConnectableRailLength(blockGameObject.BlockMasterElement);
+        }
+
+        // BlockMasterElement から各種 BlockParam の MaxConnectableRailLength を取り出す
+        // Extract MaxConnectableRailLength from each kind of BlockParam
+        public static float GetMaxConnectableRailLength(BlockMasterElement element)
+        {
+            return element.BlockParam switch
+            {
+                TrainRailBlockParam p => (float)p.MaxConnectableRailLength,
+                TrainStationBlockParam p => (float)p.MaxConnectableRailLength,
+                TrainItemPlatformBlockParam p => (float)p.MaxConnectableRailLength,
+                TrainFluidPlatformBlockParam p => (float)p.MaxConnectableRailLength,
+                _ => float.MaxValue,
+            };
         }
     }
-    
+
     public struct TrainRailConnectPreviewData : IEquatable<TrainRailConnectPreviewData>
     {
-        public static TrainRailConnectPreviewData Invalid => new(Vector3.zero, Vector3.zero, Vector3.zero, Vector3.zero, Guid.Empty, false, false); 
+        public static TrainRailConnectPreviewData Invalid => new(Vector3.zero, Vector3.zero, Vector3.zero, Vector3.zero, Guid.Empty, false, false, false);
         public Vector3 StartPoint;
         public Vector3 StartControlPoint;
         public Vector3 EndControlPoint;
@@ -92,8 +129,9 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.TrainRailConnect
         public Guid RailTypeGuid;
         public bool IsValid;
         public bool HasEnoughRailItem;
-        
-        public TrainRailConnectPreviewData(Vector3 startPoint, Vector3 startControlPoint, Vector3 endControlPoint, Vector3 endPoint, Guid railTypeGuid, bool hasEnoughRailItem, bool isValid = true)
+        public bool IsLengthValid;
+
+        public TrainRailConnectPreviewData(Vector3 startPoint, Vector3 startControlPoint, Vector3 endControlPoint, Vector3 endPoint, Guid railTypeGuid, bool hasEnoughRailItem, bool isLengthValid, bool isValid = true)
         {
             StartPoint = startPoint;
             StartControlPoint = startControlPoint;
@@ -102,10 +140,11 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.TrainRailConnect
             IsValid = isValid;
             RailTypeGuid = railTypeGuid;
             HasEnoughRailItem = hasEnoughRailItem;
+            IsLengthValid = isLengthValid;
         }
         public bool Equals(TrainRailConnectPreviewData other)
         {
-            return StartPoint.Equals(other.StartPoint) && StartControlPoint.Equals(other.StartControlPoint) && EndControlPoint.Equals(other.EndControlPoint) && EndPoint.Equals(other.EndPoint) && RailTypeGuid.Equals(other.RailTypeGuid);
+            return StartPoint.Equals(other.StartPoint) && StartControlPoint.Equals(other.StartControlPoint) && EndControlPoint.Equals(other.EndControlPoint) && EndPoint.Equals(other.EndPoint) && RailTypeGuid.Equals(other.RailTypeGuid) && IsLengthValid == other.IsLengthValid;
         }
         public override bool Equals(object obj)
         {
@@ -113,7 +152,7 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.TrainRailConnect
         }
         public override int GetHashCode()
         {
-            return HashCode.Combine(StartPoint, StartControlPoint, EndControlPoint, EndPoint, RailTypeGuid);
+            return HashCode.Combine(StartPoint, StartControlPoint, EndControlPoint, EndPoint, RailTypeGuid, IsLengthValid);
         }
         public override string ToString()
         {

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/TrainRailConnect/TrainRailConnectPreviewCalculator.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/TrainRailConnect/TrainRailConnectPreviewCalculator.cs
@@ -3,6 +3,7 @@ using Client.Game.InGame.Block;
 using Client.Game.InGame.BlockSystem.PlaceSystem.TrainRail;
 using Client.Game.InGame.Train.RailGraph;
 using Client.Game.InGame.UI.Inventory.Main;
+using Core.Master;
 using Game.Train.RailCalc;
 using Game.Train.SaveLoad;
 using Mooresmaster.Model.BlocksModule;
@@ -21,7 +22,7 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.TrainRailConnect
         /// 終点がノードの場合
         /// When the endpoint is a node
         /// </summary>
-        public static TrainRailConnectPreviewData CalculatePreviewData(ConnectionDestination from, ConnectionDestination to, RailGraphClientCache cache, ILocalPlayerInventory playerInventory, BlockGameObjectDataStore blockGameObjectDataStore)
+        public static TrainRailConnectPreviewData CalculatePreviewData(ConnectionDestination from, ConnectionDestination to, RailGraphClientCache cache, ILocalPlayerInventory playerInventory, BlockGameObjectDataStore blockGameObjectDataStore, ItemId holdingRailItemId)
         {
             // 始点ノードを取得
             // Get the start node
@@ -37,12 +38,12 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.TrainRailConnect
                 return TrainRailConnectPreviewData.Invalid;
             }
 
-            // 両端ブロックから最大レール長を解決し、サーバーと同じ判定を共有する
-            // Resolve both endpoints' max length and share the server-side judgement
+            // 両端ブロックから最大レール長を解決し、所持中レールアイテムでサーバーと同じ判定を共有する
+            // Resolve both endpoints' max length and share the server-side judgement using the held rail item
             var length = BezierUtility.GetBezierCurveLength(fromNode, toNode, 64);
             var fromMax = ResolveMaxConnectableRailLength(from, blockGameObjectDataStore);
             var toMax = ResolveMaxConnectableRailLength(to, blockGameObjectDataStore);
-            var judgement = RailConnectionEditProtocol.EvaluatePlacement(length, fromMax, toMax, playerInventory);
+            var judgement = RailConnectionEditProtocol.EvaluatePlacement(length, fromMax, toMax, playerInventory, holdingRailItemId);
 
             // 描画用の制御点を生成
             // Build render control points
@@ -50,7 +51,7 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.TrainRailConnect
             return new TrainRailConnectPreviewData(p0, p1, p2, p3, judgement);
         }
 
-        public static TrainRailConnectPreviewData CalculatePreviewData(ConnectionDestination from, Vector3 placePosition, RailComponentDirection direction, RailGraphClientCache cache, ILocalPlayerInventory playerInventory, BlockGameObjectDataStore blockGameObjectDataStore, float placingBlockMaxConnectableRailLength)
+        public static TrainRailConnectPreviewData CalculatePreviewData(ConnectionDestination from, Vector3 placePosition, RailComponentDirection direction, RailGraphClientCache cache, ILocalPlayerInventory playerInventory, BlockGameObjectDataStore blockGameObjectDataStore, float placingBlockMaxConnectableRailLength, ItemId holdingRailItemId)
         {
             // 始点ノードを取得
             // Get the start node
@@ -77,11 +78,11 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.TrainRailConnect
             // Build render control points
             BezierUtility.BuildRenderControlPoints(startPosition, endPosition, startDirection, endDirection, out var p0, out var p1, out var p2, out var p3);
 
-            // 始点側ブロックの上限と配置予定ブロックの上限でサーバーと同じ判定を共有する
-            // Share server-side judgement using source block limit and placing block limit
+            // 始点側ブロックの上限と配置予定ブロックの上限で所持中レールアイテムを使ったサーバーと同じ判定を共有する
+            // Share server-side judgement using source block limit, placing block limit, and the held rail item
             var length = BezierUtility.GetBezierCurveLength(p0, p1, p2, p3, 64);
             var fromMax = ResolveMaxConnectableRailLength(from, blockGameObjectDataStore);
-            var judgement = RailConnectionEditProtocol.EvaluatePlacement(length, fromMax, placingBlockMaxConnectableRailLength, playerInventory);
+            var judgement = RailConnectionEditProtocol.EvaluatePlacement(length, fromMax, placingBlockMaxConnectableRailLength, playerInventory, holdingRailItemId);
 
             return new TrainRailConnectPreviewData(p0, p1, p2, p3, judgement);
         }
@@ -115,7 +116,7 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.TrainRailConnect
         public bool IsPlaceable;
 
         public TrainRailConnectPreviewData(Vector3 startPoint, Vector3 startControlPoint, Vector3 endControlPoint, Vector3 endPoint, RailPlacementJudgement judgement)
-            : this(startPoint, startControlPoint, endControlPoint, endPoint, judgement.FirstPlaceableRailTypeGuid, judgement.IsPlaceable, true)
+            : this(startPoint, startControlPoint, endControlPoint, endPoint, judgement.SelectedRailTypeGuid, judgement.IsPlaceable, true)
         {
         }
 

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/TrainRailConnect/TrainRailConnectPreviewCalculator.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/TrainRailConnect/TrainRailConnectPreviewCalculator.cs
@@ -99,23 +99,15 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.TrainRailConnect
         // Resolve MaxConnectableRailLength from the block referenced by ConnectionDestination
         public static float ResolveMaxConnectableRailLength(ConnectionDestination dest, BlockGameObjectDataStore blockGameObjectDataStore)
         {
-            if (blockGameObjectDataStore == null) return float.MaxValue;
             if (!blockGameObjectDataStore.TryGetBlockGameObject((Vector3Int)dest.blockPosition, out var blockGameObject)) return float.MaxValue;
             return GetMaxConnectableRailLength(blockGameObject.BlockMasterElement);
         }
 
-        // BlockMasterElement から各種 BlockParam の MaxConnectableRailLength を取り出す
-        // Extract MaxConnectableRailLength from each kind of BlockParam
+        // BlockMasterElement の BlockParam が IRailEndpointBlockParam を実装している場合に値を取り出す
+        // Read MaxConnectableRailLength via IRailEndpointBlockParam interface
         public static float GetMaxConnectableRailLength(BlockMasterElement element)
         {
-            return element.BlockParam switch
-            {
-                TrainRailBlockParam p => (float)p.MaxConnectableRailLength,
-                TrainStationBlockParam p => (float)p.MaxConnectableRailLength,
-                TrainItemPlatformBlockParam p => (float)p.MaxConnectableRailLength,
-                TrainFluidPlatformBlockParam p => (float)p.MaxConnectableRailLength,
-                _ => float.MaxValue,
-            };
+            return element.BlockParam is IRailEndpointBlockParam param ? (float)param.MaxConnectableRailLength : float.MaxValue;
         }
     }
 

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/TrainRailConnect/TrainRailConnectSystem.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/TrainRailConnect/TrainRailConnectSystem.cs
@@ -90,7 +90,7 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.TrainRailConnect
                     {
                         // pierがない場合は設置不可。仮にデフォルトの最大長で判定する
                         // No pier in inventory: still preview with default max length
-                        var previewData = CalculatePreviewData(fromDestination, position, _trainRailPlaceSystemService.RailDirection, _cache, _playerInventory, _blockGameObjectDataStore, float.MaxValue);
+                        var previewData = CalculatePreviewData(fromDestination, position, _trainRailPlaceSystemService.RailDirection, _cache, _playerInventory, _blockGameObjectDataStore, float.MaxValue, context.HoldingItemId);
                         ShowPreview(previewData);
                     }
                     else
@@ -102,7 +102,7 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.TrainRailConnect
                         var pierBlockMaster = MasterHolder.BlockMaster.GetBlockMaster(pierBlockId);
                         var pierMaxLength = TrainRailConnectPreviewCalculator.GetMaxConnectableRailLength(pierBlockMaster);
                         var placeInfo = _trainRailPlaceSystemService.ManualUpdate(itemStack.Id);
-                        var previewData = CalculatePreviewData(fromDestination, _trainRailPlaceSystemService.ConnectorPosition, _trainRailPlaceSystemService.RailDirection, _cache, _playerInventory, _blockGameObjectDataStore, pierMaxLength);
+                        var previewData = CalculatePreviewData(fromDestination, _trainRailPlaceSystemService.ConnectorPosition, _trainRailPlaceSystemService.RailDirection, _cache, _playerInventory, _blockGameObjectDataStore, pierMaxLength, context.HoldingItemId);
                         ShowPreview(previewData);
 
                         if (!previewData.IsPlaceable) return;
@@ -131,7 +131,7 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.TrainRailConnect
                     return;
                 }
                 
-                var previewData = CalculatePreviewData(fromDestination, toDestination, _cache, _playerInventory, _blockGameObjectDataStore);
+                var previewData = CalculatePreviewData(fromDestination, toDestination, _cache, _playerInventory, _blockGameObjectDataStore, context.HoldingItemId);
                 ShowPreview(previewData);
 
                 if (!previewData.IsPlaceable) return;

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/TrainRailConnect/TrainRailConnectSystem.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/TrainRailConnect/TrainRailConnectSystem.cs
@@ -88,18 +88,25 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.TrainRailConnect
                     
                     if (!pierSlots.Any())
                     {
-                        // pierがない場合は設置不可
-                        var previewData = CalculatePreviewData(fromDestination, position, _trainRailPlaceSystemService.RailDirection, _cache, _playerInventory);
+                        // pierがない場合は設置不可。仮にデフォルトの最大長で判定する
+                        // No pier in inventory: still preview with default max length
+                        var previewData = CalculatePreviewData(fromDestination, position, _trainRailPlaceSystemService.RailDirection, _cache, _playerInventory, _blockGameObjectDataStore, float.MaxValue);
                         ShowPreview(previewData);
                     }
                     else
                     {
-                        // pierがある場合は設置可能
+                        // pierがある場合は設置可能。配置予定の TrainRail ブロックの最大長を参照する
+                        // Pier available: pass the placing TrainRail block's max length
                         var (itemStack, pierInventorySlot) = pierSlots.First();
+                        var pierBlockId = MasterHolder.BlockMaster.GetBlockId(itemStack.Id);
+                        var pierBlockMaster = MasterHolder.BlockMaster.GetBlockMaster(pierBlockId);
+                        var pierMaxLength = TrainRailConnectPreviewCalculator.GetMaxConnectableRailLength(pierBlockMaster);
                         var placeInfo = _trainRailPlaceSystemService.ManualUpdate(itemStack.Id);
-                        var previewData = CalculatePreviewData(fromDestination, _trainRailPlaceSystemService.ConnectorPosition, _trainRailPlaceSystemService.RailDirection, _cache, _playerInventory);
+                        var previewData = CalculatePreviewData(fromDestination, _trainRailPlaceSystemService.ConnectorPosition, _trainRailPlaceSystemService.RailDirection, _cache, _playerInventory, _blockGameObjectDataStore, pierMaxLength);
                         ShowPreview(previewData);
-                        
+
+                        if (!previewData.IsLengthValid) return;
+
                         // 設置
                         SendConnectRailWithPlacePierProtocol(placeInfo, previewData.RailTypeGuid, pierInventorySlot);
                     }
@@ -124,12 +131,13 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.TrainRailConnect
                     return;
                 }
                 
-                var previewData = CalculatePreviewData(fromDestination, toDestination, _cache, _playerInventory);
+                var previewData = CalculatePreviewData(fromDestination, toDestination, _cache, _playerInventory, _blockGameObjectDataStore);
                 ShowPreview(previewData);
-                
+
                 if (!previewData.HasEnoughRailItem) return;
-                
-                SendConnectRailProtocol(fromNode, toNode, previewData.RailTypeGuid);   
+                if (!previewData.IsLengthValid) return;
+
+                SendConnectRailProtocol(fromNode, toNode, previewData.RailTypeGuid);
             }
             
             #region Internal

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/TrainRailConnect/TrainRailConnectSystem.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/TrainRailConnect/TrainRailConnectSystem.cs
@@ -105,7 +105,7 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.TrainRailConnect
                         var previewData = CalculatePreviewData(fromDestination, _trainRailPlaceSystemService.ConnectorPosition, _trainRailPlaceSystemService.RailDirection, _cache, _playerInventory, _blockGameObjectDataStore, pierMaxLength);
                         ShowPreview(previewData);
 
-                        if (!previewData.IsLengthValid) return;
+                        if (!previewData.IsPlaceable) return;
 
                         // 設置
                         SendConnectRailWithPlacePierProtocol(placeInfo, previewData.RailTypeGuid, pierInventorySlot);
@@ -134,8 +134,7 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.TrainRailConnect
                 var previewData = CalculatePreviewData(fromDestination, toDestination, _cache, _playerInventory, _blockGameObjectDataStore);
                 ShowPreview(previewData);
 
-                if (!previewData.HasEnoughRailItem) return;
-                if (!previewData.IsLengthValid) return;
+                if (!previewData.IsPlaceable) return;
 
                 SendConnectRailProtocol(fromNode, toNode, previewData.RailTypeGuid);
             }

--- a/moorestech_server/Assets/Scripts/Core.Master/_CompileRequester.cs
+++ b/moorestech_server/Assets/Scripts/Core.Master/_CompileRequester.cs
@@ -5,5 +5,5 @@ public class CompileRequester
 {
 // スキーマを更新したら、こちらの更新もコミットしてください。
 // If you update the schema, please also commit this update.
-    private const string dummyText = "2026/05/18 19:32:09";
+    private const string dummyText = "2026/05/18 21:03:46";
 }

--- a/moorestech_server/Assets/Scripts/Core.Master/_CompileRequester.cs
+++ b/moorestech_server/Assets/Scripts/Core.Master/_CompileRequester.cs
@@ -5,5 +5,5 @@ public class CompileRequester
 {
 // スキーマを更新したら、こちらの更新もコミットしてください。
 // If you update the schema, please also commit this update.
-    private const string dummyText = "2026/05/18 18:59:27";
+    private const string dummyText = "2026/05/18 19:32:09";
 }

--- a/moorestech_server/Assets/Scripts/Game.Block/Blocks/TrainRail/RailComponent.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Blocks/TrainRail/RailComponent.cs
@@ -59,6 +59,8 @@ namespace Game.Block.Blocks.TrainRail
             BackNode.SetRailControlPoints(BackControlPoint, FrontControlPoint);
             FrontNode.SetConnectionDestination(new ConnectionDestination(blockPosition, componentIndex, true));
             BackNode.SetConnectionDestination(new ConnectionDestination(blockPosition, componentIndex, false));
+            FrontNode.SetMaxConnectableRailLength(maxConnectableRailLength);
+            BackNode.SetMaxConnectableRailLength(maxConnectableRailLength);
             _railGraphDatastore.AddNodePair(FrontNode, BackNode);
             return;
             

--- a/moorestech_server/Assets/Scripts/Game.Block/Blocks/TrainRail/RailComponent.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Blocks/TrainRail/RailComponent.cs
@@ -27,21 +27,26 @@ namespace Game.Block.Blocks.TrainRail
         //Vector3形式であるが、現時点でこの値自体の誤差は許容している。もしrailcomponent.positionを新規に使う場合すでに誤差が含まれていることを考慮すること
         public Vector3 Position { get; }
         public readonly Vector3 RailDirection;
-        
+
+        // このRailComponentから接続可能なレールセグメントの最大長(m)
+        // Maximum length (m) of a rail segment that can be connected from this RailComponent
+        public float MaxConnectableRailLength { get; }
+
         /// <summary>
         /// レール方向にBlockDirectionを用いるコンストラクタ
         /// </summary>
-        public RailComponent(IRailGraphDatastore railGraphDatastore, Vector3 position, BlockDirection blockDirection, Vector3Int blockPosition, int componentIndex) : this(railGraphDatastore, position, ToVector3(blockDirection), blockPosition, componentIndex) { }
+        public RailComponent(IRailGraphDatastore railGraphDatastore, Vector3 position, BlockDirection blockDirection, Vector3Int blockPosition, int componentIndex, float maxConnectableRailLength) : this(railGraphDatastore, position, ToVector3(blockDirection), blockPosition, componentIndex, maxConnectableRailLength) { }
 
         /// <summary>
         /// コンストラクタ
         /// </summary>
-        public RailComponent(IRailGraphDatastore railGraphDatastore, Vector3 position, Vector3 railDirection, Vector3Int blockPosition, int componentIndex)
+        public RailComponent(IRailGraphDatastore railGraphDatastore, Vector3 position, Vector3 railDirection, Vector3Int blockPosition, int componentIndex, float maxConnectableRailLength)
         {
             _railGraphDatastore = railGraphDatastore;
 
             Position = position;
             RailDirection = railDirection;
+            MaxConnectableRailLength = maxConnectableRailLength;
 
             // ベジェ曲線の制御点を初期化
             FrontControlPoint = new RailControlPoint(position, CalculateControlPointOffset(true));

--- a/moorestech_server/Assets/Scripts/Game.Block/Factory/BlockTemplate/Utility/RailComponentUtility.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Factory/BlockTemplate/Utility/RailComponentUtility.cs
@@ -14,24 +14,24 @@ namespace Game.Block.Factory.BlockTemplate.Utility
         /// 復元メイン
         /// </summary>
         //駅のように2つのRailComponentを持つブロックの復元処理
-        static public RailComponent[] Restore2RailComponents(BlockPositionInfo blockPositionInfo, Vector3 entryPosition, Vector3 exitPosition, IRailGraphDatastore railGraphDatastore)
+        static public RailComponent[] Restore2RailComponents(BlockPositionInfo blockPositionInfo, Vector3 entryPosition, Vector3 exitPosition, IRailGraphDatastore railGraphDatastore, float maxConnectableRailLength)
         {
             var railComponentPositions = new Vector3[2];
             railComponentPositions[0] = CalculateRailComponentPosition(blockPositionInfo, entryPosition);
             railComponentPositions[1] = CalculateRailComponentPosition(blockPositionInfo, exitPosition);
 
             var railComponents = new RailComponent[2];
-            railComponents[0] = new RailComponent(railGraphDatastore, railComponentPositions[0], blockPositionInfo.BlockDirection, blockPositionInfo.OriginalPos, 0);
-            railComponents[1] = new RailComponent(railGraphDatastore, railComponentPositions[1], blockPositionInfo.BlockDirection, blockPositionInfo.OriginalPos, 1);
+            railComponents[0] = new RailComponent(railGraphDatastore, railComponentPositions[0], blockPositionInfo.BlockDirection, blockPositionInfo.OriginalPos, 0, maxConnectableRailLength);
+            railComponents[1] = new RailComponent(railGraphDatastore, railComponentPositions[1], blockPositionInfo.BlockDirection, blockPositionInfo.OriginalPos, 1, maxConnectableRailLength);
             return railComponents;
         }
 
         //駅以外、事実上橋脚ブロックの復元処理
-        static public RailComponent[] Restore1RailComponents(BlockPositionInfo blockPositionInfo, Vector3 componentPosition, IRailGraphDatastore railGraphDatastore)
+        static public RailComponent[] Restore1RailComponents(BlockPositionInfo blockPositionInfo, Vector3 componentPosition, IRailGraphDatastore railGraphDatastore, float maxConnectableRailLength)
         {
             var railComponentPosition = CalculateRailComponentPosition(blockPositionInfo, componentPosition);
             var railComponents = new RailComponent[1];
-            railComponents[0] = new RailComponent(railGraphDatastore, railComponentPosition, blockPositionInfo.BlockDirection, blockPositionInfo.OriginalPos, 0);
+            railComponents[0] = new RailComponent(railGraphDatastore, railComponentPosition, blockPositionInfo.BlockDirection, blockPositionInfo.OriginalPos, 0, maxConnectableRailLength);
             return railComponents;
         }
 
@@ -57,7 +57,7 @@ namespace Game.Block.Factory.BlockTemplate.Utility
 
         // 指定数のRailComponentを作成し、必要に応じて自動的に接続します。
         // 今のところstation,cargoなど1つのブロックに2つのRailComponentを持つものだけを想定しています。
-        public static RailComponent[] Create2RailComponents(BlockPositionInfo positionInfo, Vector3 entryPosition, Vector3 exitPosition, IRailGraphDatastore railGraphDatastore)
+        public static RailComponent[] Create2RailComponents(BlockPositionInfo positionInfo, Vector3 entryPosition, Vector3 exitPosition, IRailGraphDatastore railGraphDatastore, float maxConnectableRailLength)
         {
             var positions = new Vector3[2];
             positions[0] = CalculateRailComponentPosition(positionInfo, entryPosition);
@@ -65,7 +65,7 @@ namespace Game.Block.Factory.BlockTemplate.Utility
             var components = new RailComponent[2];
             for (int i = 0; i < 2; i++)
             {
-                components[i] = new RailComponent(railGraphDatastore, positions[i], positionInfo.BlockDirection, positionInfo.OriginalPos, i);
+                components[i] = new RailComponent(railGraphDatastore, positions[i], positionInfo.BlockDirection, positionInfo.OriginalPos, i, maxConnectableRailLength);
             }
             // stationの前と後ろにそれぞれrailComponentがある、自動で接続する
             //components[0].ConnectRailComponent(components[1], true, true);

--- a/moorestech_server/Assets/Scripts/Game.Block/Factory/BlockTemplate/VanillaTrainFluidPlatformTemplate.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Factory/BlockTemplate/VanillaTrainFluidPlatformTemplate.cs
@@ -26,7 +26,7 @@ namespace Game.Block.Factory.BlockTemplate
         {
             var param = masterElement.BlockParam as TrainFluidPlatformBlockParam;
 
-            var railComponents = RailComponentUtility.Create2RailComponents(positionInfo, param.EntryRailPosition, param.ExitRailPosition, _railGraphDatastore);
+            var railComponents = RailComponentUtility.Create2RailComponents(positionInfo, param.EntryRailPosition, param.ExitRailPosition, _railGraphDatastore, (float)param.MaxConnectableRailLength);
             RailComponentUtility.RegisterAndConnetStationBlocks(railComponents, _railGraphDatastore);
 
             var trainPlatformDockingComponent = new TrainPlatformDockingComponent(param.LoadingAnimeSpeed);
@@ -58,7 +58,7 @@ namespace Game.Block.Factory.BlockTemplate
         {
             var param = masterElement.BlockParam as TrainFluidPlatformBlockParam;
 
-            var railComponents = RailComponentUtility.Restore2RailComponents(positionInfo, param.EntryRailPosition, param.ExitRailPosition, _railGraphDatastore);
+            var railComponents = RailComponentUtility.Restore2RailComponents(positionInfo, param.EntryRailPosition, param.ExitRailPosition, _railGraphDatastore, (float)param.MaxConnectableRailLength);
             RailComponentUtility.RegisterStationBlocks(railComponents, _railGraphDatastore);
 
             var trainPlatformDockingComponent = new TrainPlatformDockingComponent(componentStates, param.LoadingAnimeSpeed);

--- a/moorestech_server/Assets/Scripts/Game.Block/Factory/BlockTemplate/VanillaTrainItemPlatformTemplate.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Factory/BlockTemplate/VanillaTrainItemPlatformTemplate.cs
@@ -34,7 +34,7 @@ namespace Game.Block.Factory.BlockTemplate
             // 駅ブロックは常に2つのRailComponentを持つ
             //①1つのstation内にある2つのRailComponentを直線レールで接続
             //②stationをつなげて設置した場合にピッタリ重なる位置のrailComponentを自動接続するための処理
-            var railComponents = RailComponentUtility.Create2RailComponents(positionInfo, stationParam.EntryRailPosition, stationParam.ExitRailPosition, _railGraphDatastore);//①が行われる
+            var railComponents = RailComponentUtility.Create2RailComponents(positionInfo, stationParam.EntryRailPosition, stationParam.ExitRailPosition, _railGraphDatastore, (float)stationParam.MaxConnectableRailLength);//①が行われる
             RailComponentUtility.RegisterAndConnetStationBlocks(railComponents, _railGraphDatastore);//②接続処理
             var trainPlatformDockingComponent = new TrainPlatformDockingComponent(stationParam.LoadingAnimeSpeed);
             var trainPlatformTransferComponent = new TrainPlatformTransferComponent(TrainPlatformTransferComponent.TransferMode.LoadToTrain);
@@ -71,7 +71,7 @@ namespace Game.Block.Factory.BlockTemplate
             // 現仕様では接続はRailSegment復元に委ねるため、ここでは登録のみ行う
             // In current flow, connections are restored by rail segments, so we only register here
             var stationParam = masterElement.BlockParam as TrainItemPlatformBlockParam;
-            var railComponents = RailComponentUtility.Restore2RailComponents(positionInfo, stationParam.EntryRailPosition, stationParam.ExitRailPosition, _railGraphDatastore);//①復元
+            var railComponents = RailComponentUtility.Restore2RailComponents(positionInfo, stationParam.EntryRailPosition, stationParam.ExitRailPosition, _railGraphDatastore, (float)stationParam.MaxConnectableRailLength);//①復元
             RailComponentUtility.RegisterStationBlocks(railComponents, _railGraphDatastore);//②登録のみ
             var trainPlatformDockingComponent = new TrainPlatformDockingComponent(componentStates, stationParam.LoadingAnimeSpeed);
             var trainPlatformTransferComponent = new TrainPlatformTransferComponent(componentStates);

--- a/moorestech_server/Assets/Scripts/Game.Block/Factory/BlockTemplate/VanillaTrainRailTemplate.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Factory/BlockTemplate/VanillaTrainRailTemplate.cs
@@ -42,7 +42,8 @@ namespace Game.Block.Factory.BlockTemplate
             }
 
             var railComponentPosition = RailComponentUtility.CalculateRailComponentPosition(blockPositionInfo, trainRailParam.RailPosition);
-            railComponents[0] = new RailComponent(_railGraphDatastore, railComponentPosition, state.RailBlockDirection, blockPositionInfo.OriginalPos, 0);
+            var maxConnectableRailLength = (float)trainRailParam.MaxConnectableRailLength;
+            railComponents[0] = new RailComponent(_railGraphDatastore, railComponentPosition, state.RailBlockDirection, blockPositionInfo.OriginalPos, 0, maxConnectableRailLength);
 
             var stateDetailComponent = new RailComponentStateDetailComponent(railComponents[0]);
             var components = new List<IBlockComponent>();
@@ -64,7 +65,8 @@ namespace Game.Block.Factory.BlockTemplate
             var railDirection = RailComponentStateDetailComponent.LoadRailDirection(componentStates);
             var railComponents = new RailComponent[1];
             var railComponentPosition = RailComponentUtility.CalculateRailComponentPosition(positionInfo, trainRailParam.RailPosition);
-            railComponents[0] = new RailComponent(_railGraphDatastore, railComponentPosition, railDirection, positionInfo.OriginalPos, 0);
+            var maxConnectableRailLength = (float)trainRailParam.MaxConnectableRailLength;
+            railComponents[0] = new RailComponent(_railGraphDatastore, railComponentPosition, railDirection, positionInfo.OriginalPos, 0, maxConnectableRailLength);
 
             var stateDetailComponent = new RailComponentStateDetailComponent(railComponents[0]);
             var components = new List<IBlockComponent>();

--- a/moorestech_server/Assets/Scripts/Game.Block/Factory/BlockTemplate/VanillaTrainStationTemplate.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Factory/BlockTemplate/VanillaTrainStationTemplate.cs
@@ -34,7 +34,7 @@ namespace Game.Block.Factory.BlockTemplate
             // 駅ブロックは常に2つのRailComponentを持つ
             //①1つのstation内にある2つのRailComponentを直線レールで接続
             //②stationをつなげて設置した場合にピッタリ重なる位置のrailComponentを自動接続するための処理
-            var railComponents = RailComponentUtility.Create2RailComponents(positionInfo, stationParam.EntryRailPosition, stationParam.ExitRailPosition, _railGraphDatastore);//①が行われる
+            var railComponents = RailComponentUtility.Create2RailComponents(positionInfo, stationParam.EntryRailPosition, stationParam.ExitRailPosition, _railGraphDatastore, (float)stationParam.MaxConnectableRailLength);//①が行われる
             RailComponentUtility.RegisterAndConnetStationBlocks(railComponents, _railGraphDatastore);//②接続処理
             var station = new TrainStationComponent("test");
             var trainPlatformDockingComponent = new TrainPlatformDockingComponent(stationParam.LoadingAnimeSpeed);
@@ -73,7 +73,7 @@ namespace Game.Block.Factory.BlockTemplate
             // 現仕様では接続はRailSegment復元に委ねるため、ここでは登録のみ行う
             // In current flow, connections are restored by rail segments, so we only register here
             var stationParam = masterElement.BlockParam as TrainStationBlockParam;
-            var railComponents = RailComponentUtility.Restore2RailComponents(positionInfo, stationParam.EntryRailPosition, stationParam.ExitRailPosition, _railGraphDatastore);//①復元
+            var railComponents = RailComponentUtility.Restore2RailComponents(positionInfo, stationParam.EntryRailPosition, stationParam.ExitRailPosition, _railGraphDatastore, (float)stationParam.MaxConnectableRailLength);//①復元
             RailComponentUtility.RegisterStationBlocks(railComponents, _railGraphDatastore);//②登録のみ
             var station = new TrainStationComponent(componentStates);
             var trainPlatformDockingComponent = new TrainPlatformDockingComponent(componentStates, stationParam.LoadingAnimeSpeed);

--- a/moorestech_server/Assets/Scripts/Game.Train/RailGraph/RailNode.cs
+++ b/moorestech_server/Assets/Scripts/Game.Train/RailGraph/RailNode.cs
@@ -19,6 +19,10 @@ namespace Game.Train.RailGraph
         public StationReference StationRef { get; set; }
         public ConnectionDestination ConnectionDestination { get; private set; } = ConnectionDestination.Default;
         public bool HasConnectionDestination => !ConnectionDestination.IsDefault();
+
+        // この RailNode の所属ブロックが受け入れ可能なレールセグメントの最大長(m)
+        // Max length (m) of a rail segment connectable from the block that owns this node
+        public float MaxConnectableRailLength { get; private set; } = float.MaxValue;
         public Guid Guid { get; }
         Guid IRailNode.NodeGuid => Guid;
         public IRailGraphProvider GraphProvider => _graphDatastore;
@@ -97,6 +101,11 @@ namespace Game.Train.RailGraph
         public void SetConnectionDestination(ConnectionDestination destination)
         {
             ConnectionDestination = destination;
+        }
+
+        public void SetMaxConnectableRailLength(float maxConnectableRailLength)
+        {
+            MaxConnectableRailLength = maxConnectableRailLength;
         }
 
         //RailGraphに登録する

--- a/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/RailConnectionEditProtocol.cs
+++ b/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/RailConnectionEditProtocol.cs
@@ -60,14 +60,16 @@ namespace Server.Protocol.PacketResponse
                             return ResponseRailConnectionEditMessagePack.CreateFailure(RailConnectionEditFailureReason.InvalidNode, data.Mode);
 
                         var length = GetRailLength(fromNode, toNode);
-
-                        // 両端ブロックの「乗せられる最大レール長」のうち短い方を上限として比較
-                        // Use min of both endpoints' max connectable rail length as the allowed limit
-                        var allowedMaxLength = GetAllowedMaxRailLength(fromNode, toNode);
-                        if (allowedMaxLength < length)
-                            return ResponseRailConnectionEditMessagePack.CreateFailure(RailConnectionEditFailureReason.RailLengthExceeded, data.Mode);
-
                         var inventory = _playerInventoryDataStore.GetInventoryData(data.PlayerId).MainOpenableInventory;
+
+                        // 長さ・両端ブロック上限・所持インベントリから設置可否を一括判定
+                        // Single placement viability check shared with the client preview
+                        var judgement = EvaluatePlacement(length, fromNode.MaxConnectableRailLength, toNode.MaxConnectableRailLength, inventory.InventoryItems);
+                        if (!judgement.IsPlaceable)
+                            return ResponseRailConnectionEditMessagePack.CreateFailure(judgement.FailureReason, data.Mode);
+
+                        // 個別の選択レール種が所持されているか検証し、必要数を確定する
+                        // Validate the specific rail type the client picked and resolve the required count for consumption
                         var railTypeGuid = data.RailTypeGuid;
                         if (!TryResolveRailItemForPlacement(railTypeGuid, inventory.InventoryItems, length, out var placeRailItem, out var requiredCount))
                             return ResponseRailConnectionEditMessagePack.CreateFailure(RailConnectionEditFailureReason.NotEnoughRailItem, data.Mode);
@@ -219,6 +221,29 @@ namespace Server.Protocol.PacketResponse
             return Mathf.Min(fromNode.MaxConnectableRailLength, toNode.MaxConnectableRailLength);
         }
 
+        /// <summary>
+        /// 接続区間の長さ・両端ブロックの最大上限・所持インベントリから設置可否を一括判定する
+        /// Single entry point for placement viability: combines length-vs-limit and inventory-vs-required checks.
+        /// サーバー・クライアント双方からこのメソッドだけを呼ぶことで、設置条件の追加がここに集約される。
+        /// Server and client both call this so future placement rules only need to land in one place.
+        /// </summary>
+        public static RailPlacementJudgement EvaluatePlacement(float railLength, float fromMaxConnectableRailLength, float toMaxConnectableRailLength, IEnumerable<IItemStack> inventoryItems)
+        {
+            // 両端の上限の min をその接続区間の許容最大長とする
+            // Take the smaller endpoint limit as the allowed maximum for the segment
+            var allowedMax = Mathf.Min(fromMaxConnectableRailLength, toMaxConnectableRailLength);
+            if (allowedMax < railLength)
+                return new RailPlacementJudgement(RailConnectionEditFailureReason.RailLengthExceeded, railLength, allowedMax, Array.Empty<(RailItemMasterElement, int)>());
+
+            // 所持アイテムから設置可能なレール種を列挙
+            // Enumerate rail items that the player owns enough of for this length
+            var placeable = GetPlaceableRailItems(inventoryItems, railLength);
+            if (placeable.Length == 0)
+                return new RailPlacementJudgement(RailConnectionEditFailureReason.NotEnoughRailItem, railLength, allowedMax, placeable);
+
+            return new RailPlacementJudgement(RailConnectionEditFailureReason.None, railLength, allowedMax, placeable);
+        }
+
         public static float GetRailLength(IRailNode fromNode, IRailNode toNode)
         {
             var p0 = fromNode.FrontControlPoint.OriginalPosition;
@@ -346,6 +371,30 @@ namespace Server.Protocol.PacketResponse
             NotEnoughInventorySpace,
             RailLengthExceeded,
             UnknownError,
+        }
+    }
+
+    /// <summary>
+    /// レール設置可否の統合判定結果
+    /// Aggregated result of rail placement viability evaluation
+    /// </summary>
+    public readonly struct RailPlacementJudgement
+    {
+        public readonly RailConnectionEditProtocol.RailConnectionEditFailureReason FailureReason;
+        public readonly float RailLength;
+        public readonly float AllowedMaxLength;
+        public readonly (RailItemMasterElement element, int requiredCount)[] PlaceableRailItems;
+
+        public bool IsPlaceable => FailureReason == RailConnectionEditProtocol.RailConnectionEditFailureReason.None;
+
+        public Guid FirstPlaceableRailTypeGuid => PlaceableRailItems.Length > 0 ? PlaceableRailItems[0].element.ItemGuid : Guid.Empty;
+
+        public RailPlacementJudgement(RailConnectionEditProtocol.RailConnectionEditFailureReason failureReason, float railLength, float allowedMaxLength, (RailItemMasterElement element, int requiredCount)[] placeableRailItems)
+        {
+            FailureReason = failureReason;
+            RailLength = railLength;
+            AllowedMaxLength = allowedMaxLength;
+            PlaceableRailItems = placeableRailItems ?? Array.Empty<(RailItemMasterElement element, int requiredCount)>();
         }
     }
 }

--- a/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/RailConnectionEditProtocol.cs
+++ b/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/RailConnectionEditProtocol.cs
@@ -3,13 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using Core.Item.Interface;
 using Core.Master;
-using Game.Block.Blocks.TrainRail;
 using Game.Context;
 using Game.PlayerInventory.Interface;
 using Game.Train.RailCalc;
 using Game.Train.RailGraph;
 using Game.Train.RailPositions;
-using Game.World.Interface.DataStore;
 using MessagePack;
 using Microsoft.Extensions.DependencyInjection;
 using Mooresmaster.Model.TrainModule;
@@ -66,7 +64,7 @@ namespace Server.Protocol.PacketResponse
                         // 両端ブロックの「乗せられる最大レール長」のうち短い方を上限として比較
                         // Use min of both endpoints' max connectable rail length as the allowed limit
                         var allowedMaxLength = GetAllowedMaxRailLength(fromNode, toNode);
-                        if (length > allowedMaxLength)
+                        if (allowedMaxLength < length)
                             return ResponseRailConnectionEditMessagePack.CreateFailure(RailConnectionEditFailureReason.RailLengthExceeded, data.Mode);
 
                         var inventory = _playerInventoryDataStore.GetInventoryData(data.PlayerId).MainOpenableInventory;
@@ -216,24 +214,9 @@ namespace Server.Protocol.PacketResponse
         
         // 接続両端の「乗せられる最大レール長」の min を返す
         // Return the smaller of both endpoints' max connectable rail length
-        public static float GetAllowedMaxRailLength(IRailNode fromNode, IRailNode toNode)
+        public static float GetAllowedMaxRailLength(RailNode fromNode, RailNode toNode)
         {
-            var fromMax = ResolveMaxConnectableRailLength(fromNode);
-            var toMax = ResolveMaxConnectableRailLength(toNode);
-            return Mathf.Min(fromMax, toMax);
-        }
-
-        // RailNode から所属ブロックを引いて MaxConnectableRailLength を取得する
-        // Resolve MaxConnectableRailLength by looking up the source block of a RailNode
-        public static float ResolveMaxConnectableRailLength(IRailNode node)
-        {
-            // 解決できないノードは制限なし(float.MaxValue)とする
-            // Treat unresolved nodes as unlimited
-            if (node is not RailNode railNode) return float.MaxValue;
-            if (!railNode.HasConnectionDestination) return float.MaxValue;
-            var blockPos = (UnityEngine.Vector3Int)railNode.ConnectionDestination.blockPosition;
-            if (!ServerContext.WorldBlockDatastore.TryGetBlock<RailComponent>(blockPos, out var railComponent)) return float.MaxValue;
-            return railComponent.MaxConnectableRailLength;
+            return Mathf.Min(fromNode.MaxConnectableRailLength, toNode.MaxConnectableRailLength);
         }
 
         public static float GetRailLength(IRailNode fromNode, IRailNode toNode)

--- a/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/RailConnectionEditProtocol.cs
+++ b/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/RailConnectionEditProtocol.cs
@@ -62,40 +62,35 @@ namespace Server.Protocol.PacketResponse
                         var length = GetRailLength(fromNode, toNode);
                         var inventory = _playerInventoryDataStore.GetInventoryData(data.PlayerId).MainOpenableInventory;
 
-                        // 長さ・両端ブロック上限・所持インベントリから設置可否を一括判定
-                        // Single placement viability check shared with the client preview
-                        var judgement = EvaluatePlacement(length, fromNode.MaxConnectableRailLength, toNode.MaxConnectableRailLength, inventory.InventoryItems);
+                        // 長さ・両端ブロック上限・所持インベントリ・選択レール種から設置可否と消費アイテムを一括確定
+                        // Single placement evaluation shared with the client preview
+                        var preferredRailItemId = data.RailTypeGuid == Guid.Empty ? ItemMaster.EmptyItemId : MasterHolder.ItemMaster.GetItemId(data.RailTypeGuid);
+                        var judgement = EvaluatePlacement(length, fromNode.MaxConnectableRailLength, toNode.MaxConnectableRailLength, inventory.InventoryItems, preferredRailItemId);
                         if (!judgement.IsPlaceable)
                             return ResponseRailConnectionEditMessagePack.CreateFailure(judgement.FailureReason, data.Mode);
 
-                        // 個別の選択レール種が所持されているか検証し、必要数を確定する
-                        // Validate the specific rail type the client picked and resolve the required count for consumption
-                        var railTypeGuid = data.RailTypeGuid;
-                        if (!TryResolveRailItemForPlacement(railTypeGuid, inventory.InventoryItems, length, out var placeRailItem, out var requiredCount))
-                            return ResponseRailConnectionEditMessagePack.CreateFailure(RailConnectionEditFailureReason.NotEnoughRailItem, data.Mode);
 
-                        var connectResult = _commandHandler.TryConnect(data.FromNodeId, data.FromGuid, data.ToNodeId, data.ToGuid, railTypeGuid);
-                        
                         // 成功したらインベントリから引く
                         // Consume rail items on success
-                        if (connectResult && railTypeGuid != Guid.Empty)
+                        var connectResult = _commandHandler.TryConnect(data.FromNodeId, data.FromGuid, data.ToNodeId, data.ToGuid, data.RailTypeGuid);
+                        if (connectResult)
                         {
-                            var railItemId = MasterHolder.ItemMaster.GetItemId(placeRailItem.ItemGuid);
-                            var remainSubCount = requiredCount;
+                            var railItemId = MasterHolder.ItemMaster.GetItemId(judgement.SelectedRailItem.ItemGuid);
+                            var remainSubCount = judgement.RequiredCount;
                             foreach (var (stack, i) in inventory.InventoryItems.ToArray().Select((stack, i) => (stack, i)).Where(stack => stack.stack.Id == railItemId))
                             {
                                 var subCount = Mathf.Min(stack.Count, remainSubCount);
                                 Debug.Log($"Subtracting {subCount} from stack {stack.Id}");
                                 inventory.SetItem(i, stack.SubItem(subCount));
                                 remainSubCount -= subCount;
-                                
+
                                 if (remainSubCount == 0) break;
                             }
-                            
+
                             // 残りがまだあるということがあってはならない
-                            if (remainSubCount > 0) throw new Exception($"Rail item count is not enough. Required: {requiredCount}, Inventory: {inventory.InventoryItems.Where(stack => stack.Id == railItemId).Sum(stack => stack.Count)}");
+                            if (remainSubCount > 0) throw new Exception($"Rail item count is not enough. Required: {judgement.RequiredCount}, Inventory: {inventory.InventoryItems.Where(stack => stack.Id == railItemId).Sum(stack => stack.Count)}");
                         }
-                        
+
                         return ResponseRailConnectionEditMessagePack.Create(connectResult, connectResult ? RailConnectionEditFailureReason.None : RailConnectionEditFailureReason.InvalidNode, data.Mode);
                     case RailEditMode.Disconnect:
                         return HandleDisconnect(data);
@@ -222,26 +217,35 @@ namespace Server.Protocol.PacketResponse
         }
 
         /// <summary>
-        /// 接続区間の長さ・両端ブロックの最大上限・所持インベントリから設置可否を一括判定する
-        /// Single entry point for placement viability: combines length-vs-limit and inventory-vs-required checks.
+        /// 接続区間の長さ・両端ブロックの最大上限・所持インベントリ・選択レール種から設置可否と消費アイテムを一括で確定する
+        /// Single entry point for placement viability: combines length-vs-limit, inventory-vs-required, and rail-type selection.
         /// サーバー・クライアント双方からこのメソッドだけを呼ぶことで、設置条件の追加がここに集約される。
         /// Server and client both call this so future placement rules only need to land in one place.
+        /// preferredRailItemId が ItemMaster.EmptyItemId なら設置可能なレール種の先頭を採用する
+        /// When preferredRailItemId is ItemMaster.EmptyItemId, picks the first placeable rail item
         /// </summary>
-        public static RailPlacementJudgement EvaluatePlacement(float railLength, float fromMaxConnectableRailLength, float toMaxConnectableRailLength, IEnumerable<IItemStack> inventoryItems)
+        public static RailPlacementJudgement EvaluatePlacement(float railLength, float fromMaxConnectableRailLength, float toMaxConnectableRailLength, IEnumerable<IItemStack> inventoryItems, ItemId preferredRailItemId)
         {
             // 両端の上限の min をその接続区間の許容最大長とする
             // Take the smaller endpoint limit as the allowed maximum for the segment
-            var allowedMax = Mathf.Min(fromMaxConnectableRailLength, toMaxConnectableRailLength);
-            if (allowedMax < railLength)
-                return new RailPlacementJudgement(RailConnectionEditFailureReason.RailLengthExceeded, railLength, allowedMax, Array.Empty<(RailItemMasterElement, int)>());
+            if (Mathf.Min(fromMaxConnectableRailLength, toMaxConnectableRailLength) < railLength)
+                return new RailPlacementJudgement(RailConnectionEditFailureReason.RailLengthExceeded, null, 0);
 
             // 所持アイテムから設置可能なレール種を列挙
             // Enumerate rail items that the player owns enough of for this length
             var placeable = GetPlaceableRailItems(inventoryItems, railLength);
             if (placeable.Length == 0)
-                return new RailPlacementJudgement(RailConnectionEditFailureReason.NotEnoughRailItem, railLength, allowedMax, placeable);
+                return new RailPlacementJudgement(RailConnectionEditFailureReason.NotEnoughRailItem, null, 0);
 
-            return new RailPlacementJudgement(RailConnectionEditFailureReason.None, railLength, allowedMax, placeable);
+            // 選択レール種を確定する。指定なしなら先頭、指定ありなら一致する ItemId のものを採用
+            // Resolve the selected rail item by ItemId: head when unspecified, matching entry otherwise
+            var selected = preferredRailItemId == ItemMaster.EmptyItemId
+                ? placeable[0]
+                : Array.Find(placeable, p => MasterHolder.ItemMaster.GetItemId(p.element.ItemGuid) == preferredRailItemId);
+            if (selected.element == null)
+                return new RailPlacementJudgement(RailConnectionEditFailureReason.NotEnoughRailItem, null, 0);
+
+            return new RailPlacementJudgement(RailConnectionEditFailureReason.None, selected.element, selected.requiredCount);
         }
 
         public static float GetRailLength(IRailNode fromNode, IRailNode toNode)
@@ -375,26 +379,24 @@ namespace Server.Protocol.PacketResponse
     }
 
     /// <summary>
-    /// レール設置可否の統合判定結果
-    /// Aggregated result of rail placement viability evaluation
+    /// レール設置可否の統合判定結果。失敗理由、または採用レール種と必要数を保持する
+    /// Aggregated result of rail placement viability evaluation, exposing failure reason or the selected rail item with required count.
     /// </summary>
     public readonly struct RailPlacementJudgement
     {
         public readonly RailConnectionEditProtocol.RailConnectionEditFailureReason FailureReason;
-        public readonly float RailLength;
-        public readonly float AllowedMaxLength;
-        public readonly (RailItemMasterElement element, int requiredCount)[] PlaceableRailItems;
+        public readonly RailItemMasterElement SelectedRailItem;
+        public readonly int RequiredCount;
 
         public bool IsPlaceable => FailureReason == RailConnectionEditProtocol.RailConnectionEditFailureReason.None;
 
-        public Guid FirstPlaceableRailTypeGuid => PlaceableRailItems.Length > 0 ? PlaceableRailItems[0].element.ItemGuid : Guid.Empty;
+        public Guid SelectedRailTypeGuid => SelectedRailItem != null ? SelectedRailItem.ItemGuid : Guid.Empty;
 
-        public RailPlacementJudgement(RailConnectionEditProtocol.RailConnectionEditFailureReason failureReason, float railLength, float allowedMaxLength, (RailItemMasterElement element, int requiredCount)[] placeableRailItems)
+        public RailPlacementJudgement(RailConnectionEditProtocol.RailConnectionEditFailureReason failureReason, RailItemMasterElement selectedRailItem, int requiredCount)
         {
             FailureReason = failureReason;
-            RailLength = railLength;
-            AllowedMaxLength = allowedMaxLength;
-            PlaceableRailItems = placeableRailItems ?? Array.Empty<(RailItemMasterElement element, int requiredCount)>();
+            SelectedRailItem = selectedRailItem;
+            RequiredCount = requiredCount;
         }
     }
 }

--- a/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/RailConnectionEditProtocol.cs
+++ b/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/RailConnectionEditProtocol.cs
@@ -3,11 +3,13 @@ using System.Collections.Generic;
 using System.Linq;
 using Core.Item.Interface;
 using Core.Master;
+using Game.Block.Blocks.TrainRail;
 using Game.Context;
 using Game.PlayerInventory.Interface;
 using Game.Train.RailCalc;
 using Game.Train.RailGraph;
 using Game.Train.RailPositions;
+using Game.World.Interface.DataStore;
 using MessagePack;
 using Microsoft.Extensions.DependencyInjection;
 using Mooresmaster.Model.TrainModule;
@@ -58,9 +60,15 @@ namespace Server.Protocol.PacketResponse
                     case RailEditMode.Connect:
                         if (!_commandHandler.TryResolveNodes(data.FromNodeId, data.FromGuid, data.ToNodeId, data.ToGuid, out var fromNode, out var toNode))
                             return ResponseRailConnectionEditMessagePack.CreateFailure(RailConnectionEditFailureReason.InvalidNode, data.Mode);
-                        
+
                         var length = GetRailLength(fromNode, toNode);
-                        
+
+                        // 両端ブロックの「乗せられる最大レール長」のうち短い方を上限として比較
+                        // Use min of both endpoints' max connectable rail length as the allowed limit
+                        var allowedMaxLength = GetAllowedMaxRailLength(fromNode, toNode);
+                        if (length > allowedMaxLength)
+                            return ResponseRailConnectionEditMessagePack.CreateFailure(RailConnectionEditFailureReason.RailLengthExceeded, data.Mode);
+
                         var inventory = _playerInventoryDataStore.GetInventoryData(data.PlayerId).MainOpenableInventory;
                         var railTypeGuid = data.RailTypeGuid;
                         if (!TryResolveRailItemForPlacement(railTypeGuid, inventory.InventoryItems, length, out var placeRailItem, out var requiredCount))
@@ -206,6 +214,28 @@ namespace Server.Protocol.PacketResponse
             return true;
         }
         
+        // 接続両端の「乗せられる最大レール長」の min を返す
+        // Return the smaller of both endpoints' max connectable rail length
+        public static float GetAllowedMaxRailLength(IRailNode fromNode, IRailNode toNode)
+        {
+            var fromMax = ResolveMaxConnectableRailLength(fromNode);
+            var toMax = ResolveMaxConnectableRailLength(toNode);
+            return Mathf.Min(fromMax, toMax);
+        }
+
+        // RailNode から所属ブロックを引いて MaxConnectableRailLength を取得する
+        // Resolve MaxConnectableRailLength by looking up the source block of a RailNode
+        public static float ResolveMaxConnectableRailLength(IRailNode node)
+        {
+            // 解決できないノードは制限なし(float.MaxValue)とする
+            // Treat unresolved nodes as unlimited
+            if (node is not RailNode railNode) return float.MaxValue;
+            if (!railNode.HasConnectionDestination) return float.MaxValue;
+            var blockPos = (UnityEngine.Vector3Int)railNode.ConnectionDestination.blockPosition;
+            if (!ServerContext.WorldBlockDatastore.TryGetBlock<RailComponent>(blockPos, out var railComponent)) return float.MaxValue;
+            return railComponent.MaxConnectableRailLength;
+        }
+
         public static float GetRailLength(IRailNode fromNode, IRailNode toNode)
         {
             var p0 = fromNode.FrontControlPoint.OriginalPosition;
@@ -331,6 +361,7 @@ namespace Server.Protocol.PacketResponse
             InvalidMode,
             NotEnoughRailItem,
             NotEnoughInventorySpace,
+            RailLengthExceeded,
             UnknownError,
         }
     }

--- a/moorestech_server/Assets/Scripts/Tests.Module/TestMod/ForUnitTest/mods/forUnitTest/master/blocks.json
+++ b/moorestech_server/Assets/Scripts/Tests.Module/TestMod/ForUnitTest/mods/forUnitTest/master/blocks.json
@@ -2747,7 +2747,8 @@
           0.5,
           0.5
         ],
-        "controlPointLength": 0.5
+        "controlPointLength": 0.5,
+        "maxConnectableRailLength": 100
       },
       "name": "TestTrainRail",
       "blockGuid": "00000000-0000-0000-0000-000000000024",
@@ -2819,7 +2820,8 @@
         ],
         "entryControlPointLength": 0.5,
         "exitControlPointLength": 0.5,
-        "loadingAnimeSpeed": 1
+        "loadingAnimeSpeed": 1,
+        "maxConnectableRailLength": 100
       },
       "name": "TestTrainStation",
       "blockGuid": "00000000-0000-0000-0000-000000000025",
@@ -2891,7 +2893,8 @@
           8
         ],
         "itemSlotCount": 10,
-        "loadingAnimeSpeed": 1
+        "loadingAnimeSpeed": 1,
+        "maxConnectableRailLength": 100
       },
       "name": "TestTrainItemPlatform",
       "blockGuid": "00000000-0000-0000-0000-000000000026",
@@ -4018,7 +4021,8 @@
           8
         ],
         "capacity": 1000,
-        "loadingAnimeSpeed": 1
+        "loadingAnimeSpeed": 1,
+        "maxConnectableRailLength": 100
       },
       "name": "TestTrainFluidPlatform",
       "blockGuid": "00000000-0000-0000-0000-000000000029",

--- a/moorestech_server/Assets/Scripts/Tests/UnitTest/Game/SimpleTrainTest.cs
+++ b/moorestech_server/Assets/Scripts/Tests/UnitTest/Game/SimpleTrainTest.cs
@@ -141,7 +141,7 @@ namespace Tests.UnitTest.Game
                 listIsCreated.Add((x, y, z));
                 listIsDestroy.Remove((x, y, z));
                 var blockPosition = new Vector3Int(x, y, z);
-                railBlocks[x, y, z] = new RailComponent(railGraphDatastore, new Vector3(x, y, z), BlockDirection.North, blockPosition, 0);
+                railBlocks[x, y, z] = new RailComponent(railGraphDatastore, new Vector3(x, y, z), BlockDirection.North, blockPosition, 0, 100f);
 
                 var (x1, y1, z1) = listIsCreated[UnityEngine.Random.Range(0, listIsCreated.Count)];
                 var (x2, y2, z2) = listIsCreated[UnityEngine.Random.Range(0, listIsCreated.Count)];


### PR DESCRIPTION
## Summary
- TrainRail/駅ブロックに `maxConnectableRailLength` を追加し、`IRailEndpointBlockParam` を介して RailNode が最大接続長を保持するよう変更
- レール消費プロパティを `railLengthPerItem` に改名し、命名の意図を明確化
- server/client の設置判定を `EvaluatePlacement` で一本化し、ItemId 基準で二重判定を除去

## Test plan
- [ ] `SimpleTrainTest` 等の Train 関連ユニットテストがパスすること
- [ ] レール設置 / 駅接続のクライアントプレビューと実際の設置結果が一致すること
- [ ] `maxConnectableRailLength` を超える接続が拒否されること
- [ ] 既存マスタデータ（forUnitTest）のロードに問題がないこと

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rail placement now validates against maximum connectable rail length limits at endpoints.
  * Added rail length exceeded as a placement failure reason.

* **Bug Fixes**
  * Preview visual feedback now accurately reflects whether rail placement is possible based on length constraints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moorestech/moorestech/pull/899?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->