### PR TITLE
列車乗車時の子要素化機能を削除

### DIFF
--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/Train/Unit/TrainCarRidingPlayerController.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/Train/Unit/TrainCarRidingPlayerController.cs
@@ -1,17 +1,12 @@
 using Client.Game.InGame.Player;
 using Client.Game.InGame.Train.View.Object;
 using Game.Train.Unit;
-using UnityEngine;
 using VContainer.Unity;
 
 namespace Client.Game.InGame.Train.Unit
 {
     public sealed class TrainCarRidingPlayerController : ITickable, IInitializable, System.IDisposable
     {
-        private static readonly Vector3 RidingLocalPosition = new(0f, 1f, 0f);
-        private static readonly Quaternion RidingLocalRotation = Quaternion.identity;
-        private static readonly Vector3 DismountOffset = new(0.75f, 0.5f, -1.5f);
-
         private readonly TrainCarRidingState _trainCarRidingState;
         private readonly TrainCarObjectDatastore _trainCarObjectDatastore;
         private TrainCarInstanceId? _mountedTrainCarInstanceId;
@@ -39,16 +34,11 @@ namespace Client.Game.InGame.Train.Unit
                 return;
             }
 
+            // 乗車状態が外部で解除されたら降車処理を行う
+            // Release the player when the riding state has been cleared externally.
             var currentRidingTrainCarInstanceId = _trainCarRidingState.CurrentRidingTrainCarInstanceId;
             if (currentRidingTrainCarInstanceId.HasValue && currentRidingTrainCarInstanceId.Value == _mountedTrainCarInstanceId.Value)
             {
-                var playerObjectController = ResolvePlayerObjectController();
-                if (playerObjectController != null)
-                {
-                    var playerTransform = playerObjectController.transform;
-                    playerTransform.localPosition = RidingLocalPosition;
-                    playerTransform.localRotation = RidingLocalRotation;
-                }
                 return;
             }
 
@@ -59,7 +49,7 @@ namespace Client.Game.InGame.Train.Unit
         {
             _trainCarRidingState.SetRidingTrainCar(targetCarId);
 
-            if (!_trainCarObjectDatastore.TryGetEntity(targetCarId, out var entity))
+            if (!_trainCarObjectDatastore.TryGetEntity(targetCarId, out _))
             {
                 _trainCarRidingState.ClearRidingTrainCar();
                 return false;
@@ -72,10 +62,6 @@ namespace Client.Game.InGame.Train.Unit
                 return false;
             }
 
-            var playerTransform = playerObjectController.transform;
-            playerTransform.SetParent(entity.transform, false);
-            playerTransform.localPosition = RidingLocalPosition;
-            playerTransform.localRotation = RidingLocalRotation;
             playerObjectController.SetControllable(false);
             _mountedTrainCarInstanceId = targetCarId;
             return true;
@@ -101,17 +87,6 @@ namespace Client.Game.InGame.Train.Unit
             var playerObjectController = ResolvePlayerObjectController();
             if (playerObjectController != null)
             {
-                if (_mountedTrainCarInstanceId.HasValue)
-                {
-                    var playerTransform = playerObjectController.transform;
-                    var worldPosition = playerTransform.position;
-                    var worldRotation = playerTransform.rotation;
-
-                    playerTransform.SetParent(null, true);
-                    playerObjectController.SetPlayerPosition(worldPosition + worldRotation * DismountOffset);
-                    playerTransform.rotation = worldRotation;
-                }
-
                 playerObjectController.SetControllable(true);
             }
 


### PR DESCRIPTION
## Summary
- `TrainCarRidingPlayerController` から、プレイヤーを列車車両の Transform 子要素にする処理を削除
- 乗車時のローカル座標固定（`RidingLocalPosition`/`RidingLocalRotation`）と降車時のオフセット復帰（`DismountOffset`）を撤去
- 乗車・降車では `SetControllable` の切り替えと乗車状態管理のみを行うように簡素化

## Test plan
- [ ] 列車に乗車・降車してプレイヤー位置・操作が正常か確認
- [ ] 乗車状態が外部で解除された際に降車処理が走るか確認

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated train car mounting and dismounting behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moorestech/moorestech/pull/910?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->