### PR TITLE
フィルター分岐器 (FilterSplitter) ブロック追加

### DIFF
--- a/.claude/skills/creating-server-protocol/SKILL.md
+++ b/.claude/skills/creating-server-protocol/SKILL.md
@@ -98,6 +98,40 @@ namespace Server.Protocol.PacketResponse
 _packetResponseDictionary.Add(YourProtocol.ProtocolTag, new YourProtocol(serviceProvider));
 ```
 
+### Step 2.5: クライアント側 VanillaApi にメソッドを追加（**1プロトコル = 1メソッド**）
+
+`moorestech_client/Assets/Scripts/Client.Network/API/VanillaApiWithResponse.cs` にプロトコル送信用メソッドを **1個だけ** 追加する。
+
+**原則: 1プロトコル = 1 VanillaApi メソッド**。1つのプロトコルに対して複数のラッパーメソッド（`GetXxx` / `SetXxx` / `UpdateXxx` 等）を作ってはいけない。プロトコルが複数の Operation を持つ場合は、`Request` オブジェクトを呼び出し側で構築して渡す形にする。
+
+```csharp
+// 良い: 1メソッドだけ。呼び出し側が Request を構築する
+public async UniTask<YourProtocol.YourResponseMessagePack> SendYourRequest(
+    YourProtocol.YourRequestMessagePack request, CancellationToken ct)
+{
+    return await _packetExchangeManager.GetPacketResponse<YourProtocol.YourResponseMessagePack>(request, ct);
+}
+
+// 単純なプロトコルなら、全プロパティを引数に取って内部で Request を組む形も可
+public async UniTask<YourProtocol.YourResponseMessagePack> SendYourRequest(
+    Vector3Int position, int someField, CancellationToken ct)
+{
+    var request = new YourProtocol.YourRequestMessagePack(position, someField);
+    return await _packetExchangeManager.GetPacketResponse<YourProtocol.YourResponseMessagePack>(request, ct);
+}
+```
+
+**禁止例**: 1プロトコルに複数の Operation を持たせて、operation ごとに VanillaApi メソッドを生やす。これは「1プロトコル = N メソッド」になりラッパーが肥大化する。
+
+```csharp
+// 禁止: 1プロトコル (FilterSplitterStateProtocol) に対し 3 メソッド生やしている
+public async UniTask<...> GetFilterSplitterState(...) { ... }
+public async UniTask<...> SetFilterSplitterMode(...) { ... }
+public async UniTask<...> SetFilterSplitterItem(...) { ... }
+```
+
+このルールにより、プロトコルの追加コストが「1ファイル + 1 PacketResponseCreator 登録行 + 1 VanillaApi メソッド」に固定され、後続の Operation 追加が API 表面に波及しない。
+
 ### Step 3: テストを作成
 
 `/creating-server-tests` スキルを使用してテストを作成。配置先: `Tests/CombinedTest/Server/PacketTest/`
@@ -188,4 +222,63 @@ MCPツールまたは`unity-test.sh`でコンパイルを確認。
 - `[Obsolete]`付き引数なしコンストラクタは省略不可
 - イベント購読はUniRxの`.Subscribe()`を使用（`/csharp-event-pattern`参照）
 - コードのコメントは日本語・英語の2行セット
+
+## Request/Response メッセージ設計原則
+
+### enum を int に変換しない
+MessagePack は enum 型をそのままシリアライズできる。`int` への変換は型安全性を捨てているだけで、ワイヤ表現も同じバイト列。プロパティ型は enum をそのまま使う。
+
+```csharp
+// 良い
+[Key(3)] public FilterSplitterOperation Operation { get; set; }
+[Key(6)] public FilterSplitterMode Mode { get; set; }
+
+// 禁止: int に変換して受け渡しすると、受け側で `(EnumType)request.Operation` の cast が必要になる
+[Key(3)] public int Operation { get; set; }
+```
+
+### ItemId / BlockId 等の UnitGenerator 型はそのまま使う
+`Core.Master` の `ItemId` `BlockId` 等は UnitGenerator で `MessagePackFormatter` を生成済み。Guid 文字列に変換する必要は一切ない。クライアント・サーバー間で master が同期している前提で `ItemId` を直接送る。
+
+```csharp
+// 良い
+[Key(7)] public ItemId ItemId { get; set; }
+
+// 禁止: わざわざ Guid 文字列にして受け渡す（master 解決が往復する）
+[Key(7)] public string ItemGuidStr { get; set; }
+```
+
+### Operation で必要プロパティが変わる場合は static factory に分ける
+1 つの Request クラスで複数 Operation を扱い、Operation ごとに必要なフィールドが異なる場合、**呼び出し元が「使わないフィールドに何を入れるか」を悩まされる**設計は禁止。public コンストラクタは禁止し、private コンストラクタ + Operation ごとの `static CreateXxxRequest(...)` 形にする。`RailConnectionEditRequest` がこのパターン。
+
+```csharp
+[MessagePackObject]
+public class FilterSplitterStateRequest : ProtocolMessagePackBase
+{
+    [Key(2)] public Vector3IntMessagePack Position { get; set; }
+    [Key(3)] public FilterSplitterOperation Operation { get; set; }
+    [Key(4)] public int DirectionIndex { get; set; }
+    [Key(5)] public int SlotIndex { get; set; }
+    [Key(6)] public FilterSplitterMode Mode { get; set; }
+    [Key(7)] public ItemId ItemId { get; set; }
+
+    [Obsolete("デシリアライズ用のコンストラクタです。基本的に使用しないでください。")]
+    public FilterSplitterStateRequest() { Tag = ProtocolTag; }
+
+    // private コンストラクタ — 外部は static factory 経由でのみ生成する
+    // Private constructor; callers must use the static factories below
+    private FilterSplitterStateRequest(Vector3Int position, FilterSplitterOperation operation, int directionIndex, int slotIndex, FilterSplitterMode mode, ItemId itemId) { ... }
+
+    public static FilterSplitterStateRequest CreateGetRequest(Vector3Int position)
+        => new(position, FilterSplitterOperation.Get, 0, 0, FilterSplitterMode.Default, ItemMaster.EmptyItemId);
+
+    public static FilterSplitterStateRequest CreateSetModeRequest(Vector3Int position, int directionIndex, FilterSplitterMode mode)
+        => new(position, FilterSplitterOperation.SetMode, directionIndex, 0, mode, ItemMaster.EmptyItemId);
+
+    public static FilterSplitterStateRequest CreateSetFilterItemRequest(Vector3Int position, int directionIndex, int slotIndex, ItemId itemId)
+        => new(position, FilterSplitterOperation.SetFilterItem, directionIndex, slotIndex, FilterSplitterMode.Default, itemId);
+}
+```
+
+呼び出し側は `CreateXxxRequest` を見るだけで「この Operation には何が必要か」が型で分かる。public コンストラクタを生やすと「全 Operation のフィールドを全部書く」必要が出てきて、その負担が VanillaApi のラッパーに波及する（→「1プロトコル = N メソッド」原則違反の温床）。
 

--- a/VanillaSchema/blocks.yml
+++ b/VanillaSchema/blocks.yml
@@ -100,6 +100,7 @@ properties:
       - GearPump
       - ElectricPump
       - GearElectricGenerator
+      - FilterSplitter
     - key: itemGuid
       type: uuid
       foreignKey:
@@ -733,6 +734,16 @@ properties:
           default: 100
         - key: gear
           ref: gear
+      - when: FilterSplitter
+        type: object
+        implementationInterface:
+        - IInventoryConnectors
+        properties:
+        - key: filterSlotCountPerDirection
+          type: integer
+          default: 10
+        - key: inventoryConnectors
+          ref: inventoryConnects
 
     - key: overrideVerticalBlock
       type: object

--- a/moorestech_client/Assets/AddressableAssetsData/AddressableAssetSettings.asset
+++ b/moorestech_client/Assets/AddressableAssetsData/AddressableAssetSettings.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   m_DefaultGroup: 00ca334169f2ed44480534a893fe0840
   m_currentHash:
     serializedVersion: 2
-    Hash: d917658591dc5900245f89216eff1a4b
+    Hash: 00000000000000000000000000000000
   m_OptimizeCatalogSize: 0
   m_BuildRemoteCatalog: 0
   m_CatalogRequestsTimeout: 0

--- a/moorestech_client/Assets/AddressableAssetsData/AssetGroups/Vanilla Asset Group.asset
+++ b/moorestech_client/Assets/AddressableAssetsData/AssetGroups/Vanilla Asset Group.asset
@@ -175,6 +175,11 @@ MonoBehaviour:
     m_ReadOnly: 0
     m_SerializedLabels: []
     FlaggedDuringContentUpdateRestriction: 0
+  - m_GUID: 22a27ce62121b404882dff34ab352cca
+    m_Address: Vanilla/UI/Block/FilterSplitterBlockInventory
+    m_ReadOnly: 0
+    m_SerializedLabels: []
+    FlaggedDuringContentUpdateRestriction: 0
   - m_GUID: 23c9427641be06a49b66517f3f5bfd6c
     m_Address: Vanilla/Block/BeltConveyor_Cross
     m_ReadOnly: 0
@@ -497,6 +502,11 @@ MonoBehaviour:
     FlaggedDuringContentUpdateRestriction: 0
   - m_GUID: 74c661b69539b4646b58bacbc3365a30
     m_Address: Vanilla/Block/PipeStraightWindow
+    m_ReadOnly: 0
+    m_SerializedLabels: []
+    FlaggedDuringContentUpdateRestriction: 0
+  - m_GUID: 74ec9b05c9d6f43168d8ecf28b97199f
+    m_Address: Vanilla/UI/Block/FilterSplitterDirectionColumn
     m_ReadOnly: 0
     m_SerializedLabels: []
     FlaggedDuringContentUpdateRestriction: 0

--- a/moorestech_client/Assets/AddressableResources/UI/Block/FilterSplitterBlockInventory.prefab
+++ b/moorestech_client/Assets/AddressableResources/UI/Block/FilterSplitterBlockInventory.prefab
@@ -1,0 +1,365 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &625472840030447780
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5876730053986267569}
+  - component: {fileID: 8494043864745336756}
+  m_Layer: 5
+  m_Name: FilterSplitterBlockInventory
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5876730053986267569
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 625472840030447780}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2886803511559012405}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &8494043864745336756
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 625472840030447780}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b032478a1ee8d46ad94cc6742b065134, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.UI.Inventory.Block.FilterSplitterBlockInventoryView
+  columnsParent: {fileID: 6040281661971156113}
+  columnPrefab: {fileID: 8486278940009960876, guid: 74ec9b05c9d6f43168d8ecf28b97199f, type: 3}
+--- !u!1 &2418077883793440328
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 784246240824587863}
+  - component: {fileID: 6663670231782750012}
+  - component: {fileID: 3613669840810899407}
+  m_Layer: 5
+  m_Name: Title
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &784246240824587863
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2418077883793440328}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2886803511559012405}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -14}
+  m_SizeDelta: {x: -40, y: 44}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!222 &6663670231782750012
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2418077883793440328}
+  m_CullTransparentMesh: 1
+--- !u!114 &3613669840810899407
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2418077883793440328}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: FILTER SPLITTER
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: 0
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 25
+  m_fontSizeBase: 25
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &6239922388684724142
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5491221259923394559}
+  - component: {fileID: 8576860591666510381}
+  - component: {fileID: 9181843344962989242}
+  m_Layer: 5
+  m_Name: BackgroundImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5491221259923394559
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6239922388684724142}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2886803511559012405}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8576860591666510381
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6239922388684724142}
+  m_CullTransparentMesh: 1
+--- !u!114 &9181843344962989242
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6239922388684724142}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 2d79e8410180741f7ba181288b7d5367, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &7179003771243134744
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2886803511559012405}
+  m_Layer: 5
+  m_Name: Window
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2886803511559012405
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7179003771243134744}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5491221259923394559}
+  - {fileID: 784246240824587863}
+  - {fileID: 6040281661971156113}
+  m_Father: {fileID: 5876730053986267569}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 660, y: 620}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &8179593128036610311
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6040281661971156113}
+  - component: {fileID: 6516829120682995406}
+  m_Layer: 5
+  m_Name: Columns
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6040281661971156113
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8179593128036610311}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2886803511559012405}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -25}
+  m_SizeDelta: {x: -40, y: -90}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &6516829120682995406
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8179593128036610311}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.HorizontalLayoutGroup
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 4
+  m_Spacing: 12
+  m_ChildForceExpandWidth: 0
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 0
+  m_ChildControlHeight: 1
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0

--- a/moorestech_client/Assets/AddressableResources/UI/Block/FilterSplitterBlockInventory.prefab.meta
+++ b/moorestech_client/Assets/AddressableResources/UI/Block/FilterSplitterBlockInventory.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 22a27ce62121b404882dff34ab352cca
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/moorestech_client/Assets/AddressableResources/UI/Block/FilterSplitterDirectionColumn.prefab
+++ b/moorestech_client/Assets/AddressableResources/UI/Block/FilterSplitterDirectionColumn.prefab
@@ -1,0 +1,539 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3808127870449700396
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6323995534779923120}
+  - component: {fileID: 3319769825573798097}
+  m_Layer: 5
+  m_Name: FilterSlots
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6323995534779923120
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3808127870449700396}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1407020410944977469}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 400}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &3319769825573798097
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3808127870449700396}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8a8695521f0d02e499659fee002a26c2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.GridLayoutGroup
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 1
+  m_StartCorner: 0
+  m_StartAxis: 0
+  m_CellSize: {x: 75, y: 75}
+  m_Spacing: {x: 5, y: 5}
+  m_Constraint: 1
+  m_ConstraintCount: 2
+--- !u!1 &4121314267607601675
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9158007349596797970}
+  - component: {fileID: 9002676114562198502}
+  - component: {fileID: 2139211795593198787}
+  m_Layer: 5
+  m_Name: DirectionLabel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &9158007349596797970
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4121314267607601675}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1407020410944977469}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &9002676114562198502
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4121314267607601675}
+  m_CullTransparentMesh: 1
+--- !u!114 &2139211795593198787
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4121314267607601675}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Output
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: 0
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 22
+  m_fontSizeBase: 22
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &4951096678273013721
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8698628916299798872}
+  - component: {fileID: 1622358757817119015}
+  - component: {fileID: 1475860196606354313}
+  - component: {fileID: 892499895655822479}
+  m_Layer: 5
+  m_Name: ModeButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8698628916299798872
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4951096678273013721}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1976021076716172381}
+  m_Father: {fileID: 1407020410944977469}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1622358757817119015
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4951096678273013721}
+  m_CullTransparentMesh: 1
+--- !u!114 &1475860196606354313
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4951096678273013721}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.25, g: 0.45, b: 0.75, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &892499895655822479
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4951096678273013721}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1475860196606354313}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &5813542100599757295
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1407020410944977469}
+  - component: {fileID: 6108911833954472996}
+  - component: {fileID: 8486278940009960876}
+  m_Layer: 5
+  m_Name: FilterSplitterDirectionColumn
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1407020410944977469
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5813542100599757295}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 9158007349596797970}
+  - {fileID: 8698628916299798872}
+  - {fileID: 6323995534779923120}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 180, y: 500}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &6108911833954472996
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5813542100599757295}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.VerticalLayoutGroup
+  m_Padding:
+    m_Left: 8
+    m_Right: 8
+    m_Top: 8
+    m_Bottom: 8
+  m_ChildAlignment: 0
+  m_Spacing: 8
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 0
+  m_ChildControlWidth: 1
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!114 &8486278940009960876
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5813542100599757295}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7d03a11797b1144a5b702438106fa427, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.UI.Inventory.Block.FilterSplitterDirectionColumnView
+  directionLabel: {fileID: 2139211795593198787}
+  modeLabel: {fileID: 1801393885738234287}
+  modeButton: {fileID: 892499895655822479}
+  filterSlotsParent: {fileID: 6323995534779923120}
+--- !u!1 &7236727885406122692
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1976021076716172381}
+  - component: {fileID: 4507311442831931239}
+  - component: {fileID: 1801393885738234287}
+  m_Layer: 5
+  m_Name: ModeLabel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1976021076716172381
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7236727885406122692}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8698628916299798872}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4507311442831931239
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7236727885406122692}
+  m_CullTransparentMesh: 1
+--- !u!114 &1801393885738234287
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7236727885406122692}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Default
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: 0
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 18
+  m_fontSizeBase: 18
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}

--- a/moorestech_client/Assets/AddressableResources/UI/Block/FilterSplitterDirectionColumn.prefab.meta
+++ b/moorestech_client/Assets/AddressableResources/UI/Block/FilterSplitterDirectionColumn.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 74ec9b05c9d6f43168d8ecf28b97199f
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Block/FilterSplitterBlockInventoryView.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Block/FilterSplitterBlockInventoryView.cs
@@ -64,7 +64,8 @@ namespace Client.Game.InGame.UI.Inventory.Block
 
         private async UniTask LoadStateAsync(CancellationToken ct)
         {
-            var response = await ClientContext.VanillaApi.Response.GetFilterSplitterState(_blockPosition, ct);
+            var request = FilterSplitterStateProtocol.FilterSplitterStateRequest.CreateGetRequest(_blockPosition);
+            var response = await ClientContext.VanillaApi.Response.SendFilterSplitterStateRequest(request, ct);
             if (ct.IsCancellationRequested) return;
             if (response == null || !response.Success)
             {
@@ -100,14 +101,15 @@ namespace Client.Game.InGame.UI.Inventory.Block
             for (var d = 0; d < _columns.Count && d < response.Directions.Count; d++)
             {
                 var dir = response.Directions[d];
-                _columns[d].ApplyState((FilterSplitterMode)dir.Mode, dir.FilterItemGuids ?? new List<string>());
+                _columns[d].ApplyState(dir.Mode, dir.FilterItemIds ?? new List<ItemId>());
             }
         }
 
         private async UniTaskVoid OnModeCycleRequested(int directionIndex, FilterSplitterMode nextMode)
         {
             var ct = _cts?.Token ?? CancellationToken.None;
-            var response = await ClientContext.VanillaApi.Response.SetFilterSplitterMode(_blockPosition, directionIndex, nextMode, ct);
+            var request = FilterSplitterStateProtocol.FilterSplitterStateRequest.CreateSetModeRequest(_blockPosition, directionIndex, nextMode);
+            var response = await ClientContext.VanillaApi.Response.SendFilterSplitterStateRequest(request, ct);
             if (ct.IsCancellationRequested) return;
             if (response == null || !response.Success) return;
             ApplySnapshot(response);
@@ -117,21 +119,22 @@ namespace Client.Game.InGame.UI.Inventory.Block
         {
             var ct = _cts?.Token ?? CancellationToken.None;
 
-            // 左クリック: 持ち手アイテムがあればそれをフィルターに設定 / 右クリック: スロットをクリア
-            // Left click: if player holds an item, set it as filter / Right click: clear the slot
-            Guid itemGuid;
+            // 左クリック: 持ち手アイテムをそのままフィルターに設定 / 右クリック: スロットをクリア
+            // Left click: set the currently held item as filter / Right click: clear the slot
+            ItemId itemId;
             if (isLeftClick)
             {
                 var grab = _playerInventory?.GrabInventory;
                 if (grab == null || grab.Id == ItemMaster.EmptyItemId) return;
-                itemGuid = MasterHolder.ItemMaster.GetItemMaster(grab.Id).ItemGuid;
+                itemId = grab.Id;
             }
             else
             {
-                itemGuid = Guid.Empty;
+                itemId = ItemMaster.EmptyItemId;
             }
 
-            var response = await ClientContext.VanillaApi.Response.SetFilterSplitterItem(_blockPosition, directionIndex, slotIndex, itemGuid, ct);
+            var request = FilterSplitterStateProtocol.FilterSplitterStateRequest.CreateSetFilterItemRequest(_blockPosition, directionIndex, slotIndex, itemId);
+            var response = await ClientContext.VanillaApi.Response.SendFilterSplitterStateRequest(request, ct);
             if (ct.IsCancellationRequested) return;
             if (response == null || !response.Success) return;
             ApplySnapshot(response);

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Block/FilterSplitterBlockInventoryView.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Block/FilterSplitterBlockInventoryView.cs
@@ -56,10 +56,8 @@ namespace Client.Game.InGame.UI.Inventory.Block
             _cts?.Cancel();
             _cts?.Dispose();
             _subscriptions.Dispose();
-            if (this != null && gameObject != null) Destroy(gameObject);
+            Destroy(gameObject);
         }
-
-        #region Internal
 
         private async UniTask LoadStateAsync(CancellationToken ct)
         {
@@ -133,7 +131,5 @@ namespace Client.Game.InGame.UI.Inventory.Block
             if (response == null || !response.Success) return;
             ApplySnapshot(response);
         }
-
-        #endregion
     }
 }

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Block/FilterSplitterBlockInventoryView.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Block/FilterSplitterBlockInventoryView.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using Client.Game.InGame.Block;
 using Client.Game.InGame.Context;
+using Client.Game.InGame.UI.Inventory.Common;
 using Client.Game.InGame.UI.Inventory.Main;
 using Core.Item.Interface;
 using Core.Master;
@@ -10,6 +11,7 @@ using Cysharp.Threading.Tasks;
 using Game.Block.Blocks.FilterSplitter;
 using Game.Context;
 using Game.PlayerInventory.Interface.Subscription;
+using Server.Protocol.PacketResponse;
 using UniRx;
 using UnityEngine;
 using VContainer;
@@ -27,10 +29,12 @@ namespace Client.Game.InGame.UI.Inventory.Block
 
         [Inject] private LocalPlayerInventoryController _playerInventory;
 
-        public IReadOnlyList<Client.Game.InGame.UI.Inventory.Common.ItemSlotView> SubInventorySlotObjects => Array.Empty<Client.Game.InGame.UI.Inventory.Common.ItemSlotView>();
+        public IReadOnlyList<ItemSlotView> SubInventorySlotObjects => Array.Empty<ItemSlotView>();
         public int Count => 0;
         public List<IItemStack> SubInventory { get; } = new();
-        public ISubInventoryIdentifier ISubInventoryIdentifier { get; private set; }
+        // フィルター分岐器はプレイヤーインベントリ移動の対象外なので識別子は不要
+        // Filter splitter is not a target of player-inventory item moves, so identifier is unused
+        public ISubInventoryIdentifier ISubInventoryIdentifier { get; } = null;
 
         private readonly List<FilterSplitterDirectionColumnView> _columns = new();
         private readonly CompositeDisposable _subscriptions = new();
@@ -39,7 +43,6 @@ namespace Client.Game.InGame.UI.Inventory.Block
 
         public void Initialize(BlockGameObject blockGameObject)
         {
-            ISubInventoryIdentifier = new BlockInventorySubInventoryIdentifier(blockGameObject.BlockPosInfo.OriginalPos);
             _blockPosition = blockGameObject.BlockPosInfo.OriginalPos;
 
             _cts = new CancellationTokenSource();
@@ -92,7 +95,7 @@ namespace Client.Game.InGame.UI.Inventory.Block
             }
         }
 
-        private void ApplySnapshot(Server.Protocol.PacketResponse.FilterSplitterStateProtocol.FilterSplitterStateResponse response)
+        private void ApplySnapshot(FilterSplitterStateProtocol.FilterSplitterStateResponse response)
         {
             for (var d = 0; d < _columns.Count && d < response.Directions.Count; d++)
             {
@@ -105,6 +108,7 @@ namespace Client.Game.InGame.UI.Inventory.Block
         {
             var ct = _cts?.Token ?? CancellationToken.None;
             var response = await ClientContext.VanillaApi.Response.SetFilterSplitterMode(_blockPosition, directionIndex, nextMode, ct);
+            if (ct.IsCancellationRequested) return;
             if (response == null || !response.Success) return;
             ApplySnapshot(response);
         }
@@ -128,6 +132,7 @@ namespace Client.Game.InGame.UI.Inventory.Block
             }
 
             var response = await ClientContext.VanillaApi.Response.SetFilterSplitterItem(_blockPosition, directionIndex, slotIndex, itemGuid, ct);
+            if (ct.IsCancellationRequested) return;
             if (response == null || !response.Success) return;
             ApplySnapshot(response);
         }

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Block/FilterSplitterBlockInventoryView.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Block/FilterSplitterBlockInventoryView.cs
@@ -56,9 +56,13 @@ namespace Client.Game.InGame.UI.Inventory.Block
 
         public void DestroyUI()
         {
+            // 順序: in-flight タスクを Cancel → UniRx 購読破棄 → CTS Dispose → column 参照クリア → GameObject 破棄
+            // Order: cancel in-flight → dispose subscriptions → dispose CTS → release column refs → destroy GameObject
             _cts?.Cancel();
-            _cts?.Dispose();
             _subscriptions.Dispose();
+            _cts?.Dispose();
+            _cts = null;
+            _columns.Clear();
             Destroy(gameObject);
         }
 
@@ -101,23 +105,29 @@ namespace Client.Game.InGame.UI.Inventory.Block
             for (var d = 0; d < _columns.Count && d < response.Directions.Count; d++)
             {
                 var dir = response.Directions[d];
-                _columns[d].ApplyState(dir.Mode, dir.FilterItemIds ?? new List<ItemId>());
+                _columns[d].ApplyState(dir.Mode, dir.FilterItemIds ?? (IReadOnlyList<ItemId>)Array.Empty<ItemId>());
             }
         }
 
         private async UniTaskVoid OnModeCycleRequested(int directionIndex, FilterSplitterMode nextMode)
         {
-            var ct = _cts?.Token ?? CancellationToken.None;
+            // DestroyUI 後の Subject 通知で _cts が null になりうるため、ローカルでキャプチャしてから使う
+            // Cache _cts into a local in case DestroyUI nulls it before/during the async call
+            var cts = _cts;
+            if (cts == null) return;
             var request = FilterSplitterStateProtocol.FilterSplitterStateRequest.CreateSetModeRequest(_blockPosition, directionIndex, nextMode);
-            var response = await ClientContext.VanillaApi.Response.SendFilterSplitterStateRequest(request, ct);
-            if (ct.IsCancellationRequested) return;
+            var response = await ClientContext.VanillaApi.Response.SendFilterSplitterStateRequest(request, cts.Token);
+            if (cts.IsCancellationRequested) return;
             if (response == null || !response.Success) return;
             ApplySnapshot(response);
         }
 
         private async UniTaskVoid OnFilterSlotClicked(int directionIndex, int slotIndex, bool isLeftClick)
         {
-            var ct = _cts?.Token ?? CancellationToken.None;
+            // DestroyUI 後の Subject 通知で _cts が null になりうるため、ローカルでキャプチャしてから使う
+            // Cache _cts into a local in case DestroyUI nulls it before/during the async call
+            var cts = _cts;
+            if (cts == null) return;
 
             // 左クリック: 持ち手アイテムをそのままフィルターに設定 / 右クリック: スロットをクリア
             // Left click: set the currently held item as filter / Right click: clear the slot
@@ -134,8 +144,8 @@ namespace Client.Game.InGame.UI.Inventory.Block
             }
 
             var request = FilterSplitterStateProtocol.FilterSplitterStateRequest.CreateSetFilterItemRequest(_blockPosition, directionIndex, slotIndex, itemId);
-            var response = await ClientContext.VanillaApi.Response.SendFilterSplitterStateRequest(request, ct);
-            if (ct.IsCancellationRequested) return;
+            var response = await ClientContext.VanillaApi.Response.SendFilterSplitterStateRequest(request, cts.Token);
+            if (cts.IsCancellationRequested) return;
             if (response == null || !response.Success) return;
             ApplySnapshot(response);
         }

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Block/FilterSplitterBlockInventoryView.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Block/FilterSplitterBlockInventoryView.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Client.Game.InGame.Block;
+using Client.Game.InGame.Context;
+using Client.Game.InGame.UI.Inventory.Main;
+using Core.Item.Interface;
+using Core.Master;
+using Cysharp.Threading.Tasks;
+using Game.Block.Blocks.FilterSplitter;
+using Game.Context;
+using Game.PlayerInventory.Interface.Subscription;
+using UniRx;
+using UnityEngine;
+using VContainer;
+
+namespace Client.Game.InGame.UI.Inventory.Block
+{
+    /// <summary>
+    /// フィルター分岐器UIのルートビュー。出力方向ごとのColumnを生成してサーバー状態と同期する。
+    /// Root view for filter splitter UI; instantiates per-direction columns and syncs with server state.
+    /// </summary>
+    public class FilterSplitterBlockInventoryView : MonoBehaviour, IBlockInventoryView
+    {
+        [SerializeField] private Transform columnsParent;
+        [SerializeField] private FilterSplitterDirectionColumnView columnPrefab;
+
+        [Inject] private LocalPlayerInventoryController _playerInventory;
+
+        public IReadOnlyList<Client.Game.InGame.UI.Inventory.Common.ItemSlotView> SubInventorySlotObjects => Array.Empty<Client.Game.InGame.UI.Inventory.Common.ItemSlotView>();
+        public int Count => 0;
+        public List<IItemStack> SubInventory { get; } = new();
+        public ISubInventoryIdentifier ISubInventoryIdentifier { get; private set; }
+
+        private readonly List<FilterSplitterDirectionColumnView> _columns = new();
+        private readonly CompositeDisposable _subscriptions = new();
+        private CancellationTokenSource _cts;
+        private Vector3Int _blockPosition;
+
+        public void Initialize(BlockGameObject blockGameObject)
+        {
+            ISubInventoryIdentifier = new BlockInventorySubInventoryIdentifier(blockGameObject.BlockPosInfo.OriginalPos);
+            _blockPosition = blockGameObject.BlockPosInfo.OriginalPos;
+
+            _cts = new CancellationTokenSource();
+            LoadStateAsync(_cts.Token).Forget();
+        }
+
+        // フィルター分岐器は通常のインベントリを持たないため空実装
+        // Filter splitter doesn't have a normal inventory, so no-op
+        public void UpdateItemList(List<IItemStack> items) { }
+        public void UpdateInventorySlot(int slot, IItemStack item) { }
+
+        public void DestroyUI()
+        {
+            _cts?.Cancel();
+            _cts?.Dispose();
+            _subscriptions.Dispose();
+            if (this != null && gameObject != null) Destroy(gameObject);
+        }
+
+        #region Internal
+
+        private async UniTask LoadStateAsync(CancellationToken ct)
+        {
+            var response = await ClientContext.VanillaApi.Response.GetFilterSplitterState(_blockPosition, ct);
+            if (ct.IsCancellationRequested) return;
+            if (response == null || !response.Success)
+            {
+                Debug.LogError($"FilterSplitter state fetch failed. Reason:{response?.FailureReason}");
+                return;
+            }
+
+            BuildColumns(response.DirectionCount, response.FilterSlotCountPerDirection);
+            ApplySnapshot(response);
+        }
+
+        private void BuildColumns(int directionCount, int filterSlotCount)
+        {
+            for (var d = 0; d < directionCount; d++)
+            {
+                var column = Instantiate(columnPrefab, columnsParent);
+                column.Build(d, filterSlotCount);
+                var directionIndex = d;
+
+                column.OnModeCycleRequested
+                    .Subscribe(nextMode => OnModeCycleRequested(directionIndex, nextMode).Forget())
+                    .AddTo(_subscriptions);
+                column.OnFilterSlotClicked
+                    .Subscribe(args => OnFilterSlotClicked(directionIndex, args.slotIndex, args.isLeftClick).Forget())
+                    .AddTo(_subscriptions);
+
+                _columns.Add(column);
+            }
+        }
+
+        private void ApplySnapshot(Server.Protocol.PacketResponse.FilterSplitterStateProtocol.FilterSplitterStateResponse response)
+        {
+            for (var d = 0; d < _columns.Count && d < response.Directions.Count; d++)
+            {
+                var dir = response.Directions[d];
+                _columns[d].ApplyState((FilterSplitterMode)dir.Mode, dir.FilterItemGuids ?? new List<string>());
+            }
+        }
+
+        private async UniTaskVoid OnModeCycleRequested(int directionIndex, FilterSplitterMode nextMode)
+        {
+            var ct = _cts?.Token ?? CancellationToken.None;
+            var response = await ClientContext.VanillaApi.Response.SetFilterSplitterMode(_blockPosition, directionIndex, nextMode, ct);
+            if (response == null || !response.Success) return;
+            ApplySnapshot(response);
+        }
+
+        private async UniTaskVoid OnFilterSlotClicked(int directionIndex, int slotIndex, bool isLeftClick)
+        {
+            var ct = _cts?.Token ?? CancellationToken.None;
+
+            // 左クリック: 持ち手アイテムがあればそれをフィルターに設定 / 右クリック: スロットをクリア
+            // Left click: if player holds an item, set it as filter / Right click: clear the slot
+            Guid itemGuid;
+            if (isLeftClick)
+            {
+                var grab = _playerInventory?.GrabInventory;
+                if (grab == null || grab.Id == ItemMaster.EmptyItemId) return;
+                itemGuid = MasterHolder.ItemMaster.GetItemMaster(grab.Id).ItemGuid;
+            }
+            else
+            {
+                itemGuid = Guid.Empty;
+            }
+
+            var response = await ClientContext.VanillaApi.Response.SetFilterSplitterItem(_blockPosition, directionIndex, slotIndex, itemGuid, ct);
+            if (response == null || !response.Success) return;
+            ApplySnapshot(response);
+        }
+
+        #endregion
+    }
+}

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Block/FilterSplitterBlockInventoryView.cs.meta
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Block/FilterSplitterBlockInventoryView.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b032478a1ee8d46ad94cc6742b065134

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Block/FilterSplitterDirectionColumnView.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Block/FilterSplitterDirectionColumnView.cs
@@ -61,7 +61,7 @@ namespace Client.Game.InGame.UI.Inventory.Block
             }
         }
 
-        public void ApplyState(FilterSplitterMode mode, IReadOnlyList<string> filterItemGuids)
+        public void ApplyState(FilterSplitterMode mode, IReadOnlyList<ItemId> filterItemIds)
         {
             _currentMode = mode;
             modeLabel.text = mode switch
@@ -76,23 +76,12 @@ namespace Client.Game.InGame.UI.Inventory.Block
             // Apply item view to each filter slot
             for (var i = 0; i < _slots.Count; i++)
             {
-                if (filterItemGuids.Count <= i || string.IsNullOrEmpty(filterItemGuids[i]))
+                if (filterItemIds.Count <= i || filterItemIds[i] == ItemMaster.EmptyItemId)
                 {
                     _slots[i].SetItem(null, 0);
                     continue;
                 }
-                if (!Guid.TryParse(filterItemGuids[i], out var guid) || guid == Guid.Empty)
-                {
-                    _slots[i].SetItem(null, 0);
-                    continue;
-                }
-                var idOrNull = MasterHolder.ItemMaster.GetItemIdOrNull(guid);
-                if (idOrNull == null)
-                {
-                    _slots[i].SetItem(null, 0);
-                    continue;
-                }
-                var view = ClientContext.ItemImageContainer.GetItemView(idOrNull.Value);
+                var view = ClientContext.ItemImageContainer.GetItemView(filterItemIds[i]);
                 _slots[i].SetItem(view, 0);
             }
         }

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Block/FilterSplitterDirectionColumnView.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Block/FilterSplitterDirectionColumnView.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Client.Game.InGame.Context;
 using Client.Game.InGame.UI.Inventory.Common;
 using Core.Master;
 using Game.Block.Blocks.FilterSplitter;
@@ -91,7 +92,7 @@ namespace Client.Game.InGame.UI.Inventory.Block
                     _slots[i].SetItem(null, 0);
                     continue;
                 }
-                var view = Client.Game.InGame.Context.ClientContext.ItemImageContainer.GetItemView(idOrNull.Value);
+                var view = ClientContext.ItemImageContainer.GetItemView(idOrNull.Value);
                 _slots[i].SetItem(view, 0);
             }
         }

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Block/FilterSplitterDirectionColumnView.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Block/FilterSplitterDirectionColumnView.cs
@@ -37,7 +37,7 @@ namespace Client.Game.InGame.UI.Inventory.Block
 
         public void Build(int directionIndex, int filterSlotCount)
         {
-            if (directionLabel != null) directionLabel.text = $"出力 {directionIndex + 1}";
+            directionLabel.text = $"出力 {directionIndex + 1}";
 
             // モードボタンの押下でクリック通知（モード自体は親から受け取る）
             // Button click only notifies; mode value is updated by parent
@@ -75,7 +75,7 @@ namespace Client.Game.InGame.UI.Inventory.Block
             // Apply item view to each filter slot
             for (var i = 0; i < _slots.Count; i++)
             {
-                if (i >= filterItemGuids.Count || string.IsNullOrEmpty(filterItemGuids[i]))
+                if (filterItemGuids.Count <= i || string.IsNullOrEmpty(filterItemGuids[i]))
                 {
                     _slots[i].SetItem(null, 0);
                     continue;

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Block/FilterSplitterDirectionColumnView.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Block/FilterSplitterDirectionColumnView.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using Client.Game.InGame.UI.Inventory.Common;
+using Core.Master;
+using Game.Block.Blocks.FilterSplitter;
+using TMPro;
+using UniRx;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Client.Game.InGame.UI.Inventory.Block
+{
+    /// <summary>
+    /// フィルター分岐器の1出力方向ぶんのUI。モード切替と複数のフィルタースロットを管理する。
+    /// One direction column of the filter splitter UI: mode toggle + filter slots.
+    /// </summary>
+    public class FilterSplitterDirectionColumnView : MonoBehaviour
+    {
+        [SerializeField] private TMP_Text directionLabel;
+        [SerializeField] private TMP_Text modeLabel;
+        [SerializeField] private Button modeButton;
+        [SerializeField] private Transform filterSlotsParent;
+
+        // モードが切り替えられたとき
+        // Fired when mode is toggled
+        public IObservable<FilterSplitterMode> OnModeCycleRequested => _modeCycleSubject;
+        // フィルタースロットがクリックされたとき (slotIndex, leftClick:true / rightClick:false)
+        // Fired when a filter slot is clicked
+        public IObservable<(int slotIndex, bool isLeftClick)> OnFilterSlotClicked => _slotClickSubject;
+
+        private readonly Subject<FilterSplitterMode> _modeCycleSubject = new();
+        private readonly Subject<(int, bool)> _slotClickSubject = new();
+        private readonly List<ItemSlotView> _slots = new();
+        private readonly CompositeDisposable _slotSubscriptions = new();
+
+        private FilterSplitterMode _currentMode = FilterSplitterMode.Default;
+
+        public void Build(int directionIndex, int filterSlotCount)
+        {
+            if (directionLabel != null) directionLabel.text = $"出力 {directionIndex + 1}";
+
+            // モードボタンの押下でクリック通知（モード自体は親から受け取る）
+            // Button click only notifies; mode value is updated by parent
+            modeButton.onClick.AddListener(() => _modeCycleSubject.OnNext(NextMode(_currentMode)));
+
+            // フィルタースロットを生成して購読
+            // Spawn filter slots and subscribe to their click events
+            for (var i = 0; i < filterSlotCount; i++)
+            {
+                var slot = Instantiate(ItemSlotView.Prefab, filterSlotsParent);
+                slot.SetItem(null, 0);
+                var capturedIndex = i;
+                slot.OnLeftClickUp
+                    .Subscribe(_ => _slotClickSubject.OnNext((capturedIndex, true)))
+                    .AddTo(_slotSubscriptions);
+                slot.OnRightClickUp
+                    .Subscribe(_ => _slotClickSubject.OnNext((capturedIndex, false)))
+                    .AddTo(_slotSubscriptions);
+                _slots.Add(slot);
+            }
+        }
+
+        public void ApplyState(FilterSplitterMode mode, IReadOnlyList<string> filterItemGuids)
+        {
+            _currentMode = mode;
+            modeLabel.text = mode switch
+            {
+                FilterSplitterMode.Default => "Default",
+                FilterSplitterMode.Whitelist => "Whitelist",
+                FilterSplitterMode.Blacklist => "Blacklist",
+                _ => "?",
+            };
+
+            // 各スロットに対応するアイテムをセット
+            // Apply item view to each filter slot
+            for (var i = 0; i < _slots.Count; i++)
+            {
+                if (i >= filterItemGuids.Count || string.IsNullOrEmpty(filterItemGuids[i]))
+                {
+                    _slots[i].SetItem(null, 0);
+                    continue;
+                }
+                if (!Guid.TryParse(filterItemGuids[i], out var guid) || guid == Guid.Empty)
+                {
+                    _slots[i].SetItem(null, 0);
+                    continue;
+                }
+                var idOrNull = MasterHolder.ItemMaster.GetItemIdOrNull(guid);
+                if (idOrNull == null)
+                {
+                    _slots[i].SetItem(null, 0);
+                    continue;
+                }
+                var view = Client.Game.InGame.Context.ClientContext.ItemImageContainer.GetItemView(idOrNull.Value);
+                _slots[i].SetItem(view, 0);
+            }
+        }
+
+        private void OnDestroy()
+        {
+            _slotSubscriptions.Dispose();
+            _modeCycleSubject.Dispose();
+            _slotClickSubject.Dispose();
+        }
+
+        private static FilterSplitterMode NextMode(FilterSplitterMode current)
+        {
+            return current switch
+            {
+                FilterSplitterMode.Default => FilterSplitterMode.Whitelist,
+                FilterSplitterMode.Whitelist => FilterSplitterMode.Blacklist,
+                FilterSplitterMode.Blacklist => FilterSplitterMode.Default,
+                _ => FilterSplitterMode.Default,
+            };
+        }
+    }
+}

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Block/FilterSplitterDirectionColumnView.cs.meta
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Block/FilterSplitterDirectionColumnView.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7d03a11797b1144a5b702438106fa427

--- a/moorestech_client/Assets/Scripts/Client.Network/API/VanillaApiWithResponse.cs
+++ b/moorestech_client/Assets/Scripts/Client.Network/API/VanillaApiWithResponse.cs
@@ -11,6 +11,7 @@ using Game.CraftTree.Models;
 using Game.Research;
 using Game.Train.RailPositions;
 using Game.Train.Unit;
+using Game.Block.Blocks.FilterSplitter;
 using Game.Block.Blocks.TrainRail;
 using Game.Block.Interface;
 using Game.Gear.Common;
@@ -285,12 +286,12 @@ namespace Client.Network.API
         public async UniTask<FilterSplitterStateProtocol.FilterSplitterStateResponse> GetFilterSplitterState(Vector3Int position, CancellationToken ct)
         {
             var request = new FilterSplitterStateProtocol.FilterSplitterStateRequest(
-                position, FilterSplitterStateProtocol.FilterSplitterOperation.Get, 0, 0, global::Game.Block.Blocks.FilterSplitter.FilterSplitterMode.Default, string.Empty);
+                position, FilterSplitterStateProtocol.FilterSplitterOperation.Get, 0, 0, FilterSplitterMode.Default, string.Empty);
             return await _packetExchangeManager.GetPacketResponse<FilterSplitterStateProtocol.FilterSplitterStateResponse>(request, ct);
         }
 
         public async UniTask<FilterSplitterStateProtocol.FilterSplitterStateResponse> SetFilterSplitterMode(
-            Vector3Int position, int directionIndex, global::Game.Block.Blocks.FilterSplitter.FilterSplitterMode mode, CancellationToken ct)
+            Vector3Int position, int directionIndex, FilterSplitterMode mode, CancellationToken ct)
         {
             var request = new FilterSplitterStateProtocol.FilterSplitterStateRequest(
                 position, FilterSplitterStateProtocol.FilterSplitterOperation.SetMode, directionIndex, 0, mode, string.Empty);
@@ -302,7 +303,7 @@ namespace Client.Network.API
         {
             var request = new FilterSplitterStateProtocol.FilterSplitterStateRequest(
                 position, FilterSplitterStateProtocol.FilterSplitterOperation.SetFilterItem, directionIndex, slotIndex,
-                global::Game.Block.Blocks.FilterSplitter.FilterSplitterMode.Default,
+                FilterSplitterMode.Default,
                 itemGuid == Guid.Empty ? string.Empty : itemGuid.ToString());
             return await _packetExchangeManager.GetPacketResponse<FilterSplitterStateProtocol.FilterSplitterStateResponse>(request, ct);
         }

--- a/moorestech_client/Assets/Scripts/Client.Network/API/VanillaApiWithResponse.cs
+++ b/moorestech_client/Assets/Scripts/Client.Network/API/VanillaApiWithResponse.cs
@@ -280,6 +280,33 @@ namespace Client.Network.API
             return await _packetExchangeManager.GetPacketResponse<SetTrainPlatformTransferModeProtocol.SetTrainPlatformTransferModeResponse>(request, ct);
         }
 
+        // フィルター分岐器の状態取得・設定
+        // Get/Update filter splitter state
+        public async UniTask<FilterSplitterStateProtocol.FilterSplitterStateResponse> GetFilterSplitterState(Vector3Int position, CancellationToken ct)
+        {
+            var request = new FilterSplitterStateProtocol.FilterSplitterStateRequest(
+                position, FilterSplitterStateProtocol.FilterSplitterOperation.Get, 0, 0, global::Game.Block.Blocks.FilterSplitter.FilterSplitterMode.Default, string.Empty);
+            return await _packetExchangeManager.GetPacketResponse<FilterSplitterStateProtocol.FilterSplitterStateResponse>(request, ct);
+        }
+
+        public async UniTask<FilterSplitterStateProtocol.FilterSplitterStateResponse> SetFilterSplitterMode(
+            Vector3Int position, int directionIndex, global::Game.Block.Blocks.FilterSplitter.FilterSplitterMode mode, CancellationToken ct)
+        {
+            var request = new FilterSplitterStateProtocol.FilterSplitterStateRequest(
+                position, FilterSplitterStateProtocol.FilterSplitterOperation.SetMode, directionIndex, 0, mode, string.Empty);
+            return await _packetExchangeManager.GetPacketResponse<FilterSplitterStateProtocol.FilterSplitterStateResponse>(request, ct);
+        }
+
+        public async UniTask<FilterSplitterStateProtocol.FilterSplitterStateResponse> SetFilterSplitterItem(
+            Vector3Int position, int directionIndex, int slotIndex, Guid itemGuid, CancellationToken ct)
+        {
+            var request = new FilterSplitterStateProtocol.FilterSplitterStateRequest(
+                position, FilterSplitterStateProtocol.FilterSplitterOperation.SetFilterItem, directionIndex, slotIndex,
+                global::Game.Block.Blocks.FilterSplitter.FilterSplitterMode.Default,
+                itemGuid == Guid.Empty ? string.Empty : itemGuid.ToString());
+            return await _packetExchangeManager.GetPacketResponse<FilterSplitterStateProtocol.FilterSplitterStateResponse>(request, ct);
+        }
+
         public async UniTask<RailConnectionEditProtocol.ResponseRailConnectionEditMessagePack> DisconnectRailAsync(
             int playerId,
             int fromNodeId,

--- a/moorestech_client/Assets/Scripts/Client.Network/API/VanillaApiWithResponse.cs
+++ b/moorestech_client/Assets/Scripts/Client.Network/API/VanillaApiWithResponse.cs
@@ -11,7 +11,6 @@ using Game.CraftTree.Models;
 using Game.Research;
 using Game.Train.RailPositions;
 using Game.Train.Unit;
-using Game.Block.Blocks.FilterSplitter;
 using Game.Block.Blocks.TrainRail;
 using Game.Block.Interface;
 using Game.Gear.Common;
@@ -281,30 +280,11 @@ namespace Client.Network.API
             return await _packetExchangeManager.GetPacketResponse<SetTrainPlatformTransferModeProtocol.SetTrainPlatformTransferModeResponse>(request, ct);
         }
 
-        // フィルター分岐器の状態取得・設定
-        // Get/Update filter splitter state
-        public async UniTask<FilterSplitterStateProtocol.FilterSplitterStateResponse> GetFilterSplitterState(Vector3Int position, CancellationToken ct)
+        // フィルター分岐器の状態取得・設定 (Get/SetMode/SetFilterItem を 1 メソッドで扱う)
+        // Filter splitter state request (single endpoint for Get / SetMode / SetFilterItem)
+        public async UniTask<FilterSplitterStateProtocol.FilterSplitterStateResponse> SendFilterSplitterStateRequest(
+            FilterSplitterStateProtocol.FilterSplitterStateRequest request, CancellationToken ct)
         {
-            var request = new FilterSplitterStateProtocol.FilterSplitterStateRequest(
-                position, FilterSplitterStateProtocol.FilterSplitterOperation.Get, 0, 0, FilterSplitterMode.Default, string.Empty);
-            return await _packetExchangeManager.GetPacketResponse<FilterSplitterStateProtocol.FilterSplitterStateResponse>(request, ct);
-        }
-
-        public async UniTask<FilterSplitterStateProtocol.FilterSplitterStateResponse> SetFilterSplitterMode(
-            Vector3Int position, int directionIndex, FilterSplitterMode mode, CancellationToken ct)
-        {
-            var request = new FilterSplitterStateProtocol.FilterSplitterStateRequest(
-                position, FilterSplitterStateProtocol.FilterSplitterOperation.SetMode, directionIndex, 0, mode, string.Empty);
-            return await _packetExchangeManager.GetPacketResponse<FilterSplitterStateProtocol.FilterSplitterStateResponse>(request, ct);
-        }
-
-        public async UniTask<FilterSplitterStateProtocol.FilterSplitterStateResponse> SetFilterSplitterItem(
-            Vector3Int position, int directionIndex, int slotIndex, Guid itemGuid, CancellationToken ct)
-        {
-            var request = new FilterSplitterStateProtocol.FilterSplitterStateRequest(
-                position, FilterSplitterStateProtocol.FilterSplitterOperation.SetFilterItem, directionIndex, slotIndex,
-                FilterSplitterMode.Default,
-                itemGuid == Guid.Empty ? string.Empty : itemGuid.ToString());
             return await _packetExchangeManager.GetPacketResponse<FilterSplitterStateProtocol.FilterSplitterStateResponse>(request, ct);
         }
 

--- a/moorestech_server/Assets/Scripts/Core.Master/ItemMaster.cs
+++ b/moorestech_server/Assets/Scripts/Core.Master/ItemMaster.cs
@@ -81,6 +81,11 @@ namespace Core.Master
         {
             return _itemGuidToItemId.ContainsKey(guid);
         }
+
+        public bool ExistItemId(ItemId itemId)
+        {
+            return _itemElementTableById.ContainsKey(itemId);
+        }
         
         public IEnumerable<ItemId> GetItemAllIds()
         {

--- a/moorestech_server/Assets/Scripts/Core.Master/_CompileRequester.cs
+++ b/moorestech_server/Assets/Scripts/Core.Master/_CompileRequester.cs
@@ -5,5 +5,5 @@ public class CompileRequester
 {
 // スキーマを更新したら、こちらの更新もコミットしてください。
 // If you update the schema, please also commit this update.
-    private const string dummyText = "2026/05/18 18:59:27";
+    private const string dummyText = "2026/05/18 21:08:46";
 }

--- a/moorestech_server/Assets/Scripts/Game.Block/Blocks/FilterSplitter.meta
+++ b/moorestech_server/Assets/Scripts/Game.Block/Blocks/FilterSplitter.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8cc2c0b3231354fcc9ba2b168b1d76a3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/moorestech_server/Assets/Scripts/Game.Block/Blocks/FilterSplitter/FilterSplitterMode.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Blocks/FilterSplitter/FilterSplitterMode.cs
@@ -1,0 +1,11 @@
+namespace Game.Block.Blocks.FilterSplitter
+{
+    // 出力方向ごとのフィルター動作モード
+    // Per-direction filter behavior mode
+    public enum FilterSplitterMode
+    {
+        Default = 0,
+        Whitelist = 1,
+        Blacklist = 2,
+    }
+}

--- a/moorestech_server/Assets/Scripts/Game.Block/Blocks/FilterSplitter/FilterSplitterMode.cs.meta
+++ b/moorestech_server/Assets/Scripts/Game.Block/Blocks/FilterSplitter/FilterSplitterMode.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a185215807900478bbcd7be5515bb067

--- a/moorestech_server/Assets/Scripts/Game.Block/Blocks/FilterSplitter/VanillaFilterSplitterComponent.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Blocks/FilterSplitter/VanillaFilterSplitterComponent.cs
@@ -1,0 +1,356 @@
+using System;
+using System.Collections.Generic;
+using Core.Item.Interface;
+using Core.Master;
+using Game.Block.Component;
+using Game.Block.Interface;
+using Game.Block.Interface.Component;
+using Game.Context;
+using Mooresmaster.Model.BlockConnectInfoModule;
+using Newtonsoft.Json;
+
+namespace Game.Block.Blocks.FilterSplitter
+{
+    /// <summary>
+    /// 出力方向ごとにアイテムをフィルタリングして分岐するブロック。
+    /// 受け取ったアイテムは出力方向ごとの内部バッファ(1スロット)を経由し、
+    /// Updateで実出力先へ送出される。出力方向の選択はラウンドロビン。
+    /// Filter splitter that routes incoming items per direction with a per-direction 1-slot buffer.
+    /// </summary>
+    public class VanillaFilterSplitterComponent : IBlockInventory, IBlockSaveState, IUpdatableBlockComponent
+    {
+        public string SaveKey { get; } = typeof(VanillaFilterSplitterComponent).FullName;
+        public bool IsDestroy { get; private set; }
+
+        // 出力方向の数（マスタ上の outputConnects.Length と等価）
+        // Number of output directions (equals master's outputConnects length)
+        public int DirectionCount => _directions.Length;
+        public int FilterSlotCountPerDirection => _filterSlotCount;
+
+        private readonly DirectionState[] _directions;
+        private readonly BlockConnectorComponent<IBlockInventory> _connectorComponent;
+        private readonly BlockInstanceId _blockInstanceId;
+        private readonly int _filterSlotCount;
+        private int _roundRobinIndex = -1;
+
+        public VanillaFilterSplitterComponent(
+            BlockInstanceId blockInstanceId,
+            BlockConnectorComponent<IBlockInventory> connectorComponent,
+            BlockConnectInfoElement[] outputConnectorElements,
+            int filterSlotCountPerDirection)
+        {
+            _blockInstanceId = blockInstanceId;
+            _connectorComponent = connectorComponent;
+            _filterSlotCount = filterSlotCountPerDirection;
+            _directions = new DirectionState[outputConnectorElements.Length];
+            for (var i = 0; i < outputConnectorElements.Length; i++)
+            {
+                _directions[i] = new DirectionState(outputConnectorElements[i].ConnectorGuid, filterSlotCountPerDirection);
+            }
+        }
+
+        public VanillaFilterSplitterComponent(
+            Dictionary<string, string> componentStates,
+            BlockInstanceId blockInstanceId,
+            BlockConnectorComponent<IBlockInventory> connectorComponent,
+            BlockConnectInfoElement[] outputConnectorElements,
+            int filterSlotCountPerDirection) :
+            this(blockInstanceId, connectorComponent, outputConnectorElements, filterSlotCountPerDirection)
+        {
+            if (!componentStates.TryGetValue(SaveKey, out var json)) return;
+            var saveData = JsonConvert.DeserializeObject<SaveJsonObject>(json);
+            if (saveData?.Directions == null) return;
+
+            // 保存データの方向数とマスタの方向数が異なる場合は、両者の最小数まで復元
+            // Restore up to the minimum of saved direction count and master direction count
+            var count = Math.Min(saveData.Directions.Count, _directions.Length);
+            for (var i = 0; i < count; i++)
+            {
+                _directions[i].LoadFromJson(saveData.Directions[i]);
+            }
+        }
+
+        #region IBlockInventory
+
+        public IItemStack InsertItem(IItemStack itemStack, InsertItemContext context)
+        {
+            BlockException.CheckDestroy(this);
+
+            if (itemStack.Count <= 0 || itemStack.Id == ItemMaster.EmptyItemId) return itemStack;
+
+            // フィルター適合かつバッファ空きのある方向をラウンドロビンで決定
+            // Find the next eligible direction (filter match + empty buffer) via round-robin
+            var directionIndex = SelectNextDirection(itemStack.Id);
+            if (directionIndex < 0) return itemStack;
+
+            // 1個だけ受け取ってバッファへ格納（残りは呼び出し元へ返す）
+            // Accept exactly one item into the buffer slot; return the rest to caller
+            _directions[directionIndex].BufferedItem = ServerContext.ItemStackFactory.Create(itemStack.Id, 1, itemStack.ItemInstanceId);
+            return itemStack.SubItem(1);
+        }
+
+        public bool InsertionCheck(List<IItemStack> itemStacks)
+        {
+            BlockException.CheckDestroy(this);
+            if (itemStacks.Count == 0) return false;
+
+            // 受け入れ可能な方向が1つでもあればtrue
+            // Returns true if at least one direction can accept the item
+            foreach (var stack in itemStacks)
+            {
+                if (stack.Id == ItemMaster.EmptyItemId) continue;
+                if (FindAnyEligibleDirection(stack.Id) >= 0) return true;
+            }
+            return false;
+        }
+
+        public int GetSlotSize()
+        {
+            BlockException.CheckDestroy(this);
+            return _directions.Length;
+        }
+
+        public IItemStack GetItem(int slot)
+        {
+            BlockException.CheckDestroy(this);
+            return _directions[slot].BufferedItem ?? ServerContext.ItemStackFactory.CreatEmpty();
+        }
+
+        public void SetItem(int slot, IItemStack itemStack)
+        {
+            BlockException.CheckDestroy(this);
+            _directions[slot].BufferedItem = itemStack;
+        }
+
+        #endregion
+
+        #region Update
+
+        public void Update()
+        {
+            BlockException.CheckDestroy(this);
+
+            // 各方向のバッファアイテムを対応する出力先へ送る
+            // Push each direction's buffered item to its corresponding output target
+            for (var i = 0; i < _directions.Length; i++)
+            {
+                var dir = _directions[i];
+                if (dir.BufferedItem == null) continue;
+
+                var target = FindConnectedTargetByGuid(dir.ConnectorGuid);
+                if (target == null) continue;
+
+                var context = new InsertItemContext(_blockInstanceId, target.Value.Info.SelfConnector, target.Value.Info.TargetConnector);
+                var result = target.Value.Inventory.InsertItem(dir.BufferedItem, context);
+                dir.BufferedItem = result.Id == ItemMaster.EmptyItemId ? null : result;
+            }
+        }
+
+        #endregion
+
+        #region Save
+
+        public string GetSaveState()
+        {
+            BlockException.CheckDestroy(this);
+
+            var directions = new List<DirectionSaveJsonObject>();
+            foreach (var dir in _directions)
+            {
+                directions.Add(dir.ToJsonObject());
+            }
+            return JsonConvert.SerializeObject(new SaveJsonObject { Directions = directions });
+        }
+
+        #endregion
+
+        #region Filter Config API
+
+        public FilterSplitterMode GetMode(int directionIndex)
+        {
+            BlockException.CheckDestroy(this);
+            return _directions[directionIndex].Mode;
+        }
+
+        public void SetMode(int directionIndex, FilterSplitterMode mode)
+        {
+            BlockException.CheckDestroy(this);
+            _directions[directionIndex].Mode = mode;
+        }
+
+        public ItemId GetFilterItem(int directionIndex, int slotIndex)
+        {
+            BlockException.CheckDestroy(this);
+            return _directions[directionIndex].FilterItems[slotIndex];
+        }
+
+        public void SetFilterItem(int directionIndex, int slotIndex, ItemId itemId)
+        {
+            BlockException.CheckDestroy(this);
+            var dir = _directions[directionIndex];
+            // 旧アイテムをセットからも除外
+            // Remove old item from set as well
+            var prev = dir.FilterItems[slotIndex];
+            if (prev != ItemMaster.EmptyItemId) dir.FilterItemSet.Remove(prev);
+            dir.FilterItems[slotIndex] = itemId;
+            if (itemId != ItemMaster.EmptyItemId) dir.FilterItemSet.Add(itemId);
+        }
+
+        public IReadOnlyList<ItemId> GetFilterItems(int directionIndex)
+        {
+            BlockException.CheckDestroy(this);
+            return _directions[directionIndex].FilterItems;
+        }
+
+        #endregion
+
+        public void Destroy()
+        {
+            IsDestroy = true;
+        }
+
+        #region Internal Routing
+
+        private int SelectNextDirection(ItemId itemId)
+        {
+            var count = _directions.Length;
+            if (count == 0) return -1;
+
+            for (var step = 1; step <= count; step++)
+            {
+                var index = (_roundRobinIndex + step) % count;
+                if (IsDirectionEligible(index, itemId))
+                {
+                    _roundRobinIndex = index;
+                    return index;
+                }
+            }
+            return -1;
+        }
+
+        private int FindAnyEligibleDirection(ItemId itemId)
+        {
+            for (var i = 0; i < _directions.Length; i++)
+            {
+                if (IsDirectionEligible(i, itemId)) return i;
+            }
+            return -1;
+        }
+
+        private bool IsDirectionEligible(int index, ItemId itemId)
+        {
+            var dir = _directions[index];
+            if (dir.BufferedItem != null) return false;
+
+            switch (dir.Mode)
+            {
+                case FilterSplitterMode.Default:
+                    return true;
+                case FilterSplitterMode.Whitelist:
+                    return dir.FilterItemSet.Contains(itemId);
+                case FilterSplitterMode.Blacklist:
+                    return !dir.FilterItemSet.Contains(itemId);
+                default:
+                    return false;
+            }
+        }
+
+        private (IBlockInventory Inventory, ConnectedInfo Info)? FindConnectedTargetByGuid(Guid connectorGuid)
+        {
+            foreach (var pair in _connectorComponent.ConnectedTargets)
+            {
+                if (pair.Value.SelfConnector != null && pair.Value.SelfConnector.ConnectorGuid == connectorGuid)
+                {
+                    return (pair.Key, pair.Value);
+                }
+            }
+            return null;
+        }
+
+        #endregion
+
+        #region Direction State
+
+        private class DirectionState
+        {
+            public readonly Guid ConnectorGuid;
+            public readonly ItemId[] FilterItems;
+            public readonly HashSet<ItemId> FilterItemSet = new();
+            public FilterSplitterMode Mode = FilterSplitterMode.Default;
+            public IItemStack BufferedItem;
+
+            public DirectionState(Guid connectorGuid, int slotCount)
+            {
+                ConnectorGuid = connectorGuid;
+                FilterItems = new ItemId[slotCount];
+                for (var i = 0; i < slotCount; i++) FilterItems[i] = ItemMaster.EmptyItemId;
+            }
+
+            public DirectionSaveJsonObject ToJsonObject()
+            {
+                var itemGuids = new List<string>();
+                foreach (var id in FilterItems)
+                {
+                    if (id == ItemMaster.EmptyItemId)
+                    {
+                        itemGuids.Add(null);
+                    }
+                    else
+                    {
+                        var master = MasterHolder.ItemMaster.GetItemMaster(id);
+                        itemGuids.Add(master.ItemGuid.ToString());
+                    }
+                }
+                return new DirectionSaveJsonObject
+                {
+                    Mode = (int)Mode,
+                    FilterItemGuids = itemGuids,
+                    BufferedItem = BufferedItem == null ? null : new ItemStackSaveJsonObject(BufferedItem),
+                };
+            }
+
+            public void LoadFromJson(DirectionSaveJsonObject json)
+            {
+                Mode = (FilterSplitterMode)json.Mode;
+                FilterItemSet.Clear();
+                if (json.FilterItemGuids != null)
+                {
+                    var count = Math.Min(json.FilterItemGuids.Count, FilterItems.Length);
+                    for (var i = 0; i < count; i++)
+                    {
+                        var guidStr = json.FilterItemGuids[i];
+                        if (string.IsNullOrEmpty(guidStr) || !Guid.TryParse(guidStr, out var guid) || guid == Guid.Empty)
+                        {
+                            FilterItems[i] = ItemMaster.EmptyItemId;
+                            continue;
+                        }
+                        var idOrNull = MasterHolder.ItemMaster.GetItemIdOrNull(guid);
+                        if (idOrNull == null)
+                        {
+                            FilterItems[i] = ItemMaster.EmptyItemId;
+                            continue;
+                        }
+                        FilterItems[i] = idOrNull.Value;
+                        FilterItemSet.Add(idOrNull.Value);
+                    }
+                }
+
+                BufferedItem = json.BufferedItem?.ToItemStack();
+            }
+        }
+
+        private class SaveJsonObject
+        {
+            [JsonProperty("directions")] public List<DirectionSaveJsonObject> Directions { get; set; }
+        }
+
+        private class DirectionSaveJsonObject
+        {
+            [JsonProperty("mode")] public int Mode { get; set; }
+            [JsonProperty("filterItemGuids")] public List<string> FilterItemGuids { get; set; }
+            [JsonProperty("bufferedItem")] public ItemStackSaveJsonObject BufferedItem { get; set; }
+        }
+
+        #endregion
+    }
+}

--- a/moorestech_server/Assets/Scripts/Game.Block/Blocks/FilterSplitter/VanillaFilterSplitterComponent.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Blocks/FilterSplitter/VanillaFilterSplitterComponent.cs
@@ -196,20 +196,12 @@ namespace Game.Block.Blocks.FilterSplitter
         public void SetMode(int directionIndex, FilterSplitterMode mode)
         {
             BlockException.CheckDestroy(this);
-            // Protocol 経由以外の呼び出しも壊れた値を入れられないようガード
-            // Guard component-level callers (not only protocol) from injecting undefined values
-            if (!Enum.IsDefined(typeof(FilterSplitterMode), mode))
-                throw new ArgumentOutOfRangeException(nameof(mode), mode, "Undefined FilterSplitterMode value");
             _directions[directionIndex].Mode = mode;
         }
 
         public void SetFilterItem(int directionIndex, int slotIndex, ItemId itemId)
         {
             BlockException.CheckDestroy(this);
-            // EmptyItemId はクリア、それ以外は master 存在チェック (save 時の例外を防ぐ)
-            // EmptyItemId means clear; otherwise verify the item exists in the master to avoid save-time errors
-            if (itemId != ItemMaster.EmptyItemId && !MasterHolder.ItemMaster.ExistItemId(itemId))
-                throw new ArgumentException($"ItemId {itemId} not registered in master", nameof(itemId));
             _directions[directionIndex].FilterItems[slotIndex] = itemId;
         }
 

--- a/moorestech_server/Assets/Scripts/Game.Block/Blocks/FilterSplitter/VanillaFilterSplitterComponent.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Blocks/FilterSplitter/VanillaFilterSplitterComponent.cs
@@ -161,7 +161,9 @@ namespace Game.Block.Blocks.FilterSplitter
 
                 var context = new InsertItemContext(_blockInstanceId, target.Value.Info.SelfConnector, target.Value.Info.TargetConnector);
                 var result = target.Value.Inventory.InsertItem(dir.BufferedItem, context);
-                dir.BufferedItem = result.Id == ItemMaster.EmptyItemId ? null : result;
+                // 送信完了は「空 ID」または「Count <= 0」で判定（IItemStack 実装によって戻り値が異なるため両方見る）
+                // Treat both "empty id" and "count <= 0" as fully delivered (IItemStack implementations differ)
+                dir.BufferedItem = (result.Id == ItemMaster.EmptyItemId || result.Count <= 0) ? null : result;
             }
         }
 

--- a/moorestech_server/Assets/Scripts/Game.Block/Blocks/FilterSplitter/VanillaFilterSplitterComponent.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Blocks/FilterSplitter/VanillaFilterSplitterComponent.cs
@@ -99,7 +99,7 @@ namespace Game.Block.Blocks.FilterSplitter
             foreach (var stack in itemStacks)
             {
                 if (stack.Id == ItemMaster.EmptyItemId) continue;
-                if (FindAnyEligibleDirection(stack.Id) >= 0) return true;
+                if (0 <= FindAnyEligibleDirection(stack.Id)) return true;
             }
             return false;
         }
@@ -178,12 +178,6 @@ namespace Game.Block.Blocks.FilterSplitter
             _directions[directionIndex].Mode = mode;
         }
 
-        public ItemId GetFilterItem(int directionIndex, int slotIndex)
-        {
-            BlockException.CheckDestroy(this);
-            return _directions[directionIndex].FilterItems[slotIndex];
-        }
-
         public void SetFilterItem(int directionIndex, int slotIndex, ItemId itemId)
         {
             BlockException.CheckDestroy(this);
@@ -208,8 +202,6 @@ namespace Game.Block.Blocks.FilterSplitter
         {
             IsDestroy = true;
         }
-
-        #region Internal Routing
 
         private int SelectNextDirection(ItemId itemId)
         {
@@ -266,10 +258,6 @@ namespace Game.Block.Blocks.FilterSplitter
             }
             return null;
         }
-
-        #endregion
-
-        #region Direction State
 
         private class DirectionState
         {
@@ -350,7 +338,5 @@ namespace Game.Block.Blocks.FilterSplitter
             [JsonProperty("filterItemGuids")] public List<string> FilterItemGuids { get; set; }
             [JsonProperty("bufferedItem")] public ItemStackSaveJsonObject BufferedItem { get; set; }
         }
-
-        #endregion
     }
 }

--- a/moorestech_server/Assets/Scripts/Game.Block/Blocks/FilterSplitter/VanillaFilterSplitterComponent.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Blocks/FilterSplitter/VanillaFilterSplitterComponent.cs
@@ -8,14 +8,14 @@ using Game.Block.Interface.Component;
 using Game.Context;
 using Mooresmaster.Model.BlockConnectInfoModule;
 using Newtonsoft.Json;
+using UnityEngine;
 
 namespace Game.Block.Blocks.FilterSplitter
 {
     /// <summary>
     /// 出力方向ごとにアイテムをフィルタリングして分岐するブロック。
-    /// 受け取ったアイテムは出力方向ごとの内部バッファ(1スロット)を経由し、
-    /// Updateで実出力先へ送出される。出力方向の選択はラウンドロビン。
-    /// Filter splitter that routes incoming items per direction with a per-direction 1-slot buffer.
+    /// Whitelist/Blacklist で明示マッチした方向を優先、Default は fallback として使う。
+    /// Filter splitter that routes items per direction. Explicit (Whitelist/Blacklist) directions take priority, Default acts as fallback.
     /// </summary>
     public class VanillaFilterSplitterComponent : IBlockInventory, IBlockSaveState, IUpdatableBlockComponent
     {
@@ -41,11 +41,11 @@ namespace Game.Block.Blocks.FilterSplitter
         {
             _blockInstanceId = blockInstanceId;
             _connectorComponent = connectorComponent;
-            _filterSlotCount = filterSlotCountPerDirection;
+            _filterSlotCount = Math.Max(0, filterSlotCountPerDirection);
             _directions = new DirectionState[outputConnectorElements.Length];
             for (var i = 0; i < outputConnectorElements.Length; i++)
             {
-                _directions[i] = new DirectionState(outputConnectorElements[i].ConnectorGuid, filterSlotCountPerDirection);
+                _directions[i] = new DirectionState(outputConnectorElements[i].ConnectorGuid, _filterSlotCount);
             }
         }
 
@@ -61,12 +61,22 @@ namespace Game.Block.Blocks.FilterSplitter
             var saveData = JsonConvert.DeserializeObject<SaveJsonObject>(json);
             if (saveData?.Directions == null) return;
 
-            // 保存データの方向数とマスタの方向数が異なる場合は、両者の最小数まで復元
-            // Restore up to the minimum of saved direction count and master direction count
-            var count = Math.Min(saveData.Directions.Count, _directions.Length);
-            for (var i = 0; i < count; i++)
+            // 保存データの方向を ConnectorGuid ベースで現方向にマップして復元する
+            // Restore each saved direction by mapping its ConnectorGuid onto current directions
+            foreach (var savedDir in saveData.Directions)
             {
-                _directions[i].LoadFromJson(saveData.Directions[i]);
+                if (string.IsNullOrEmpty(savedDir.ConnectorGuid) || !Guid.TryParse(savedDir.ConnectorGuid, out var g))
+                {
+                    Debug.LogWarning($"FilterSplitter load: invalid connectorGuid '{savedDir.ConnectorGuid}', direction settings dropped");
+                    continue;
+                }
+                var currentIndex = FindDirectionIndexByGuid(g);
+                if (currentIndex < 0)
+                {
+                    Debug.LogWarning($"FilterSplitter load: connectorGuid {g} not found in current master, direction settings dropped");
+                    continue;
+                }
+                _directions[currentIndex].LoadFromJson(savedDir);
             }
         }
 
@@ -78,8 +88,8 @@ namespace Game.Block.Blocks.FilterSplitter
 
             if (itemStack.Count <= 0 || itemStack.Id == ItemMaster.EmptyItemId) return itemStack;
 
-            // フィルター適合かつバッファ空きのある方向をラウンドロビンで決定
-            // Find the next eligible direction (filter match + empty buffer) via round-robin
+            // 明示マッチ方向を優先し、なければ Default 方向をラウンドロビン
+            // Pick explicit match first, then fall back to Default directions via round-robin
             var directionIndex = SelectNextDirection(itemStack.Id);
             if (directionIndex < 0) return itemStack;
 
@@ -119,7 +129,16 @@ namespace Game.Block.Blocks.FilterSplitter
         public void SetItem(int slot, IItemStack itemStack)
         {
             BlockException.CheckDestroy(this);
-            _directions[slot].BufferedItem = itemStack;
+            // empty / 不正カウントは null 化、count >= 2 は 1 に丸めて格納
+            // Normalize: empty/invalid count to null, clamp count to 1
+            if (itemStack == null || itemStack.Id == ItemMaster.EmptyItemId || itemStack.Count <= 0)
+            {
+                _directions[slot].BufferedItem = null;
+                return;
+            }
+            _directions[slot].BufferedItem = itemStack.Count == 1
+                ? itemStack
+                : ServerContext.ItemStackFactory.Create(itemStack.Id, 1, itemStack.ItemInstanceId);
         }
 
         #endregion
@@ -181,13 +200,7 @@ namespace Game.Block.Blocks.FilterSplitter
         public void SetFilterItem(int directionIndex, int slotIndex, ItemId itemId)
         {
             BlockException.CheckDestroy(this);
-            var dir = _directions[directionIndex];
-            // 旧アイテムをセットからも除外
-            // Remove old item from set as well
-            var prev = dir.FilterItems[slotIndex];
-            if (prev != ItemMaster.EmptyItemId) dir.FilterItemSet.Remove(prev);
-            dir.FilterItems[slotIndex] = itemId;
-            if (itemId != ItemMaster.EmptyItemId) dir.FilterItemSet.Add(itemId);
+            _directions[directionIndex].FilterItems[slotIndex] = itemId;
         }
 
         public IReadOnlyList<ItemId> GetFilterItems(int directionIndex)
@@ -208,10 +221,38 @@ namespace Game.Block.Blocks.FilterSplitter
             var count = _directions.Length;
             if (count == 0) return -1;
 
+            // 1パス目: Whitelist/Blacklist で明示マッチする方向を優先
+            // Pass 1: prefer directions that explicitly match (Whitelist/Blacklist)
+            var explicitIndex = TryPickRoundRobin(itemId, requireExplicitMatch: true);
+            if (0 <= explicitIndex) return explicitIndex;
+
+            // 2パス目: Default 方向を fallback として選ぶ
+            // Pass 2: fall back to Default directions
+            return TryPickRoundRobin(itemId, requireExplicitMatch: false);
+        }
+
+        private int TryPickRoundRobin(ItemId itemId, bool requireExplicitMatch)
+        {
+            var count = _directions.Length;
             for (var step = 1; step <= count; step++)
             {
                 var index = (_roundRobinIndex + step) % count;
-                if (IsDirectionEligible(index, itemId))
+                if (!CanAcceptInDirection(index)) continue;
+                var mode = _directions[index].Mode;
+                if (requireExplicitMatch)
+                {
+                    if (mode == FilterSplitterMode.Whitelist && _directions[index].ContainsFilterItem(itemId))
+                    {
+                        _roundRobinIndex = index;
+                        return index;
+                    }
+                    if (mode == FilterSplitterMode.Blacklist && !_directions[index].ContainsFilterItem(itemId))
+                    {
+                        _roundRobinIndex = index;
+                        return index;
+                    }
+                }
+                else if (mode == FilterSplitterMode.Default)
                 {
                     _roundRobinIndex = index;
                     return index;
@@ -222,29 +263,43 @@ namespace Game.Block.Blocks.FilterSplitter
 
         private int FindAnyEligibleDirection(ItemId itemId)
         {
+            // 明示マッチ方向を優先
+            // Prefer explicit match directions
             for (var i = 0; i < _directions.Length; i++)
             {
-                if (IsDirectionEligible(i, itemId)) return i;
+                if (!CanAcceptInDirection(i)) continue;
+                var mode = _directions[i].Mode;
+                if (mode == FilterSplitterMode.Whitelist && _directions[i].ContainsFilterItem(itemId)) return i;
+                if (mode == FilterSplitterMode.Blacklist && !_directions[i].ContainsFilterItem(itemId)) return i;
+            }
+            // Default 方向を fallback
+            // Default directions as fallback
+            for (var i = 0; i < _directions.Length; i++)
+            {
+                if (!CanAcceptInDirection(i)) continue;
+                if (_directions[i].Mode == FilterSplitterMode.Default) return i;
             }
             return -1;
         }
 
-        private bool IsDirectionEligible(int index, ItemId itemId)
+        private bool CanAcceptInDirection(int index)
         {
             var dir = _directions[index];
+            // バッファ占有中は受け取らない
+            // Skip directions whose buffer is occupied
             if (dir.BufferedItem != null) return false;
+            // 接続先が無い方向は受け取らない（永久滞留防止）
+            // Skip directions with no connected target (avoid permanent stalling)
+            return HasConnection(dir.ConnectorGuid);
+        }
 
-            switch (dir.Mode)
+        private bool HasConnection(Guid connectorGuid)
+        {
+            foreach (var pair in _connectorComponent.ConnectedTargets)
             {
-                case FilterSplitterMode.Default:
-                    return true;
-                case FilterSplitterMode.Whitelist:
-                    return dir.FilterItemSet.Contains(itemId);
-                case FilterSplitterMode.Blacklist:
-                    return !dir.FilterItemSet.Contains(itemId);
-                default:
-                    return false;
+                if (pair.Value.SelfConnector != null && pair.Value.SelfConnector.ConnectorGuid == connectorGuid) return true;
             }
+            return false;
         }
 
         private (IBlockInventory Inventory, ConnectedInfo Info)? FindConnectedTargetByGuid(Guid connectorGuid)
@@ -259,11 +314,19 @@ namespace Game.Block.Blocks.FilterSplitter
             return null;
         }
 
+        private int FindDirectionIndexByGuid(Guid connectorGuid)
+        {
+            for (var i = 0; i < _directions.Length; i++)
+            {
+                if (_directions[i].ConnectorGuid == connectorGuid) return i;
+            }
+            return -1;
+        }
+
         private class DirectionState
         {
             public readonly Guid ConnectorGuid;
             public readonly ItemId[] FilterItems;
-            public readonly HashSet<ItemId> FilterItemSet = new();
             public FilterSplitterMode Mode = FilterSplitterMode.Default;
             public IItemStack BufferedItem;
 
@@ -272,6 +335,17 @@ namespace Game.Block.Blocks.FilterSplitter
                 ConnectorGuid = connectorGuid;
                 FilterItems = new ItemId[slotCount];
                 for (var i = 0; i < slotCount; i++) FilterItems[i] = ItemMaster.EmptyItemId;
+            }
+
+            public bool ContainsFilterItem(ItemId itemId)
+            {
+                // 重複登録があっても誤判定にならないよう配列を直接走査
+                // Scan the array directly so duplicate entries don't corrupt judgment
+                for (var i = 0; i < FilterItems.Length; i++)
+                {
+                    if (FilterItems[i] == itemId) return true;
+                }
+                return false;
             }
 
             public DirectionSaveJsonObject ToJsonObject()
@@ -291,6 +365,7 @@ namespace Game.Block.Blocks.FilterSplitter
                 }
                 return new DirectionSaveJsonObject
                 {
+                    ConnectorGuid = ConnectorGuid.ToString(),
                     Mode = (int)Mode,
                     FilterItemGuids = itemGuids,
                     BufferedItem = BufferedItem == null ? null : new ItemStackSaveJsonObject(BufferedItem),
@@ -299,11 +374,19 @@ namespace Game.Block.Blocks.FilterSplitter
 
             public void LoadFromJson(DirectionSaveJsonObject json)
             {
-                Mode = (FilterSplitterMode)json.Mode;
-                FilterItemSet.Clear();
+                // 未知 mode 値は Default に fallback
+                // Unknown mode value falls back to Default
+                Mode = Enum.IsDefined(typeof(FilterSplitterMode), json.Mode)
+                    ? (FilterSplitterMode)json.Mode
+                    : FilterSplitterMode.Default;
                 if (json.FilterItemGuids != null)
                 {
-                    var count = Math.Min(json.FilterItemGuids.Count, FilterItems.Length);
+                    var saveCount = json.FilterItemGuids.Count;
+                    if (FilterItems.Length < saveCount)
+                    {
+                        Debug.LogWarning($"FilterSplitter load: saved slot count {saveCount} exceeds current master {FilterItems.Length}, extra slots dropped");
+                    }
+                    var count = Math.Min(saveCount, FilterItems.Length);
                     for (var i = 0; i < count; i++)
                     {
                         var guidStr = json.FilterItemGuids[i];
@@ -313,13 +396,7 @@ namespace Game.Block.Blocks.FilterSplitter
                             continue;
                         }
                         var idOrNull = MasterHolder.ItemMaster.GetItemIdOrNull(guid);
-                        if (idOrNull == null)
-                        {
-                            FilterItems[i] = ItemMaster.EmptyItemId;
-                            continue;
-                        }
-                        FilterItems[i] = idOrNull.Value;
-                        FilterItemSet.Add(idOrNull.Value);
+                        FilterItems[i] = idOrNull ?? ItemMaster.EmptyItemId;
                     }
                 }
 
@@ -334,6 +411,7 @@ namespace Game.Block.Blocks.FilterSplitter
 
         private class DirectionSaveJsonObject
         {
+            [JsonProperty("connectorGuid")] public string ConnectorGuid { get; set; }
             [JsonProperty("mode")] public int Mode { get; set; }
             [JsonProperty("filterItemGuids")] public List<string> FilterItemGuids { get; set; }
             [JsonProperty("bufferedItem")] public ItemStackSaveJsonObject BufferedItem { get; set; }

--- a/moorestech_server/Assets/Scripts/Game.Block/Blocks/FilterSplitter/VanillaFilterSplitterComponent.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Blocks/FilterSplitter/VanillaFilterSplitterComponent.cs
@@ -104,11 +104,11 @@ namespace Game.Block.Blocks.FilterSplitter
             BlockException.CheckDestroy(this);
             if (itemStacks.Count == 0) return false;
 
-            // 受け入れ可能な方向が1つでもあればtrue
-            // Returns true if at least one direction can accept the item
+            // 受け入れ可能な方向が1つでもあればtrue (count <= 0 のスタックは InsertItem 側で拒否される)
+            // Returns true if at least one direction can accept the item; count<=0 stacks are rejected by InsertItem
             foreach (var stack in itemStacks)
             {
-                if (stack.Id == ItemMaster.EmptyItemId) continue;
+                if (stack.Id == ItemMaster.EmptyItemId || stack.Count <= 0) continue;
                 if (0 <= FindAnyEligibleDirection(stack.Id)) return true;
             }
             return false;
@@ -196,12 +196,20 @@ namespace Game.Block.Blocks.FilterSplitter
         public void SetMode(int directionIndex, FilterSplitterMode mode)
         {
             BlockException.CheckDestroy(this);
+            // Protocol 経由以外の呼び出しも壊れた値を入れられないようガード
+            // Guard component-level callers (not only protocol) from injecting undefined values
+            if (!Enum.IsDefined(typeof(FilterSplitterMode), mode))
+                throw new ArgumentOutOfRangeException(nameof(mode), mode, "Undefined FilterSplitterMode value");
             _directions[directionIndex].Mode = mode;
         }
 
         public void SetFilterItem(int directionIndex, int slotIndex, ItemId itemId)
         {
             BlockException.CheckDestroy(this);
+            // EmptyItemId はクリア、それ以外は master 存在チェック (save 時の例外を防ぐ)
+            // EmptyItemId means clear; otherwise verify the item exists in the master to avoid save-time errors
+            if (itemId != ItemMaster.EmptyItemId && !MasterHolder.ItemMaster.ExistItemId(itemId))
+                throw new ArgumentException($"ItemId {itemId} not registered in master", nameof(itemId));
             _directions[directionIndex].FilterItems[slotIndex] = itemId;
         }
 
@@ -402,7 +410,19 @@ namespace Game.Block.Blocks.FilterSplitter
                     }
                 }
 
-                BufferedItem = json.BufferedItem?.ToItemStack();
+                // SetItem と同じ正規化: 空 / 不正カウントは null、count >= 2 は 1 に丸める
+                // Apply the same normalization as SetItem: empty/invalid-count → null, count >= 2 → 1
+                var loadedItem = json.BufferedItem?.ToItemStack();
+                if (loadedItem == null || loadedItem.Id == ItemMaster.EmptyItemId || loadedItem.Count <= 0)
+                {
+                    BufferedItem = null;
+                }
+                else
+                {
+                    BufferedItem = loadedItem.Count == 1
+                        ? loadedItem
+                        : Game.Context.ServerContext.ItemStackFactory.Create(loadedItem.Id, 1, loadedItem.ItemInstanceId);
+                }
             }
         }
 

--- a/moorestech_server/Assets/Scripts/Game.Block/Blocks/FilterSplitter/VanillaFilterSplitterComponent.cs.meta
+++ b/moorestech_server/Assets/Scripts/Game.Block/Blocks/FilterSplitter/VanillaFilterSplitterComponent.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6b2590e1e9a5347899cb1f66423021c8

--- a/moorestech_server/Assets/Scripts/Game.Block/Factory/BlockTemplate/VanillaFilterSplitterTemplate.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Factory/BlockTemplate/VanillaFilterSplitterTemplate.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using Game.Block.Blocks;
+using Game.Block.Blocks.FilterSplitter;
+using Game.Block.Interface;
+using Game.Block.Interface.Component;
+using Mooresmaster.Model.BlockConnectInfoModule;
+using Mooresmaster.Model.BlocksModule;
+
+namespace Game.Block.Factory.BlockTemplate
+{
+    public class VanillaFilterSplitterTemplate : IBlockTemplate
+    {
+        public IBlock New(BlockMasterElement blockMasterElement, BlockInstanceId blockInstanceId, BlockPositionInfo blockPositionInfo, BlockCreateParam[] createParams)
+        {
+            return GetBlock(null, blockMasterElement, blockInstanceId, blockPositionInfo);
+        }
+
+        public IBlock Load(Dictionary<string, string> componentStates, BlockMasterElement blockMasterElement, BlockInstanceId blockInstanceId, BlockPositionInfo blockPositionInfo)
+        {
+            return GetBlock(componentStates, blockMasterElement, blockInstanceId, blockPositionInfo);
+        }
+
+        private IBlock GetBlock(Dictionary<string, string> componentStates, BlockMasterElement blockMasterElement, BlockInstanceId blockInstanceId, BlockPositionInfo blockPositionInfo)
+        {
+            var param = blockMasterElement.BlockParam as FilterSplitterBlockParam;
+
+            var connectorComponent = BlockTemplateUtil.CreateInventoryConnector(param.InventoryConnectors, blockPositionInfo);
+
+            // マスタの outputConnects の順序が方向インデックスとなる
+            // The order of outputConnects in master data defines the direction index
+            BlockConnectInfoElement[] outputElements = param.InventoryConnectors.OutputConnects.items;
+
+            var splitter = componentStates == null
+                ? new VanillaFilterSplitterComponent(blockInstanceId, connectorComponent, outputElements, param.FilterSlotCountPerDirection)
+                : new VanillaFilterSplitterComponent(componentStates, blockInstanceId, connectorComponent, outputElements, param.FilterSlotCountPerDirection);
+
+            var components = new List<IBlockComponent>
+            {
+                splitter,
+                connectorComponent,
+            };
+
+            return new BlockSystem(blockInstanceId, blockMasterElement.BlockGuid, components, blockPositionInfo);
+        }
+    }
+}

--- a/moorestech_server/Assets/Scripts/Game.Block/Factory/BlockTemplate/VanillaFilterSplitterTemplate.cs.meta
+++ b/moorestech_server/Assets/Scripts/Game.Block/Factory/BlockTemplate/VanillaFilterSplitterTemplate.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 396a1096b5f30488eb86c89f9fbc2bed

--- a/moorestech_server/Assets/Scripts/Game.Block/Factory/VanillaIBlockTemplates.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Factory/VanillaIBlockTemplates.cs
@@ -47,6 +47,7 @@ namespace Game.Block.Factory
             BlockTypesDictionary.Add(BlockTypeConst.BaseCamp, new BaseCampBlockTemplate());
             BlockTypesDictionary.Add(BlockTypeConst.GearPump, new VanillaGearPumpTemplate());
             BlockTypesDictionary.Add(BlockTypeConst.ElectricPump, new VanillaElectricPumpTemplate());
+            BlockTypesDictionary.Add(BlockTypeConst.FilterSplitter, new VanillaFilterSplitterTemplate());
         }
     }
 }

--- a/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/FilterSplitterStateProtocol.cs
+++ b/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/FilterSplitterStateProtocol.cs
@@ -27,6 +27,10 @@ namespace Server.Protocol.PacketResponse
         {
             var request = MessagePackSerializer.Deserialize<FilterSplitterStateRequest>(payload);
 
+            // malformed payload で Position が null の場合は早期に拒否する
+            // Reject malformed payloads whose Position is null up-front
+            if (request.Position == null) return FailResponse(FilterSplitterStateFailureReason.InvalidRequest);
+
             var block = ServerContext.WorldBlockDatastore.GetBlock(request.Position.Vector3Int);
             if (block == null) return FailResponse(FilterSplitterStateFailureReason.BlockNotFound);
 
@@ -189,6 +193,7 @@ namespace Server.Protocol.PacketResponse
             UnknownOperation = 5,
             InvalidMode = 6,
             InvalidItem = 7,
+            InvalidRequest = 8,
         }
 
         #endregion

--- a/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/FilterSplitterStateProtocol.cs
+++ b/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/FilterSplitterStateProtocol.cs
@@ -61,12 +61,12 @@ namespace Server.Protocol.PacketResponse
 
             static bool ValidateDirection(VanillaFilterSplitterComponent s, int directionIndex)
             {
-                return directionIndex >= 0 && directionIndex < s.DirectionCount;
+                return 0 <= directionIndex && directionIndex < s.DirectionCount;
             }
 
             static bool ValidateSlot(VanillaFilterSplitterComponent s, int slotIndex)
             {
-                return slotIndex >= 0 && slotIndex < s.FilterSlotCountPerDirection;
+                return 0 <= slotIndex && slotIndex < s.FilterSlotCountPerDirection;
             }
 
             static ItemId ResolveItemId(string itemGuidStr)

--- a/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/FilterSplitterStateProtocol.cs
+++ b/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/FilterSplitterStateProtocol.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Collections.Generic;
+using Core.Master;
+using Game.Block.Blocks.FilterSplitter;
+using Game.Context;
+using MessagePack;
+using Microsoft.Extensions.DependencyInjection;
+using Server.Util.MessagePack;
+using UnityEngine;
+
+namespace Server.Protocol.PacketResponse
+{
+    /// <summary>
+    /// FilterSplitter ブロックのフィルター設定をGet/Updateする統合プロトコル。
+    /// OperationType により取得・モード変更・スロット設定を切り替える。
+    /// Combined Get/Update protocol for FilterSplitter filter configuration.
+    /// </summary>
+    public class FilterSplitterStateProtocol : IPacketResponse
+    {
+        public const string ProtocolTag = "va:filterSplitterState";
+
+        public FilterSplitterStateProtocol(ServiceProvider serviceProvider)
+        {
+        }
+
+        public ProtocolMessagePackBase GetResponse(byte[] payload)
+        {
+            var request = MessagePackSerializer.Deserialize<FilterSplitterStateRequest>(payload);
+
+            var block = ServerContext.WorldBlockDatastore.GetBlock(request.Position.Vector3Int);
+            if (block == null) return FailResponse(FilterSplitterStateFailureReason.BlockNotFound);
+
+            if (!block.ComponentManager.TryGetComponent<VanillaFilterSplitterComponent>(out var splitter))
+            {
+                return FailResponse(FilterSplitterStateFailureReason.NotFilterSplitter);
+            }
+
+            // 操作種別ごとに分岐し、最後に最新の全状態スナップショットを返す
+            // Branch by operation type, then return latest full state snapshot
+            switch ((FilterSplitterOperation)request.Operation)
+            {
+                case FilterSplitterOperation.Get:
+                    break;
+                case FilterSplitterOperation.SetMode:
+                    if (!ValidateDirection(splitter, request.DirectionIndex)) return FailResponse(FilterSplitterStateFailureReason.InvalidDirection);
+                    splitter.SetMode(request.DirectionIndex, (FilterSplitterMode)request.Mode);
+                    break;
+                case FilterSplitterOperation.SetFilterItem:
+                    if (!ValidateDirection(splitter, request.DirectionIndex)) return FailResponse(FilterSplitterStateFailureReason.InvalidDirection);
+                    if (!ValidateSlot(splitter, request.SlotIndex)) return FailResponse(FilterSplitterStateFailureReason.InvalidSlot);
+                    var itemId = ResolveItemId(request.ItemGuidStr);
+                    splitter.SetFilterItem(request.DirectionIndex, request.SlotIndex, itemId);
+                    break;
+                default:
+                    return FailResponse(FilterSplitterStateFailureReason.UnknownOperation);
+            }
+
+            return BuildSnapshotResponse(splitter);
+
+            #region Internal
+
+            static bool ValidateDirection(VanillaFilterSplitterComponent s, int directionIndex)
+            {
+                return directionIndex >= 0 && directionIndex < s.DirectionCount;
+            }
+
+            static bool ValidateSlot(VanillaFilterSplitterComponent s, int slotIndex)
+            {
+                return slotIndex >= 0 && slotIndex < s.FilterSlotCountPerDirection;
+            }
+
+            static ItemId ResolveItemId(string itemGuidStr)
+            {
+                if (string.IsNullOrEmpty(itemGuidStr)) return ItemMaster.EmptyItemId;
+                if (!Guid.TryParse(itemGuidStr, out var guid) || guid == Guid.Empty) return ItemMaster.EmptyItemId;
+                var idOrNull = MasterHolder.ItemMaster.GetItemIdOrNull(guid);
+                return idOrNull ?? ItemMaster.EmptyItemId;
+            }
+
+            static FilterSplitterStateResponse FailResponse(FilterSplitterStateFailureReason reason)
+            {
+                return new FilterSplitterStateResponse(false, reason, 0, 0, new List<DirectionStatePack>());
+            }
+
+            FilterSplitterStateResponse BuildSnapshotResponse(VanillaFilterSplitterComponent s)
+            {
+                var directions = new List<DirectionStatePack>(s.DirectionCount);
+                for (var d = 0; d < s.DirectionCount; d++)
+                {
+                    var slots = s.GetFilterItems(d);
+                    var guidStrs = new List<string>(slots.Count);
+                    foreach (var id in slots)
+                    {
+                        if (id == ItemMaster.EmptyItemId)
+                        {
+                            guidStrs.Add(string.Empty);
+                        }
+                        else
+                        {
+                            guidStrs.Add(MasterHolder.ItemMaster.GetItemMaster(id).ItemGuid.ToString());
+                        }
+                    }
+                    directions.Add(new DirectionStatePack
+                    {
+                        Mode = (int)s.GetMode(d),
+                        FilterItemGuids = guidStrs,
+                    });
+                }
+                return new FilterSplitterStateResponse(true, FilterSplitterStateFailureReason.None, s.DirectionCount, s.FilterSlotCountPerDirection, directions);
+            }
+
+            #endregion
+        }
+
+        #region MessagePack
+
+        [MessagePackObject]
+        public class FilterSplitterStateRequest : ProtocolMessagePackBase
+        {
+            [Key(2)] public Vector3IntMessagePack Position { get; set; }
+            [Key(3)] public int Operation { get; set; }
+            [Key(4)] public int DirectionIndex { get; set; }
+            [Key(5)] public int SlotIndex { get; set; }
+            [Key(6)] public int Mode { get; set; }
+            [Key(7)] public string ItemGuidStr { get; set; }
+
+            [Obsolete("デシリアライズ用のコンストラクタです。基本的に使用しないでください。")]
+            public FilterSplitterStateRequest() { }
+
+            public FilterSplitterStateRequest(Vector3Int position, FilterSplitterOperation operation, int directionIndex, int slotIndex, FilterSplitterMode mode, string itemGuidStr)
+            {
+                Tag = ProtocolTag;
+                Position = new Vector3IntMessagePack(position);
+                Operation = (int)operation;
+                DirectionIndex = directionIndex;
+                SlotIndex = slotIndex;
+                Mode = (int)mode;
+                ItemGuidStr = itemGuidStr ?? string.Empty;
+            }
+        }
+
+        [MessagePackObject]
+        public class FilterSplitterStateResponse : ProtocolMessagePackBase
+        {
+            [Key(2)] public bool Success { get; set; }
+            [Key(3)] public FilterSplitterStateFailureReason FailureReason { get; set; }
+            [Key(4)] public int DirectionCount { get; set; }
+            [Key(5)] public int FilterSlotCountPerDirection { get; set; }
+            [Key(6)] public List<DirectionStatePack> Directions { get; set; }
+
+            [Obsolete("デシリアライズ用のコンストラクタです。基本的に使用しないでください。")]
+            public FilterSplitterStateResponse() { }
+
+            public FilterSplitterStateResponse(bool success, FilterSplitterStateFailureReason failureReason, int directionCount, int filterSlotCountPerDirection, List<DirectionStatePack> directions)
+            {
+                Tag = ProtocolTag;
+                Success = success;
+                FailureReason = failureReason;
+                DirectionCount = directionCount;
+                FilterSlotCountPerDirection = filterSlotCountPerDirection;
+                Directions = directions;
+            }
+        }
+
+        [MessagePackObject]
+        public class DirectionStatePack
+        {
+            [Key(0)] public int Mode { get; set; }
+            [Key(1)] public List<string> FilterItemGuids { get; set; }
+        }
+
+        public enum FilterSplitterOperation
+        {
+            Get = 0,
+            SetMode = 1,
+            SetFilterItem = 2,
+        }
+
+        public enum FilterSplitterStateFailureReason
+        {
+            None = 0,
+            BlockNotFound = 1,
+            NotFilterSplitter = 2,
+            InvalidDirection = 3,
+            InvalidSlot = 4,
+            UnknownOperation = 5,
+        }
+
+        #endregion
+    }
+}

--- a/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/FilterSplitterStateProtocol.cs
+++ b/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/FilterSplitterStateProtocol.cs
@@ -11,9 +11,9 @@ using UnityEngine;
 namespace Server.Protocol.PacketResponse
 {
     /// <summary>
-    /// FilterSplitter ブロックのフィルター設定をGet/Updateする統合プロトコル。
-    /// OperationType により取得・モード変更・スロット設定を切り替える。
-    /// Combined Get/Update protocol for FilterSplitter filter configuration.
+    /// FilterSplitter ブロックのフィルター設定を取得・更新するプロトコル。
+    /// Operation により Get / SetMode / SetFilterItem を切り替える。
+    /// Protocol for getting/updating FilterSplitter filter configuration; dispatches by Operation.
     /// </summary>
     public class FilterSplitterStateProtocol : IPacketResponse
     {
@@ -37,20 +37,23 @@ namespace Server.Protocol.PacketResponse
 
             // 操作種別ごとに分岐し、最後に最新の全状態スナップショットを返す
             // Branch by operation type, then return latest full state snapshot
-            switch ((FilterSplitterOperation)request.Operation)
+            switch (request.Operation)
             {
                 case FilterSplitterOperation.Get:
                     break;
                 case FilterSplitterOperation.SetMode:
                     if (!ValidateDirection(splitter, request.DirectionIndex)) return FailResponse(FilterSplitterStateFailureReason.InvalidDirection);
                     if (!Enum.IsDefined(typeof(FilterSplitterMode), request.Mode)) return FailResponse(FilterSplitterStateFailureReason.InvalidMode);
-                    splitter.SetMode(request.DirectionIndex, (FilterSplitterMode)request.Mode);
+                    splitter.SetMode(request.DirectionIndex, request.Mode);
                     break;
                 case FilterSplitterOperation.SetFilterItem:
                     if (!ValidateDirection(splitter, request.DirectionIndex)) return FailResponse(FilterSplitterStateFailureReason.InvalidDirection);
                     if (!ValidateSlot(splitter, request.SlotIndex)) return FailResponse(FilterSplitterStateFailureReason.InvalidSlot);
-                    if (!TryResolveFilterItem(request.ItemGuidStr, out var itemId)) return FailResponse(FilterSplitterStateFailureReason.InvalidItem);
-                    splitter.SetFilterItem(request.DirectionIndex, request.SlotIndex, itemId);
+                    // EmptyItemId はクリア、それ以外は master 存在チェック
+                    // EmptyItemId means clear; otherwise verify the item exists in the master
+                    if (request.ItemId != ItemMaster.EmptyItemId && !MasterHolder.ItemMaster.ExistItemId(request.ItemId))
+                        return FailResponse(FilterSplitterStateFailureReason.InvalidItem);
+                    splitter.SetFilterItem(request.DirectionIndex, request.SlotIndex, request.ItemId);
                     break;
                 default:
                     return FailResponse(FilterSplitterStateFailureReason.UnknownOperation);
@@ -70,57 +73,23 @@ namespace Server.Protocol.PacketResponse
                 return 0 <= slotIndex && slotIndex < s.FilterSlotCountPerDirection;
             }
 
-            // 空文字 = クリア指示として success、解析失敗・master 未登録は false で InvalidItem を返す
-            // Empty string = clear request (success). Parse failure / unknown master GUID returns false → InvalidItem
-            static bool TryResolveFilterItem(string itemGuidStr, out ItemId resolved)
-            {
-                if (string.IsNullOrEmpty(itemGuidStr))
-                {
-                    resolved = ItemMaster.EmptyItemId;
-                    return true;
-                }
-                if (!Guid.TryParse(itemGuidStr, out var guid) || guid == Guid.Empty)
-                {
-                    resolved = ItemMaster.EmptyItemId;
-                    return false;
-                }
-                var idOrNull = MasterHolder.ItemMaster.GetItemIdOrNull(guid);
-                if (idOrNull == null)
-                {
-                    resolved = ItemMaster.EmptyItemId;
-                    return false;
-                }
-                resolved = idOrNull.Value;
-                return true;
-            }
-
             static FilterSplitterStateResponse FailResponse(FilterSplitterStateFailureReason reason)
             {
                 return new FilterSplitterStateResponse(false, reason, 0, 0, new List<DirectionStatePack>());
             }
 
-            FilterSplitterStateResponse BuildSnapshotResponse(VanillaFilterSplitterComponent s)
+            static FilterSplitterStateResponse BuildSnapshotResponse(VanillaFilterSplitterComponent s)
             {
                 var directions = new List<DirectionStatePack>(s.DirectionCount);
                 for (var d = 0; d < s.DirectionCount; d++)
                 {
                     var slots = s.GetFilterItems(d);
-                    var guidStrs = new List<string>(slots.Count);
-                    foreach (var id in slots)
-                    {
-                        if (id == ItemMaster.EmptyItemId)
-                        {
-                            guidStrs.Add(string.Empty);
-                        }
-                        else
-                        {
-                            guidStrs.Add(MasterHolder.ItemMaster.GetItemMaster(id).ItemGuid.ToString());
-                        }
-                    }
+                    var filterItemIds = new List<ItemId>(slots.Count);
+                    foreach (var id in slots) filterItemIds.Add(id);
                     directions.Add(new DirectionStatePack
                     {
-                        Mode = (int)s.GetMode(d),
-                        FilterItemGuids = guidStrs,
+                        Mode = s.GetMode(d),
+                        FilterItemIds = filterItemIds,
                     });
                 }
                 return new FilterSplitterStateResponse(true, FilterSplitterStateFailureReason.None, s.DirectionCount, s.FilterSlotCountPerDirection, directions);
@@ -135,24 +104,41 @@ namespace Server.Protocol.PacketResponse
         public class FilterSplitterStateRequest : ProtocolMessagePackBase
         {
             [Key(2)] public Vector3IntMessagePack Position { get; set; }
-            [Key(3)] public int Operation { get; set; }
+            [Key(3)] public FilterSplitterOperation Operation { get; set; }
             [Key(4)] public int DirectionIndex { get; set; }
             [Key(5)] public int SlotIndex { get; set; }
-            [Key(6)] public int Mode { get; set; }
-            [Key(7)] public string ItemGuidStr { get; set; }
+            [Key(6)] public FilterSplitterMode Mode { get; set; }
+            [Key(7)] public ItemId ItemId { get; set; }
 
             [Obsolete("デシリアライズ用のコンストラクタです。基本的に使用しないでください。")]
-            public FilterSplitterStateRequest() { }
+            public FilterSplitterStateRequest() { Tag = ProtocolTag; }
 
-            public FilterSplitterStateRequest(Vector3Int position, FilterSplitterOperation operation, int directionIndex, int slotIndex, FilterSplitterMode mode, string itemGuidStr)
+            // Operation ごとに必要なフィールドだけを設定する private コンストラクタ
+            // Private constructor; static factories below set only the fields each Operation needs
+            private FilterSplitterStateRequest(Vector3Int position, FilterSplitterOperation operation, int directionIndex, int slotIndex, FilterSplitterMode mode, ItemId itemId)
             {
                 Tag = ProtocolTag;
                 Position = new Vector3IntMessagePack(position);
-                Operation = (int)operation;
+                Operation = operation;
                 DirectionIndex = directionIndex;
                 SlotIndex = slotIndex;
-                Mode = (int)mode;
-                ItemGuidStr = itemGuidStr ?? string.Empty;
+                Mode = mode;
+                ItemId = itemId;
+            }
+
+            public static FilterSplitterStateRequest CreateGetRequest(Vector3Int position)
+            {
+                return new FilterSplitterStateRequest(position, FilterSplitterOperation.Get, 0, 0, FilterSplitterMode.Default, ItemMaster.EmptyItemId);
+            }
+
+            public static FilterSplitterStateRequest CreateSetModeRequest(Vector3Int position, int directionIndex, FilterSplitterMode mode)
+            {
+                return new FilterSplitterStateRequest(position, FilterSplitterOperation.SetMode, directionIndex, 0, mode, ItemMaster.EmptyItemId);
+            }
+
+            public static FilterSplitterStateRequest CreateSetFilterItemRequest(Vector3Int position, int directionIndex, int slotIndex, ItemId itemId)
+            {
+                return new FilterSplitterStateRequest(position, FilterSplitterOperation.SetFilterItem, directionIndex, slotIndex, FilterSplitterMode.Default, itemId);
             }
         }
 
@@ -182,8 +168,8 @@ namespace Server.Protocol.PacketResponse
         [MessagePackObject]
         public class DirectionStatePack
         {
-            [Key(0)] public int Mode { get; set; }
-            [Key(1)] public List<string> FilterItemGuids { get; set; }
+            [Key(0)] public FilterSplitterMode Mode { get; set; }
+            [Key(1)] public List<ItemId> FilterItemIds { get; set; }
         }
 
         public enum FilterSplitterOperation

--- a/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/FilterSplitterStateProtocol.cs
+++ b/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/FilterSplitterStateProtocol.cs
@@ -43,12 +43,13 @@ namespace Server.Protocol.PacketResponse
                     break;
                 case FilterSplitterOperation.SetMode:
                     if (!ValidateDirection(splitter, request.DirectionIndex)) return FailResponse(FilterSplitterStateFailureReason.InvalidDirection);
+                    if (!Enum.IsDefined(typeof(FilterSplitterMode), request.Mode)) return FailResponse(FilterSplitterStateFailureReason.InvalidMode);
                     splitter.SetMode(request.DirectionIndex, (FilterSplitterMode)request.Mode);
                     break;
                 case FilterSplitterOperation.SetFilterItem:
                     if (!ValidateDirection(splitter, request.DirectionIndex)) return FailResponse(FilterSplitterStateFailureReason.InvalidDirection);
                     if (!ValidateSlot(splitter, request.SlotIndex)) return FailResponse(FilterSplitterStateFailureReason.InvalidSlot);
-                    var itemId = ResolveItemId(request.ItemGuidStr);
+                    if (!TryResolveFilterItem(request.ItemGuidStr, out var itemId)) return FailResponse(FilterSplitterStateFailureReason.InvalidItem);
                     splitter.SetFilterItem(request.DirectionIndex, request.SlotIndex, itemId);
                     break;
                 default:
@@ -69,12 +70,28 @@ namespace Server.Protocol.PacketResponse
                 return 0 <= slotIndex && slotIndex < s.FilterSlotCountPerDirection;
             }
 
-            static ItemId ResolveItemId(string itemGuidStr)
+            // 空文字 = クリア指示として success、解析失敗・master 未登録は false で InvalidItem を返す
+            // Empty string = clear request (success). Parse failure / unknown master GUID returns false → InvalidItem
+            static bool TryResolveFilterItem(string itemGuidStr, out ItemId resolved)
             {
-                if (string.IsNullOrEmpty(itemGuidStr)) return ItemMaster.EmptyItemId;
-                if (!Guid.TryParse(itemGuidStr, out var guid) || guid == Guid.Empty) return ItemMaster.EmptyItemId;
+                if (string.IsNullOrEmpty(itemGuidStr))
+                {
+                    resolved = ItemMaster.EmptyItemId;
+                    return true;
+                }
+                if (!Guid.TryParse(itemGuidStr, out var guid) || guid == Guid.Empty)
+                {
+                    resolved = ItemMaster.EmptyItemId;
+                    return false;
+                }
                 var idOrNull = MasterHolder.ItemMaster.GetItemIdOrNull(guid);
-                return idOrNull ?? ItemMaster.EmptyItemId;
+                if (idOrNull == null)
+                {
+                    resolved = ItemMaster.EmptyItemId;
+                    return false;
+                }
+                resolved = idOrNull.Value;
+                return true;
             }
 
             static FilterSplitterStateResponse FailResponse(FilterSplitterStateFailureReason reason)
@@ -184,6 +201,8 @@ namespace Server.Protocol.PacketResponse
             InvalidDirection = 3,
             InvalidSlot = 4,
             UnknownOperation = 5,
+            InvalidMode = 6,
+            InvalidItem = 7,
         }
 
         #endregion

--- a/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/FilterSplitterStateProtocol.cs.meta
+++ b/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/FilterSplitterStateProtocol.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ef1d0c757fa6943aea0e834857024145

--- a/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponseCreator.cs
+++ b/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponseCreator.cs
@@ -68,6 +68,7 @@ namespace Server.Protocol
             _packetResponseDictionary.Add(TrainCarRidingInputProtocol.ProtocolTag, new TrainCarRidingInputProtocol(trainCarRidingInputBuffer, trainUpdateService));
             _packetResponseDictionary.Add(RemoveTrainCarProtocol.ProtocolTag, new RemoveTrainCarProtocol(trainUnitSnapshotNotifyEvent, trainUnitLookupDatastore, trainUnitMutationDatastore));
             _packetResponseDictionary.Add(SetTrainPlatformTransferModeProtocol.ProtocolTag, new SetTrainPlatformTransferModeProtocol(serviceProvider));
+            _packetResponseDictionary.Add(FilterSplitterStateProtocol.ProtocolTag, new FilterSplitterStateProtocol(serviceProvider));
         }
         
         public List<byte[]> GetPacketResponse(byte[] payload)

--- a/moorestech_server/Assets/Scripts/Tests.Module/TestMod/ForUnitTest/mods/forUnitTest/master/blocks.json
+++ b/moorestech_server/Assets/Scripts/Tests.Module/TestMod/ForUnitTest/mods/forUnitTest/master/blocks.json
@@ -4023,6 +4023,51 @@
       "name": "TestTrainFluidPlatform",
       "blockGuid": "00000000-0000-0000-0000-000000000029",
       "overrideVerticalBlock": {}
+    },
+    {
+      "blockSize": [1, 1, 1],
+      "name": "TestFilterSplitter",
+      "blockType": "FilterSplitter",
+      "blockParam": {
+        "filterSlotCountPerDirection": 4,
+        "inventoryConnectors": {
+          "inputConnects": [
+            {
+              "offset": [0, 0, 0],
+              "connectType": "Inventory",
+              "directions": [[0, 0, -1]],
+              "connectOption": { "inventoryOptions": [] },
+              "connectorGuid": "f1110000-0000-0000-0000-000000000010"
+            }
+          ],
+          "outputConnects": [
+            {
+              "offset": [0, 0, 0],
+              "connectType": "Inventory",
+              "directions": [[1, 0, 0]],
+              "connectOption": { "inventoryOptions": [] },
+              "connectorGuid": "f1110000-0000-0000-0000-000000000001"
+            },
+            {
+              "offset": [0, 0, 0],
+              "connectType": "Inventory",
+              "directions": [[-1, 0, 0]],
+              "connectOption": { "inventoryOptions": [] },
+              "connectorGuid": "f1110000-0000-0000-0000-000000000002"
+            },
+            {
+              "offset": [0, 0, 0],
+              "connectType": "Inventory",
+              "directions": [[0, 0, 1]],
+              "connectOption": { "inventoryOptions": [] },
+              "connectorGuid": "f1110000-0000-0000-0000-000000000003"
+            }
+          ]
+        }
+      },
+      "itemGuid": "00000000-0000-0000-1234-000000000031",
+      "blockGuid": "00000000-0000-0000-0000-000000000031",
+      "overrideVerticalBlock": {}
     }
   ],
   "gearChainItems": [

--- a/moorestech_server/Assets/Scripts/Tests.Module/TestMod/ForUnitTest/mods/forUnitTest/master/items.json
+++ b/moorestech_server/Assets/Scripts/Tests.Module/TestMod/ForUnitTest/mods/forUnitTest/master/items.json
@@ -466,6 +466,19 @@
         "handGrabModel": "",
         "entityModel": ""
       }
+    },
+    {
+      "itemGuid": "00000000-0000-0000-1234-000000000031",
+      "imagePath": "",
+      "name": "TestFilterSplitter",
+      "maxStack": 100,
+      "sortPriority": 840,
+      "initialUnlocked": false,
+      "recipeViewType": "IsUnlocked",
+      "addressablePaths": {
+        "handGrabModel": "",
+        "entityModel": ""
+      }
     }
   ]
 }

--- a/moorestech_server/Assets/Scripts/Tests.Module/TestMod/ForUnitTestModBlockId.cs
+++ b/moorestech_server/Assets/Scripts/Tests.Module/TestMod/ForUnitTestModBlockId.cs
@@ -63,5 +63,6 @@ namespace Tests.Module.TestMod
         public static BlockId ElectricPump => GetBlock("3829088a-5a78-43d7-8c3c-d3e4bb91b90a");
         public static BlockId GearChainPole => GetBlock("00000000-0000-0000-0000-00000000002c");
         public static BlockId TestTrainFluidPlatform => GetBlock("00000000-0000-0000-0000-000000000029");
+        public static BlockId FilterSplitter => GetBlock("00000000-0000-0000-0000-000000000031");
     }
 }

--- a/moorestech_server/Assets/Scripts/Tests/CombinedTest/Core/FilterSplitterTest.cs
+++ b/moorestech_server/Assets/Scripts/Tests/CombinedTest/Core/FilterSplitterTest.cs
@@ -1,0 +1,243 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Core.Item.Interface;
+using Core.Master;
+using Game.Block.Blocks.FilterSplitter;
+using Game.Block.Component;
+using Game.Block.Interface;
+using Game.Block.Interface.Component;
+using Game.Block.Interface.Extension;
+using Game.Context;
+using Mooresmaster.Model.BlockConnectInfoModule;
+using Mooresmaster.Model.BlocksModule;
+using NUnit.Framework;
+using Server.Boot;
+using Tests.Module;
+using Tests.Module.TestMod;
+using UnityEngine;
+
+namespace Tests.CombinedTest.Core
+{
+    /// <summary>
+    /// FilterSplitter ブロックのルーティング・フィルター・永続化を検証する。
+    /// Verifies routing, filtering, and persistence of the FilterSplitter block.
+    /// </summary>
+    public class FilterSplitterTest
+    {
+        [Test]
+        public void DefaultModeCatchAllTest()
+        {
+            var (_, _) = new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
+            var (splitter, component, dummies) = CreateSplitterWithDummies(new BlockInstanceId(1));
+
+            // 全方向 Default のまま 3 アイテム挿入 → 各方向に 1 個ずつラウンドロビン
+            // All directions stay Default; 3 inserts should round-robin one item each
+            for (var i = 0; i < 3; i++)
+            {
+                var stack = ServerContext.ItemStackFactory.Create(ForUnitTestItemId.ItemId1, 1);
+                var remain = component.InsertItem(stack, InsertItemContext.Empty);
+                Assert.AreEqual(0, remain.Count);
+            }
+            component.Update();
+
+            foreach (var dummy in dummies)
+            {
+                Assert.AreEqual(1, TotalCount(dummy));
+            }
+        }
+
+        [Test]
+        public void WhitelistPriorityOverDefaultTest()
+        {
+            var (_, _) = new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
+            var (splitter, component, dummies) = CreateSplitterWithDummies(new BlockInstanceId(2));
+
+            // dir0 を Whitelist[ItemId1]、dir1/dir2 は Default
+            // dir0 = Whitelist[ItemId1], dir1/dir2 = Default
+            component.SetMode(0, FilterSplitterMode.Whitelist);
+            component.SetFilterItem(0, 0, ForUnitTestItemId.ItemId1);
+
+            // ItemId1 を 10 個挿入 → 全て dir0 へ集中（Default は fallback）
+            // Insert ItemId1 ten times; all should land in dir0 (Default is only fallback)
+            for (var i = 0; i < 10; i++)
+            {
+                var stack = ServerContext.ItemStackFactory.Create(ForUnitTestItemId.ItemId1, 1);
+                component.InsertItem(stack, InsertItemContext.Empty);
+                component.Update();
+            }
+
+            Assert.AreEqual(10, TotalCount(dummies[0]));
+            Assert.AreEqual(0, TotalCount(dummies[1]));
+            Assert.AreEqual(0, TotalCount(dummies[2]));
+        }
+
+        [Test]
+        public void BlacklistRoutingTest()
+        {
+            var (_, _) = new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
+            var (splitter, component, dummies) = CreateSplitterWithDummies(new BlockInstanceId(3));
+
+            // dir0 を Blacklist[ItemId1]、dir1/dir2 は Default
+            // dir0 = Blacklist[ItemId1], dir1/dir2 = Default
+            component.SetMode(0, FilterSplitterMode.Blacklist);
+            component.SetFilterItem(0, 0, ForUnitTestItemId.ItemId1);
+
+            // ItemId1 は dir0 では拒否され Default 方向 (dir1/dir2) にラウンドロビンで流れる
+            // ItemId1 is rejected by dir0; it round-robins through Default (dir1/dir2)
+            for (var i = 0; i < 4; i++)
+            {
+                var stack = ServerContext.ItemStackFactory.Create(ForUnitTestItemId.ItemId1, 1);
+                component.InsertItem(stack, InsertItemContext.Empty);
+                component.Update();
+            }
+
+            Assert.AreEqual(0, TotalCount(dummies[0]));
+            Assert.AreEqual(4, TotalCount(dummies[1]) + TotalCount(dummies[2]));
+
+            // ItemId2 (Blacklist に無い) は dir0 にも Whitelist マッチ扱い (Blacklist 非マッチ = 明示許可) で入れる
+            // ItemId2 (not in Blacklist) is explicitly allowed at dir0; explicit-match priority kicks in
+            for (var i = 0; i < 3; i++)
+            {
+                var stack = ServerContext.ItemStackFactory.Create(ForUnitTestItemId.ItemId2, 1);
+                component.InsertItem(stack, InsertItemContext.Empty);
+                component.Update();
+            }
+            Assert.IsTrue(0 < TotalCount(dummies[0]), "Blacklist 非マッチアイテムが dir0 に届いていない");
+        }
+
+        [Test]
+        public void UnconnectedDirectionSkippedTest()
+        {
+            var (_, _) = new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
+            var (splitter, component, dummies) = CreateSplitterWithDummies(new BlockInstanceId(4));
+
+            // dir1 の接続を外す
+            // Disconnect dir1 from the splitter
+            var connectedTargets = (Dictionary<IBlockInventory, ConnectedInfo>)splitter.GetComponent<BlockConnectorComponent<IBlockInventory>>().ConnectedTargets;
+            connectedTargets.Remove(dummies[1]);
+
+            // 6 個挿入 → dir0 と dir2 のみに分配される (dir1 はスキップされ詰まらない)
+            // 6 inserts should distribute to dir0 and dir2 only; dir1 must never block insertion
+            for (var i = 0; i < 6; i++)
+            {
+                var stack = ServerContext.ItemStackFactory.Create(ForUnitTestItemId.ItemId1, 1);
+                var remain = component.InsertItem(stack, InsertItemContext.Empty);
+                Assert.AreEqual(0, remain.Count);
+                component.Update();
+            }
+
+            Assert.AreEqual(0, TotalCount(dummies[1]));
+            Assert.AreEqual(6, TotalCount(dummies[0]) + TotalCount(dummies[2]));
+        }
+
+        [Test]
+        public void DuplicateFilterSlotItemsHandledCorrectlyTest()
+        {
+            var (_, _) = new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
+            var (splitter, component, dummies) = CreateSplitterWithDummies(new BlockInstanceId(5));
+
+            // dir0 の slot0/slot1 両方に ItemId1、その後 slot0 を ItemId2 に変更
+            // Put ItemId1 in dir0 slot0 and slot1, then change slot0 to ItemId2
+            component.SetMode(0, FilterSplitterMode.Whitelist);
+            component.SetFilterItem(0, 0, ForUnitTestItemId.ItemId1);
+            component.SetFilterItem(0, 1, ForUnitTestItemId.ItemId1);
+            component.SetFilterItem(0, 0, ForUnitTestItemId.ItemId2);
+
+            // slot1 にまだ ItemId1 があるので、ItemId1 は dir0 にマッチしなければならない
+            // slot1 still holds ItemId1, so ItemId1 must still be accepted by dir0
+            var stack = ServerContext.ItemStackFactory.Create(ForUnitTestItemId.ItemId1, 1);
+            component.InsertItem(stack, InsertItemContext.Empty);
+            component.Update();
+
+            Assert.AreEqual(1, TotalCount(dummies[0]));
+        }
+
+        [Test]
+        public void SaveLoadPreservesFilterConfigTest()
+        {
+            var (_, _) = new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
+
+            // 1個目: フィルター設定を行い save state を取得
+            // First splitter: configure filters and capture save state
+            var (splitter1, component1, _) = CreateSplitterWithDummies(new BlockInstanceId(6));
+            component1.SetMode(0, FilterSplitterMode.Whitelist);
+            component1.SetFilterItem(0, 0, ForUnitTestItemId.ItemId1);
+            component1.SetMode(1, FilterSplitterMode.Blacklist);
+            component1.SetFilterItem(1, 0, ForUnitTestItemId.ItemId2);
+            var savedJson = component1.GetSaveState();
+
+            // 2個目: save state を渡してロード → 設定が復元されている
+            // Second splitter: load with save state; settings must match
+            var blockGuid = MasterHolder.BlockMaster.GetBlockMaster(ForUnitTestModBlockId.FilterSplitter).BlockGuid;
+            var loaded = ServerContext.BlockFactory.Load(
+                blockGuid,
+                new BlockInstanceId(7),
+                new Dictionary<string, string> { { component1.SaveKey, savedJson } },
+                new BlockPositionInfo(new Vector3Int(10, 0, 0), BlockDirection.North, Vector3Int.one));
+            var component2 = loaded.GetComponent<VanillaFilterSplitterComponent>();
+
+            Assert.AreEqual(FilterSplitterMode.Whitelist, component2.GetMode(0));
+            Assert.AreEqual(ForUnitTestItemId.ItemId1, component2.GetFilterItems(0)[0]);
+            Assert.AreEqual(FilterSplitterMode.Blacklist, component2.GetMode(1));
+            Assert.AreEqual(ForUnitTestItemId.ItemId2, component2.GetFilterItems(1)[0]);
+        }
+
+        [Test]
+        public void SetItemNormalizesInvalidInputTest()
+        {
+            var (_, _) = new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
+            var (splitter, component, _) = CreateSplitterWithDummies(new BlockInstanceId(8));
+
+            // count >= 2 を SetItem → 1 個に丸めて格納
+            // SetItem with count >= 2 must be clamped to 1
+            var stack = ServerContext.ItemStackFactory.Create(ForUnitTestItemId.ItemId1, 5);
+            component.SetItem(0, stack);
+            Assert.AreEqual(1, component.GetItem(0).Count);
+
+            // empty を SetItem → null 化されて empty が返る
+            // SetItem with empty must null out the buffer and return empty
+            component.SetItem(0, ServerContext.ItemStackFactory.CreatEmpty());
+            Assert.AreEqual(ItemMaster.EmptyItemId, component.GetItem(0).Id);
+        }
+
+        #region Helpers
+
+        // DummyBlockInventory は同 ID をスタックして 1 スロットにまとめるため、個数比較は Count 合計で行う
+        // DummyBlockInventory stacks same-ID items into a single slot, so compare totals via Count sum
+        private static int TotalCount(DummyBlockInventory dummy)
+        {
+            return dummy.InsertedItems.Sum(stack => stack.Count);
+        }
+
+        private static (IBlock Block, VanillaFilterSplitterComponent Component, DummyBlockInventory[] Dummies) CreateSplitterWithDummies(BlockInstanceId blockInstanceId)
+        {
+            // FilterSplitter ブロックを生成し、3 つの出力方向に DummyBlockInventory を接続する
+            // Create a FilterSplitter and wire up 3 DummyBlockInventory targets to its outputs
+            var splitter = ServerContext.BlockFactory.Create(
+                ForUnitTestModBlockId.FilterSplitter,
+                blockInstanceId,
+                new BlockPositionInfo(Vector3Int.zero, BlockDirection.North, Vector3Int.one));
+            var component = splitter.GetComponent<VanillaFilterSplitterComponent>();
+
+            var param = MasterHolder.BlockMaster.GetBlockMaster(ForUnitTestModBlockId.FilterSplitter).BlockParam as FilterSplitterBlockParam;
+            var outputs = param.InventoryConnectors.OutputConnects.items;
+
+            var connectedTargets = (Dictionary<IBlockInventory, ConnectedInfo>)splitter.GetComponent<BlockConnectorComponent<IBlockInventory>>().ConnectedTargets;
+            connectedTargets.Clear();
+
+            var dummies = new DummyBlockInventory[outputs.Length];
+            for (var i = 0; i < outputs.Length; i++)
+            {
+                var selfConnector = new BlockConnectInfoElement(i, "Inventory", outputs[i].ConnectorGuid, Vector3Int.zero, Array.Empty<Vector3Int>(), null);
+                var targetConnector = new BlockConnectInfoElement(i + 100, "Inventory", Guid.NewGuid(), Vector3Int.zero, Array.Empty<Vector3Int>(), null);
+                dummies[i] = new DummyBlockInventory();
+                connectedTargets.Add(dummies[i], new ConnectedInfo(selfConnector, targetConnector, null));
+            }
+
+            return (splitter, component, dummies);
+        }
+
+        #endregion
+    }
+}

--- a/moorestech_server/Assets/Scripts/Tests/CombinedTest/Core/FilterSplitterTest.cs
+++ b/moorestech_server/Assets/Scripts/Tests/CombinedTest/Core/FilterSplitterTest.cs
@@ -29,7 +29,7 @@ namespace Tests.CombinedTest.Core
         public void DefaultModeCatchAllTest()
         {
             var (_, _) = new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
-            var (splitter, component, dummies) = CreateSplitterWithDummies(new BlockInstanceId(1));
+            var (_, component, dummies) = CreateSplitterWithDummies(new BlockInstanceId(1));
 
             // 全方向 Default のまま 3 アイテム挿入 → 各方向に 1 個ずつラウンドロビン
             // All directions stay Default; 3 inserts should round-robin one item each
@@ -51,7 +51,7 @@ namespace Tests.CombinedTest.Core
         public void WhitelistPriorityOverDefaultTest()
         {
             var (_, _) = new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
-            var (splitter, component, dummies) = CreateSplitterWithDummies(new BlockInstanceId(2));
+            var (_, component, dummies) = CreateSplitterWithDummies(new BlockInstanceId(2));
 
             // dir0 を Whitelist[ItemId1]、dir1/dir2 は Default
             // dir0 = Whitelist[ItemId1], dir1/dir2 = Default
@@ -76,7 +76,7 @@ namespace Tests.CombinedTest.Core
         public void BlacklistRoutingTest()
         {
             var (_, _) = new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
-            var (splitter, component, dummies) = CreateSplitterWithDummies(new BlockInstanceId(3));
+            var (_, component, dummies) = CreateSplitterWithDummies(new BlockInstanceId(3));
 
             // dir0 を Blacklist[ItemId1]、dir1/dir2 は Default
             // dir0 = Blacklist[ItemId1], dir1/dir2 = Default
@@ -135,7 +135,7 @@ namespace Tests.CombinedTest.Core
         public void DuplicateFilterSlotItemsHandledCorrectlyTest()
         {
             var (_, _) = new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
-            var (splitter, component, dummies) = CreateSplitterWithDummies(new BlockInstanceId(5));
+            var (_, component, dummies) = CreateSplitterWithDummies(new BlockInstanceId(5));
 
             // dir0 の slot0/slot1 両方に ItemId1、その後 slot0 を ItemId2 に変更
             // Put ItemId1 in dir0 slot0 and slot1, then change slot0 to ItemId2
@@ -160,7 +160,7 @@ namespace Tests.CombinedTest.Core
 
             // 1個目: フィルター設定を行い save state を取得
             // First splitter: configure filters and capture save state
-            var (splitter1, component1, _) = CreateSplitterWithDummies(new BlockInstanceId(6));
+            var (_, component1, _) = CreateSplitterWithDummies(new BlockInstanceId(6));
             component1.SetMode(0, FilterSplitterMode.Whitelist);
             component1.SetFilterItem(0, 0, ForUnitTestItemId.ItemId1);
             component1.SetMode(1, FilterSplitterMode.Blacklist);
@@ -187,7 +187,7 @@ namespace Tests.CombinedTest.Core
         public void SetItemNormalizesInvalidInputTest()
         {
             var (_, _) = new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
-            var (splitter, component, _) = CreateSplitterWithDummies(new BlockInstanceId(8));
+            var (_, component, _) = CreateSplitterWithDummies(new BlockInstanceId(8));
 
             // count >= 2 を SetItem → 1 個に丸めて格納
             // SetItem with count >= 2 must be clamped to 1
@@ -200,8 +200,6 @@ namespace Tests.CombinedTest.Core
             component.SetItem(0, ServerContext.ItemStackFactory.CreatEmpty());
             Assert.AreEqual(ItemMaster.EmptyItemId, component.GetItem(0).Id);
         }
-
-        #region Helpers
 
         // DummyBlockInventory は同 ID をスタックして 1 スロットにまとめるため、個数比較は Count 合計で行う
         // DummyBlockInventory stacks same-ID items into a single slot, so compare totals via Count sum
@@ -237,7 +235,5 @@ namespace Tests.CombinedTest.Core
 
             return (splitter, component, dummies);
         }
-
-        #endregion
     }
 }

--- a/moorestech_server/Assets/Scripts/Tests/CombinedTest/Core/FilterSplitterTest.cs.meta
+++ b/moorestech_server/Assets/Scripts/Tests/CombinedTest/Core/FilterSplitterTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 77f66b66bba7d48fea82421601c9ab7e

--- a/moorestech_server/Assets/Scripts/Tests/CombinedTest/Server/PacketTest/FilterSplitterStateProtocolTest.cs
+++ b/moorestech_server/Assets/Scripts/Tests/CombinedTest/Server/PacketTest/FilterSplitterStateProtocolTest.cs
@@ -1,0 +1,184 @@
+using System;
+using Core.Master;
+using Game.Block.Blocks.FilterSplitter;
+using Game.Block.Interface;
+using Game.Block.Interface.Extension;
+using Game.Context;
+using MessagePack;
+using NUnit.Framework;
+using Server.Boot;
+using Server.Protocol;
+using Server.Protocol.PacketResponse;
+using Tests.Module.TestMod;
+using UnityEngine;
+
+namespace Tests.CombinedTest.Server.PacketTest
+{
+    /// <summary>
+    /// FilterSplitterStateProtocol の Get/SetMode/SetFilterItem 各 Operation を検証する。
+    /// Verifies the Get/SetMode/SetFilterItem operations of FilterSplitterStateProtocol.
+    /// </summary>
+    public class FilterSplitterStateProtocolTest
+    {
+        private static readonly Vector3Int SplitterPos = new(20, 0, 20);
+
+        [Test]
+        public void GetReturnsCurrentSnapshotTest()
+        {
+            var (packet, _) = new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
+            PlaceFilterSplitter();
+
+            var response = Send(packet, FilterSplitterStateProtocol.FilterSplitterStateRequest.CreateGetRequest(SplitterPos));
+
+            Assert.IsTrue(response.Success);
+            Assert.AreEqual(3, response.DirectionCount);
+            Assert.AreEqual(4, response.FilterSlotCountPerDirection);
+            // 初期状態は全方向 Default
+            // Initial state is Default for all directions
+            for (var d = 0; d < response.DirectionCount; d++)
+            {
+                Assert.AreEqual(FilterSplitterMode.Default, response.Directions[d].Mode);
+            }
+        }
+
+        [Test]
+        public void GetForNonexistentBlockReturnsBlockNotFoundTest()
+        {
+            var (packet, _) = new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
+
+            var response = Send(packet, FilterSplitterStateProtocol.FilterSplitterStateRequest.CreateGetRequest(new Vector3Int(999, 0, 999)));
+
+            Assert.IsFalse(response.Success);
+            Assert.AreEqual(FilterSplitterStateProtocol.FilterSplitterStateFailureReason.BlockNotFound, response.FailureReason);
+        }
+
+        [Test]
+        public void GetForWrongBlockTypeReturnsNotFilterSplitterTest()
+        {
+            var (packet, _) = new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
+            // Chest を置く（FilterSplitter ではない）
+            // Place a Chest (not a FilterSplitter)
+            ServerContext.WorldBlockDatastore.TryAddBlock(ForUnitTestModBlockId.ChestId, SplitterPos, BlockDirection.North, Array.Empty<BlockCreateParam>(), out _);
+
+            var response = Send(packet, FilterSplitterStateProtocol.FilterSplitterStateRequest.CreateGetRequest(SplitterPos));
+
+            Assert.IsFalse(response.Success);
+            Assert.AreEqual(FilterSplitterStateProtocol.FilterSplitterStateFailureReason.NotFilterSplitter, response.FailureReason);
+        }
+
+        [Test]
+        public void SetModeUpdatesModeAndReturnsSnapshotTest()
+        {
+            var (packet, _) = new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
+            PlaceFilterSplitter();
+
+            var response = Send(packet, FilterSplitterStateProtocol.FilterSplitterStateRequest.CreateSetModeRequest(SplitterPos, 1, FilterSplitterMode.Whitelist));
+
+            Assert.IsTrue(response.Success);
+            Assert.AreEqual(FilterSplitterMode.Whitelist, response.Directions[1].Mode);
+            Assert.AreEqual(FilterSplitterMode.Default, response.Directions[0].Mode);
+        }
+
+        [Test]
+        public void SetModeWithInvalidDirectionReturnsInvalidDirectionTest()
+        {
+            var (packet, _) = new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
+            PlaceFilterSplitter();
+
+            var response = Send(packet, FilterSplitterStateProtocol.FilterSplitterStateRequest.CreateSetModeRequest(SplitterPos, 99, FilterSplitterMode.Whitelist));
+
+            Assert.IsFalse(response.Success);
+            Assert.AreEqual(FilterSplitterStateProtocol.FilterSplitterStateFailureReason.InvalidDirection, response.FailureReason);
+        }
+
+        [Test]
+        public void SetModeWithInvalidModeReturnsInvalidModeTest()
+        {
+            var (packet, _) = new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
+            PlaceFilterSplitter();
+
+            // 未定義 enum 値 (例: 999) を投入
+            // Inject an undefined enum value (e.g. 999)
+            var response = Send(packet, FilterSplitterStateProtocol.FilterSplitterStateRequest.CreateSetModeRequest(SplitterPos, 0, (FilterSplitterMode)999));
+
+            Assert.IsFalse(response.Success);
+            Assert.AreEqual(FilterSplitterStateProtocol.FilterSplitterStateFailureReason.InvalidMode, response.FailureReason);
+        }
+
+        [Test]
+        public void SetFilterItemValidIdUpdatesSlotTest()
+        {
+            var (packet, _) = new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
+            PlaceFilterSplitter();
+
+            var response = Send(packet, FilterSplitterStateProtocol.FilterSplitterStateRequest.CreateSetFilterItemRequest(SplitterPos, 0, 0, ForUnitTestItemId.ItemId1));
+
+            Assert.IsTrue(response.Success);
+            Assert.AreEqual(ForUnitTestItemId.ItemId1, response.Directions[0].FilterItemIds[0]);
+        }
+
+        [Test]
+        public void SetFilterItemEmptyClearsSlotTest()
+        {
+            var (packet, _) = new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
+            PlaceFilterSplitter();
+            // 一旦アイテムを入れてからクリアする
+            // Set then clear
+            Send(packet, FilterSplitterStateProtocol.FilterSplitterStateRequest.CreateSetFilterItemRequest(SplitterPos, 0, 0, ForUnitTestItemId.ItemId1));
+            var response = Send(packet, FilterSplitterStateProtocol.FilterSplitterStateRequest.CreateSetFilterItemRequest(SplitterPos, 0, 0, ItemMaster.EmptyItemId));
+
+            Assert.IsTrue(response.Success);
+            Assert.AreEqual(ItemMaster.EmptyItemId, response.Directions[0].FilterItemIds[0]);
+        }
+
+        [Test]
+        public void SetFilterItemUnknownIdReturnsInvalidItemTest()
+        {
+            var (packet, _) = new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
+            PlaceFilterSplitter();
+
+            // master に存在しない ItemId を投入
+            // Inject an ItemId that does not exist in the master
+            var unknownItemId = new ItemId(int.MaxValue);
+            var response = Send(packet, FilterSplitterStateProtocol.FilterSplitterStateRequest.CreateSetFilterItemRequest(SplitterPos, 0, 0, unknownItemId));
+
+            Assert.IsFalse(response.Success);
+            Assert.AreEqual(FilterSplitterStateProtocol.FilterSplitterStateFailureReason.InvalidItem, response.FailureReason);
+        }
+
+        [Test]
+        public void SetFilterItemInvalidSlotReturnsInvalidSlotTest()
+        {
+            var (packet, _) = new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
+            PlaceFilterSplitter();
+
+            var response = Send(packet, FilterSplitterStateProtocol.FilterSplitterStateRequest.CreateSetFilterItemRequest(SplitterPos, 0, 99, ForUnitTestItemId.ItemId1));
+
+            Assert.IsFalse(response.Success);
+            Assert.AreEqual(FilterSplitterStateProtocol.FilterSplitterStateFailureReason.InvalidSlot, response.FailureReason);
+        }
+
+        #region Helpers
+
+        private static void PlaceFilterSplitter()
+        {
+            ServerContext.WorldBlockDatastore.TryAddBlock(
+                ForUnitTestModBlockId.FilterSplitter,
+                SplitterPos,
+                BlockDirection.North,
+                Array.Empty<BlockCreateParam>(),
+                out _);
+        }
+
+        private static FilterSplitterStateProtocol.FilterSplitterStateResponse Send(
+            PacketResponseCreator packet,
+            FilterSplitterStateProtocol.FilterSplitterStateRequest request)
+        {
+            var payload = MessagePackSerializer.Serialize(request);
+            var responseBytes = packet.GetPacketResponse(payload)[0];
+            return MessagePackSerializer.Deserialize<FilterSplitterStateProtocol.FilterSplitterStateResponse>(responseBytes);
+        }
+
+        #endregion
+    }
+}

--- a/moorestech_server/Assets/Scripts/Tests/CombinedTest/Server/PacketTest/FilterSplitterStateProtocolTest.cs
+++ b/moorestech_server/Assets/Scripts/Tests/CombinedTest/Server/PacketTest/FilterSplitterStateProtocolTest.cs
@@ -158,8 +158,6 @@ namespace Tests.CombinedTest.Server.PacketTest
             Assert.AreEqual(FilterSplitterStateProtocol.FilterSplitterStateFailureReason.InvalidSlot, response.FailureReason);
         }
 
-        #region Helpers
-
         private static void PlaceFilterSplitter()
         {
             ServerContext.WorldBlockDatastore.TryAddBlock(
@@ -178,7 +176,5 @@ namespace Tests.CombinedTest.Server.PacketTest
             var responseBytes = packet.GetPacketResponse(payload)[0];
             return MessagePackSerializer.Deserialize<FilterSplitterStateProtocol.FilterSplitterStateResponse>(responseBytes);
         }
-
-        #endregion
     }
 }

--- a/moorestech_server/Assets/Scripts/Tests/CombinedTest/Server/PacketTest/FilterSplitterStateProtocolTest.cs.meta
+++ b/moorestech_server/Assets/Scripts/Tests/CombinedTest/Server/PacketTest/FilterSplitterStateProtocolTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d11f90a932bd94aa2a54df491d94b594


### PR DESCRIPTION
## Summary
- アイテムをフィルタ条件で分岐させる新ブロック「FilterSplitter」をサーバ・クライアント両側で実装
- 各方向ごとに Output / Filter / None の3モードとフィルタアイテムを設定できる UI / プロトコル / マスタを追加
- 1プロトコル1メソッド原則に沿った `FilterSplitterStateProtocol` を新規追加し、CombinedTest / PacketTest でカバー

## 主な変更点
- `VanillaFilterSplitterComponent` / `VanillaFilterSplitterTemplate`: フィルタ分岐ロジックとブロック生成テンプレート
- `FilterSplitterStateProtocol`: GetState / SetMode / SetFilterItem を1プロトコルに統合した Request 再設計済み API
- `FilterSplitterBlockInventoryView` / `FilterSplitterDirectionColumnView`: 方向ごとのモード・フィルタ設定 UI
- `VanillaSchema/blocks.yml` および `ForUnitTest` のマスタ JSON にブロック定義を追加
- `.claude/skills/creating-server-protocol/SKILL.md`: 本作業で得た知見をスキル化

## Test plan
- [ ] `uloop run-tests --project-path ./moorestech_client --filter-type regex --filter-value "FilterSplitter"` で CombinedTest / PacketTest が全てパスすること
- [ ] PlayMode でフィルター分岐器を設置し、各方向の Output / Filter / None 切替とフィルタアイテム設定が UI から反映されること
- [ ] フィルタ条件に応じてアイテムが想定通りの方向に振り分けられること

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Filter Splitter block for advanced item routing with directional filtering
  * Supports three filter modes per direction: Default, Whitelist, and Blacklist
  * Configure filter slots for each output direction to control item routing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moorestech/moorestech/pull/900?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->