### PR TITLE
歯車チェーンポール削除時のギアネットワーク分断漏れを修正

### DIFF
--- a/moorestech_server/Assets/Scripts/Game.Block/Blocks/GearChainPole/GearChainPoleComponent.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Blocks/GearChainPole/GearChainPoleComponent.cs
@@ -186,10 +186,12 @@ namespace Game.Block.Blocks.GearChainPole
                 if (targetPole != null) targetPole.TryRemoveChainConnection(BlockInstanceId, out _);
             }
 
-            // コンポーネントのリソースを解放する
-            // Release component resources
-            _connectorComponent.Destroy();
+            // ギアネットワークから除去する。隣接ギアの噛み合いを次数判定に含めるため、コネクタ生存中に実行する
+            // Remove from the gear network while the connector is still alive so adjacent gear meshing counts toward the degree check
             GearNetworkDatastore.RemoveGear(this);
+
+            // コネクタはBlockComponentManagerが別コンポーネントとして破棄するため、ここでは破棄しない
+            // The connector is destroyed separately by BlockComponentManager, so it must not be destroyed here
             _chainTargets.Clear();
             _onChangeBlockState.Dispose();
             IsDestroy = true;

--- a/moorestech_server/Assets/Scripts/Tests/CombinedTest/Core/ChainEnergyTransmissionTest.cs
+++ b/moorestech_server/Assets/Scripts/Tests/CombinedTest/Core/ChainEnergyTransmissionTest.cs
@@ -62,6 +62,92 @@ namespace Tests.CombinedTest.Core
         }
 
         [Test]
+        public void RemoveChainConnectedPoleDoesNotThrow()
+        {
+            // テスト用DIコンテナを立ち上げる
+            // Initialize test DI container
+            var (_, serviceProvider) = new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
+            const int playerId = 0;
+            var chainItemId = MasterHolder.ItemMaster.GetItemId(ChainConstants.ChainItemGuid);
+
+            // 3本のチェーンポールを直列に配置する
+            // Place three chain poles in a line
+            var worldBlockDatastore = ServerContext.WorldBlockDatastore;
+            var posA = new Vector3Int(1, 0, 0);
+            var posB = new Vector3Int(4, 0, 0);
+            var posC = new Vector3Int(7, 0, 0);
+            worldBlockDatastore.TryAddBlock(ForUnitTestModBlockId.GearChainPole, posA, BlockDirection.North, Array.Empty<BlockCreateParam>(), out var poleA);
+            worldBlockDatastore.TryAddBlock(ForUnitTestModBlockId.GearChainPole, posB, BlockDirection.North, Array.Empty<BlockCreateParam>(), out var poleB);
+            worldBlockDatastore.TryAddBlock(ForUnitTestModBlockId.GearChainPole, posC, BlockDirection.North, Array.Empty<BlockCreateParam>(), out var poleC);
+
+            // プレイヤーにチェーンを付与し、A-B / B-C を接続する
+            // Grant chain items and connect A-B / B-C
+            var inventory = serviceProvider.GetService<IPlayerInventoryDataStore>().GetInventoryData(playerId).MainOpenableInventory;
+            inventory.SetItem(0, ServerContext.ItemStackFactory.Create(chainItemId, 20));
+            Assert.True(GearChainSystemUtil.TryConnect(posA, posB, playerId, chainItemId, out _));
+            Assert.True(GearChainSystemUtil.TryConnect(posB, posC, playerId, chainItemId, out _));
+
+            var poleAId = poleA.BlockInstanceId;
+            var poleBId = poleB.BlockInstanceId;
+            var poleCId = poleC.BlockInstanceId;
+
+            // 他ポールに接続された中央ポールを削除しても例外が出ないことを確認する
+            // Removing the chain-connected middle pole must not throw
+            Assert.DoesNotThrow(() => worldBlockDatastore.RemoveBlock(posB, BlockRemoveReason.ManualRemove));
+
+            // 中央ポールが消え、両端ポールから接続が消えていることを確認する
+            // Verify the middle pole is gone and the connection is cleared from both ends
+            Assert.IsNull(worldBlockDatastore.GetBlock(poleBId));
+            Assert.IsFalse(worldBlockDatastore.GetBlock(poleAId).GetComponent<IGearChainPole>().ContainsChainConnection(poleBId));
+            Assert.IsFalse(worldBlockDatastore.GetBlock(poleCId).GetComponent<IGearChainPole>().ContainsChainConnection(poleBId));
+
+            // 残ったネットワークの更新でも例外が出ないことを確認する
+            // Updating the surviving networks must not throw either
+            Assert.DoesNotThrow(() =>
+            {
+                foreach (var network in serviceProvider.GetService<GearNetworkDatastore>().GearNetworks.Values) network.ManualUpdate();
+            });
+        }
+
+        [Test]
+        public void RemoveChainPoleBridgingGearMeshDoesNotThrow()
+        {
+            // テスト用DIコンテナを立ち上げる
+            // Initialize test DI container
+            var (_, serviceProvider) = new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
+            const int playerId = 0;
+            var chainItemId = MasterHolder.ItemMaster.GetItemId(ChainConstants.ChainItemGuid);
+
+            // 発電機-poleA(隣接ギア噛み合い)-チェーン-poleB-ギア のネットワークを構築する
+            // Build network: generator-poleA(gear-meshed)-chain-poleB-gear
+            var worldBlockDatastore = ServerContext.WorldBlockDatastore;
+            var generatorPos = new Vector3Int(0, 0, 0);
+            var poleAPos = new Vector3Int(1, 0, 0);
+            var poleBPos = new Vector3Int(6, 0, 0);
+            worldBlockDatastore.TryAddBlock(ForUnitTestModBlockId.SimpleGearGenerator, generatorPos, BlockDirection.North, Array.Empty<BlockCreateParam>(), out _);
+            worldBlockDatastore.TryAddBlock(ForUnitTestModBlockId.GearChainPole, poleAPos, BlockDirection.North, Array.Empty<BlockCreateParam>(), out _);
+            worldBlockDatastore.TryAddBlock(ForUnitTestModBlockId.GearChainPole, poleBPos, BlockDirection.North, Array.Empty<BlockCreateParam>(), out _);
+            worldBlockDatastore.TryAddBlock(ForUnitTestModBlockId.SmallGear, new Vector3Int(7, 0, 0), BlockDirection.North, Array.Empty<BlockCreateParam>(), out _);
+
+            // poleA-poleB をチェーン接続する
+            // Connect poleA-poleB with chain
+            var inventory = serviceProvider.GetService<IPlayerInventoryDataStore>().GetInventoryData(playerId).MainOpenableInventory;
+            inventory.SetItem(0, ServerContext.ItemStackFactory.Create(chainItemId, 20));
+            Assert.True(GearChainSystemUtil.TryConnect(poleAPos, poleBPos, playerId, chainItemId, out _));
+
+            // 隣接ギアと噛み合いつつチェーンで橋渡しするpoleAを削除しても例外が出ないことを確認する
+            // Removing poleA, which both gear-meshes and chain-bridges, must not throw
+            Assert.DoesNotThrow(() => worldBlockDatastore.RemoveBlock(poleAPos, BlockRemoveReason.ManualRemove));
+
+            // 削除後のネットワーク更新でも例外が出ないことを確認する
+            // Updating networks after removal must not throw either
+            Assert.DoesNotThrow(() =>
+            {
+                foreach (var network in serviceProvider.GetService<GearNetworkDatastore>().GearNetworks.Values) network.ManualUpdate();
+            });
+        }
+
+        [Test]
         public void SaveLoadRestoresChainPoleNetworkConnection()
         {
             // 保存前ワールドにチェーン経由のギアネットワークを構築する


### PR DESCRIPTION
## Summary
- GearChainPole 破棄処理で、ギアネットワークからの除去をコネクタ生存中に行うよう順序を修正。隣接ギアの噛み合いが次数判定に正しく含まれるようにした
- コネクタは BlockComponentManager が別コンポーネントとして破棄するため、二重破棄になっていた `_connectorComponent.Destroy()` を削除
- チェーン接続されたポール削除・ギア噛み合いと橋渡しを兼ねるポール削除で例外が出ないことを検証する CombinedTest を 2 件追加

## Test plan
- [ ] `uloop run-tests --project-path ./moorestech_client --filter-type regex --filter-value "ChainEnergyTransmissionTest"`
- [ ] RemoveChainConnectedPoleDoesNotThrow が通る
- [ ] RemoveChainPoleBridgingGearMeshDoesNotThrow が通る

Generated with [Claude Code](https://claude.com/claude-code)