### PR TITLE
デバッグ用サーバーディレクトリを server_v8 に更新

### DIFF
--- a/moorestech_server/Assets/Scripts/Core.Master/_CompileRequester.cs
+++ b/moorestech_server/Assets/Scripts/Core.Master/_CompileRequester.cs
@@ -5,5 +5,5 @@ public class CompileRequester
 {
 // スキーマを更新したら、こちらの更新もコミットしてください。
 // If you update the schema, please also commit this update.
-    private const string dummyText = "2026/05/18 21:03:46";
+    private const string dummyText = "2026/05/20 17:36:54";
 }

--- a/moorestech_server/Assets/Scripts/Server.Boot/ServerDirectory.cs
+++ b/moorestech_server/Assets/Scripts/Server.Boot/ServerDirectory.cs
@@ -11,7 +11,7 @@ namespace Server.Boot
         public static string GetDirectory()
         {
 #if UNITY_EDITOR
-            var debugServerDirectory = Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, "../../moorestech_master/server_v4/"));
+            var debugServerDirectory = Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, "../../moorestech_master/server_v8/"));
             var serverDirectory = DebugParameters.GetValueOrDefaultString(DebugServerDirectorySettingKey ,debugServerDirectory);
 #else
             var serverDirectory = Path.Combine(UnityEngine.Application.dataPath, "../","../", "game");


### PR DESCRIPTION
## Summary
- `ServerDirectory.GetDirectory()` のエディタ用デバッグサーバーパスを `server_v4` から `server_v8` へ更新
- スキーマ更新の `_CompileRequester` のダミータイムスタンプを更新

## Test plan
- [ ] Unity エディタでサーバーを起動し、`moorestech_master/server_v8` の mod がロードされることを確認

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal server configuration paths and timestamp values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moorestech/moorestech/pull/906?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->