### PR TITLE
マップ・デバッグシート・3Dモデル更新の修正

### DIFF
--- a/.claude/skills/recalc-research-sort-priority/scripts/recalc_sort_priority.py
+++ b/.claude/skills/recalc-research-sort-priority/scripts/recalc_sort_priority.py
@@ -19,10 +19,9 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
 from pathlib import Path
 
-# クラスタ閾値 (nodeGraph 座標) — 4 パターンの検証で確認済み
+# クラスタ閾値 (nodeGraph 座標)
 X_COLUMN_THRESHOLD = 100   # research 内アイテムの列クラスタリング
 Y_ROW_THRESHOLD = 100      # 同 depth research の行クラスタリング
 
@@ -47,7 +46,7 @@ def cluster_sorted(values_with_keys, threshold):
     return clusters
 
 
-def recalc(mod_dir: Path, *, validate_patterns=None) -> dict:
+def recalc(mod_dir: Path) -> dict:
     items_path = mod_dir / "master" / "items.json"
     blocks_path = mod_dir / "master" / "blocks.json"
     research_path = mod_dir / "master" / "research.json"
@@ -184,22 +183,6 @@ def recalc(mod_dir: Path, *, validate_patterns=None) -> dict:
         if "sortPriority" in b and ig in new_priority:
             b["sortPriority"] = new_priority[ig]
 
-    # ----- パターン検証 (任意) -----
-    name_to_priority = {it["name"]: it["sortPriority"] for it in items}
-    if validate_patterns:
-        all_ok = True
-        for p in validate_patterns:
-            missing = [n for n in p if n not in name_to_priority]
-            if missing:
-                print(f"  SKIP (missing items): {p} -> {missing}", file=sys.stderr)
-                continue
-            prios = [name_to_priority[n] for n in p]
-            ok = prios == sorted(prios)
-            all_ok = all_ok and ok
-            print(f"  {'OK' if ok else 'NG'}: {p} -> {prios}")
-        if not all_ok:
-            raise SystemExit("Pattern verification failed.")
-
     # ----- items / blocks の並べ替え -----
     items.sort(key=lambda it: it["sortPriority"])
 
@@ -236,14 +219,6 @@ def recalc(mod_dir: Path, *, validate_patterns=None) -> dict:
     }
 
 
-DEFAULT_PATTERNS = [
-    ["鉄鉱石", "鉄鉱石の粉", "大きな木の歯車", "鉄インゴット"],
-    ["鉄板", "鉄のロッド", "鉄のワイヤー", "複合鉄板", "鉄のフレーム"],
-    ["鉄の歯車ベルトコンベア", "鉄の上り歯車ベルトコンベア", "鉄の下り歯車ベルトコンベア", "鉄の歯車ベルトコンベア分岐機"],
-    ["銅のワイヤー", "銅板", "電柱", "回転発電機", "電気炉"],
-]
-
-
 def main():
     ap = argparse.ArgumentParser(description=__doc__.split("\n\n", 1)[0])
     ap.add_argument(
@@ -251,11 +226,6 @@ def main():
         required=True,
         type=Path,
         help="mod root (例: /path/to/moorestech_master/server_v8/mods/moorestechAlphaMod_8)",
-    )
-    ap.add_argument(
-        "--no-validate",
-        action="store_true",
-        help="既定パターン (鉄鉱石系等) の検証を省略する",
     )
     ap.add_argument(
         "--quiet",
@@ -267,10 +237,7 @@ def main():
     if not args.mod_dir.is_dir():
         ap.error(f"--mod-dir not found: {args.mod_dir}")
 
-    patterns = None if args.no_validate else DEFAULT_PATTERNS
-    if patterns:
-        print("=== Pattern verification ===")
-    result = recalc(args.mod_dir, validate_patterns=patterns)
+    result = recalc(args.mod_dir)
 
     print(f"\nUpdated {result['items_count']} items.")
     print(

--- a/moorestech_client/Assets/AddressableAssetsData/AssetGroups/Vanilla Asset Group.asset
+++ b/moorestech_client/Assets/AddressableAssetsData/AssetGroups/Vanilla Asset Group.asset
@@ -125,6 +125,11 @@ MonoBehaviour:
     m_ReadOnly: 0
     m_SerializedLabels: []
     FlaggedDuringContentUpdateRestriction: 0
+  - m_GUID: 1afaa129b8e3241af8a05447cdb40df0
+    m_Address: Vanilla/Block/Iron_conveyor_mini_chest
+    m_ReadOnly: 0
+    m_SerializedLabels: []
+    FlaggedDuringContentUpdateRestriction: 0
   - m_GUID: 1b7c45dd4914c49f89afd1440e3fb692
     m_Address: Vanilla/Block/Shaft Iron
     m_ReadOnly: 0

--- a/moorestech_client/Assets/AddressableResources/Block/Iron_conveyor_mini_chest.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/Iron_conveyor_mini_chest.prefab
@@ -1,0 +1,316 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4481296206355019165
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2669571601615993733}
+  - component: {fileID: 8132120179142033388}
+  - component: {fileID: 5803664024189095593}
+  - component: {fileID: 7292451008751077979}
+  m_Layer: 7
+  m_Name: Cube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2669571601615993733
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4481296206355019165}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.5, y: 0.5, z: 0.5}
+  m_LocalScale: {x: 0.7, y: 0.7, z: 0.7}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7123416310584280708}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &8132120179142033388
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4481296206355019165}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &5803664024189095593
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4481296206355019165}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: ea421dfc65052ae47a41293f6a19a3b1, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &7292451008751077979
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4481296206355019165}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &6076873693263505988
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7123416310584280708}
+  m_Layer: 7
+  m_Name: Iron_conveyor_mini_chest
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7123416310584280708
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6076873693263505988}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3424847775844772304}
+  - {fileID: 8366917386591645842}
+  - {fileID: 2669571601615993733}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1520969618947809253
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 7123416310584280708}
+    m_Modifications:
+    - target: {fileID: 3341151878822521776, guid: 66b2692d1f051412b9556e6abc2b9393, type: 3}
+      propertyPath: m_Name
+      value: PreviewOnly_6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6991507227427090295, guid: 66b2692d1f051412b9556e6abc2b9393, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.5669
+      objectReference: {fileID: 0}
+    - target: {fileID: 6991507227427090295, guid: 66b2692d1f051412b9556e6abc2b9393, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.5669
+      objectReference: {fileID: 0}
+    - target: {fileID: 6991507227427090295, guid: 66b2692d1f051412b9556e6abc2b9393, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.5669
+      objectReference: {fileID: 0}
+    - target: {fileID: 6991507227427090295, guid: 66b2692d1f051412b9556e6abc2b9393, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.21547
+      objectReference: {fileID: 0}
+    - target: {fileID: 6991507227427090295, guid: 66b2692d1f051412b9556e6abc2b9393, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.69618
+      objectReference: {fileID: 0}
+    - target: {fileID: 6991507227427090295, guid: 66b2692d1f051412b9556e6abc2b9393, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.155
+      objectReference: {fileID: 0}
+    - target: {fileID: 6991507227427090295, guid: 66b2692d1f051412b9556e6abc2b9393, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6991507227427090295, guid: 66b2692d1f051412b9556e6abc2b9393, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6991507227427090295, guid: 66b2692d1f051412b9556e6abc2b9393, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6991507227427090295, guid: 66b2692d1f051412b9556e6abc2b9393, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6991507227427090295, guid: 66b2692d1f051412b9556e6abc2b9393, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6991507227427090295, guid: 66b2692d1f051412b9556e6abc2b9393, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6991507227427090295, guid: 66b2692d1f051412b9556e6abc2b9393, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 66b2692d1f051412b9556e6abc2b9393, type: 3}
+--- !u!4 &8366917386591645842 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6991507227427090295, guid: 66b2692d1f051412b9556e6abc2b9393, type: 3}
+  m_PrefabInstance: {fileID: 1520969618947809253}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2886026250202041915
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 7123416310584280708}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 46ff888fbddf3984ba88c4e74baa960f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.541
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 46ff888fbddf3984ba88c4e74baa960f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.296
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 46ff888fbddf3984ba88c4e74baa960f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 46ff888fbddf3984ba88c4e74baa960f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 46ff888fbddf3984ba88c4e74baa960f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 46ff888fbddf3984ba88c4e74baa960f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 46ff888fbddf3984ba88c4e74baa960f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 46ff888fbddf3984ba88c4e74baa960f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 46ff888fbddf3984ba88c4e74baa960f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 46ff888fbddf3984ba88c4e74baa960f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -7855493880976053290, guid: 46ff888fbddf3984ba88c4e74baa960f, type: 3}
+      propertyPath: m_Layer
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: -4819223349682164798, guid: 46ff888fbddf3984ba88c4e74baa960f, type: 3}
+      propertyPath: m_Layer
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 277094265346638427, guid: 46ff888fbddf3984ba88c4e74baa960f, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: ea421dfc65052ae47a41293f6a19a3b1, type: 2}
+    - target: {fileID: 919132149155446097, guid: 46ff888fbddf3984ba88c4e74baa960f, type: 3}
+      propertyPath: m_Name
+      value: model
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 46ff888fbddf3984ba88c4e74baa960f, type: 3}
+      propertyPath: m_Layer
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 3410272414270506081, guid: 46ff888fbddf3984ba88c4e74baa960f, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: ea421dfc65052ae47a41293f6a19a3b1, type: 2}
+    - target: {fileID: 7296069837254451689, guid: 46ff888fbddf3984ba88c4e74baa960f, type: 3}
+      propertyPath: m_Layer
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 8449996119470504636, guid: 46ff888fbddf3984ba88c4e74baa960f, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: ea421dfc65052ae47a41293f6a19a3b1, type: 2}
+    - target: {fileID: 8449996119470504636, guid: 46ff888fbddf3984ba88c4e74baa960f, type: 3}
+      propertyPath: 'm_Materials.Array.data[1]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 43a7d2d53259df94cb60e51d30df1810, type: 2}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 46ff888fbddf3984ba88c4e74baa960f, type: 3}
+--- !u!4 &3424847775844772304 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 46ff888fbddf3984ba88c4e74baa960f, type: 3}
+  m_PrefabInstance: {fileID: 2886026250202041915}
+  m_PrefabAsset: {fileID: 0}

--- a/moorestech_client/Assets/AddressableResources/Block/Iron_conveyor_mini_chest.prefab.meta
+++ b/moorestech_client/Assets/AddressableResources/Block/Iron_conveyor_mini_chest.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1afaa129b8e3241af8a05447cdb40df0
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/moorestech_client/Assets/AddressableResources/Block/Oxygen_generator.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/Oxygen_generator.prefab
@@ -35,8 +35,8 @@ Transform:
   - {fileID: 5877659586818331480}
   - {fileID: 5278242646497534338}
   - {fileID: 2887718278964020748}
-  - {fileID: 572585717639968736}
   - {fileID: 1901945270797985027}
+  - {fileID: 9063428415708409657}
   - {fileID: 7539570336613920954}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -107,8 +107,8 @@ Transform:
   m_GameObject: {fileID: 3380106106878857986}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: 0.7071058, w: 0.70710784}
-  m_LocalPosition: {x: 1.5, y: 0.5, z: 1.5}
-  m_LocalScale: {x: 0.1500001, y: 1.5000007, z: 0.15}
+  m_LocalPosition: {x: 2.5, y: 0.5, z: 1.5}
+  m_LocalScale: {x: 0.1500001, y: 2.5, z: 0.15}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1416632361609516136}
@@ -198,8 +198,8 @@ Transform:
   m_GameObject: {fileID: 3888924981453173810}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 1.5106, y: 0.4678, z: 1.5347}
-  m_LocalScale: {x: 2.3785841, y: 0.8568479, z: 2.209304}
+  m_LocalPosition: {x: 2.5496, y: 0.4678, z: 2.0515}
+  m_LocalScale: {x: 4.45673, y: 0.8568479, z: 3.2430563}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1416632361609516136}
@@ -300,7 +300,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2750780202867129520, guid: a22f794443335e74c82387a9f622ffcd, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 1.99
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 2750780202867129520, guid: a22f794443335e74c82387a9f622ffcd, type: 3}
       propertyPath: m_LocalPosition.y
@@ -362,27 +362,27 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4019100579942471578, guid: c7d31de868216fa449519e33ab7fcad0, type: 3}
       propertyPath: m_LocalScale.x
-      value: 1.5215
+      value: 2.4225323
       objectReference: {fileID: 0}
     - target: {fileID: 4019100579942471578, guid: c7d31de868216fa449519e33ab7fcad0, type: 3}
       propertyPath: m_LocalScale.y
-      value: 1.5215001
+      value: 2.4225326
       objectReference: {fileID: 0}
     - target: {fileID: 4019100579942471578, guid: c7d31de868216fa449519e33ab7fcad0, type: 3}
       propertyPath: m_LocalScale.z
-      value: 1.5215001
+      value: 2.4225326
       objectReference: {fileID: 0}
     - target: {fileID: 4019100579942471578, guid: c7d31de868216fa449519e33ab7fcad0, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 1.563
+      value: 2.3
       objectReference: {fileID: 0}
     - target: {fileID: 4019100579942471578, guid: c7d31de868216fa449519e33ab7fcad0, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.78148997
+      value: 0.69
       objectReference: {fileID: 0}
     - target: {fileID: 4019100579942471578, guid: c7d31de868216fa449519e33ab7fcad0, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 2.38
+      value: 3.29
       objectReference: {fileID: 0}
     - target: {fileID: 4019100579942471578, guid: c7d31de868216fa449519e33ab7fcad0, type: 3}
       propertyPath: m_LocalRotation.w
@@ -426,7 +426,7 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4019100579942471578, guid: c7d31de868216fa449519e33ab7fcad0, type: 3}
   m_PrefabInstance: {fileID: 3288656370100630169}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &3473556260382433402
+--- !u!1001 &5332669539617519779
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -436,27 +436,27 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4019100579942471578, guid: c7d31de868216fa449519e33ab7fcad0, type: 3}
       propertyPath: m_LocalScale.x
-      value: 1.5215
+      value: 2.4225323
       objectReference: {fileID: 0}
     - target: {fileID: 4019100579942471578, guid: c7d31de868216fa449519e33ab7fcad0, type: 3}
       propertyPath: m_LocalScale.y
-      value: 1.5215001
+      value: 2.4225326
       objectReference: {fileID: 0}
     - target: {fileID: 4019100579942471578, guid: c7d31de868216fa449519e33ab7fcad0, type: 3}
       propertyPath: m_LocalScale.z
-      value: 1.5215001
+      value: 2.4225326
       objectReference: {fileID: 0}
     - target: {fileID: 4019100579942471578, guid: c7d31de868216fa449519e33ab7fcad0, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.028254
+      value: 0.29
       objectReference: {fileID: 0}
     - target: {fileID: 4019100579942471578, guid: c7d31de868216fa449519e33ab7fcad0, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.78148997
+      value: 0.69
       objectReference: {fileID: 0}
     - target: {fileID: 4019100579942471578, guid: c7d31de868216fa449519e33ab7fcad0, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 2.38
+      value: 3.29
       objectReference: {fileID: 0}
     - target: {fileID: 4019100579942471578, guid: c7d31de868216fa449519e33ab7fcad0, type: 3}
       propertyPath: m_LocalRotation.w
@@ -488,17 +488,17 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5686027223961289271, guid: c7d31de868216fa449519e33ab7fcad0, type: 3}
       propertyPath: m_Name
-      value: PipeStraight_1
+      value: PipeStraight_3
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c7d31de868216fa449519e33ab7fcad0, type: 3}
---- !u!4 &572585717639968736 stripped
+--- !u!4 &9063428415708409657 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4019100579942471578, guid: c7d31de868216fa449519e33ab7fcad0, type: 3}
-  m_PrefabInstance: {fileID: 3473556260382433402}
+  m_PrefabInstance: {fileID: 5332669539617519779}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8028978867356032306
 PrefabInstance:
@@ -518,7 +518,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2750780202867129520, guid: a22f794443335e74c82387a9f622ffcd, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.99
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 2750780202867129520, guid: a22f794443335e74c82387a9f622ffcd, type: 3}
       propertyPath: m_LocalPosition.y
@@ -526,7 +526,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2750780202867129520, guid: a22f794443335e74c82387a9f622ffcd, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 2.04
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 2750780202867129520, guid: a22f794443335e74c82387a9f622ffcd, type: 3}
       propertyPath: m_LocalRotation.w
@@ -588,7 +588,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2750780202867129520, guid: a22f794443335e74c82387a9f622ffcd, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.02
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2750780202867129520, guid: a22f794443335e74c82387a9f622ffcd, type: 3}
       propertyPath: m_LocalPosition.y

--- a/moorestech_client/Assets/AddressableResources/Block/Rotary_mortor.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/Rotary_mortor.prefab
@@ -1,0 +1,87 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &4333540973713413960
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 520157683752194964, guid: 5f6c0d705933140bdb8d4f3388a6bd82, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 25f27c30593ea42a2b5d6a018b099edd, type: 2}
+    - target: {fileID: 1594346163436662847, guid: 5f6c0d705933140bdb8d4f3388a6bd82, type: 3}
+      propertyPath: m_Name
+      value: Rotary_mortor Variant
+      objectReference: {fileID: 0}
+    - target: {fileID: 2164821982687787727, guid: 5f6c0d705933140bdb8d4f3388a6bd82, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 25f27c30593ea42a2b5d6a018b099edd, type: 2}
+    - target: {fileID: 3966438965973971867, guid: 5f6c0d705933140bdb8d4f3388a6bd82, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 25f27c30593ea42a2b5d6a018b099edd, type: 2}
+    - target: {fileID: 5087506465750405268, guid: 5f6c0d705933140bdb8d4f3388a6bd82, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 25f27c30593ea42a2b5d6a018b099edd, type: 2}
+    - target: {fileID: 6197954709366685060, guid: 5f6c0d705933140bdb8d4f3388a6bd82, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 25f27c30593ea42a2b5d6a018b099edd, type: 2}
+    - target: {fileID: 6407780163861461167, guid: 5f6c0d705933140bdb8d4f3388a6bd82, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 25f27c30593ea42a2b5d6a018b099edd, type: 2}
+    - target: {fileID: 6828182762524490648, guid: 5f6c0d705933140bdb8d4f3388a6bd82, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 25f27c30593ea42a2b5d6a018b099edd, type: 2}
+    - target: {fileID: 9006984235645658401, guid: 5f6c0d705933140bdb8d4f3388a6bd82, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 557.25726
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006984235645658401, guid: 5f6c0d705933140bdb8d4f3388a6bd82, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 74.59194
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006984235645658401, guid: 5f6c0d705933140bdb8d4f3388a6bd82, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 39.388256
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006984235645658401, guid: 5f6c0d705933140bdb8d4f3388a6bd82, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006984235645658401, guid: 5f6c0d705933140bdb8d4f3388a6bd82, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006984235645658401, guid: 5f6c0d705933140bdb8d4f3388a6bd82, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006984235645658401, guid: 5f6c0d705933140bdb8d4f3388a6bd82, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006984235645658401, guid: 5f6c0d705933140bdb8d4f3388a6bd82, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006984235645658401, guid: 5f6c0d705933140bdb8d4f3388a6bd82, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006984235645658401, guid: 5f6c0d705933140bdb8d4f3388a6bd82, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5f6c0d705933140bdb8d4f3388a6bd82, type: 3}

--- a/moorestech_client/Assets/AddressableResources/Block/Rotary_mortor.prefab.meta
+++ b/moorestech_client/Assets/AddressableResources/Block/Rotary_mortor.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0e3dbe73743414920a22086496120f8d
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/moorestech_client/Assets/AddressableResources/Block/Stone_oven.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/Stone_oven.prefab
@@ -196,7 +196,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &6098340719469096340
 Transform:
   m_ObjectHideFlags: 0
@@ -345,6 +345,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 6098340719469096340}
     m_Modifications:
+    - target: {fileID: 6837161692775537191, guid: 6b30a50b2c72dc94f9e6763ab6755447, type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7379783776434672465, guid: 6b30a50b2c72dc94f9e6763ab6755447, type: 3}
       propertyPath: m_Name
       value: FX_Flame_2

--- a/moorestech_client/Assets/AddressableResources/Block/Stone_oven.prefab
+++ b/moorestech_client/Assets/AddressableResources/Block/Stone_oven.prefab
@@ -196,7 +196,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &6098340719469096340
 Transform:
   m_ObjectHideFlags: 0
@@ -345,10 +345,6 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 6098340719469096340}
     m_Modifications:
-    - target: {fileID: 6837161692775537191, guid: 6b30a50b2c72dc94f9e6763ab6755447, type: 3}
-      propertyPath: m_Enabled
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 7379783776434672465, guid: 6b30a50b2c72dc94f9e6763ab6755447, type: 3}
       propertyPath: m_Name
       value: FX_Flame_2

--- a/moorestech_client/Assets/AddressableResources/Character/Chr001.prefab
+++ b/moorestech_client/Assets/AddressableResources/Character/Chr001.prefab
@@ -439,7 +439,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &4636086845486516408
 Transform:
   m_ObjectHideFlags: 0
@@ -475,8 +475,6 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
-  m_ForceMeshLod: -1
-  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -498,7 +496,6 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -1487,7 +1484,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &1578322976130945714
 Transform:
   m_ObjectHideFlags: 0
@@ -1523,8 +1520,6 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
-  m_ForceMeshLod: -1
-  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1546,7 +1541,6 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -1818,7 +1812,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &3984490849597388871
 Transform:
   m_ObjectHideFlags: 0
@@ -1854,8 +1848,6 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
-  m_ForceMeshLod: -1
-  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1877,7 +1869,6 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -2054,7 +2045,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &7101801678347656921
 Transform:
   m_ObjectHideFlags: 0
@@ -2090,8 +2081,6 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
-  m_ForceMeshLod: -1
-  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -2113,7 +2102,6 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -2876,7 +2864,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &8483756609392695530
 Transform:
   m_ObjectHideFlags: 0
@@ -2912,8 +2900,6 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
-  m_ForceMeshLod: -1
-  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -2935,7 +2921,6 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -3174,7 +3159,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &4889879641202985741
 Transform:
   m_ObjectHideFlags: 0
@@ -3210,8 +3195,6 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
-  m_ForceMeshLod: -1
-  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -3233,7 +3216,6 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -3512,8 +3494,6 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
-  m_ForceMeshLod: -1
-  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -3535,7 +3515,6 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -3813,8 +3792,6 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
-  m_ForceMeshLod: -1
-  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -3836,7 +3813,6 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -4077,7 +4053,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &5720658862019006506
 Transform:
   m_ObjectHideFlags: 0
@@ -4113,8 +4089,6 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
-  m_ForceMeshLod: -1
-  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -4136,7 +4110,6 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -4377,7 +4350,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &8720448209975741269
 Transform:
   m_ObjectHideFlags: 0
@@ -4413,8 +4386,6 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
-  m_ForceMeshLod: -1
-  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -4436,7 +4407,6 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -4741,7 +4711,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &6582561434112519223
 Transform:
   m_ObjectHideFlags: 0
@@ -4777,8 +4747,6 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
-  m_ForceMeshLod: -1
-  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -4801,7 +4769,6 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -5385,7 +5352,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &7242753336521834983
 Transform:
   m_ObjectHideFlags: 0
@@ -5421,8 +5388,6 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
-  m_ForceMeshLod: -1
-  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -5444,7 +5409,6 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -7158,7 +7122,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &1360656686078197166
 Transform:
   m_ObjectHideFlags: 0
@@ -7194,8 +7158,6 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
-  m_ForceMeshLod: -1
-  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -7217,7 +7179,6 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -7934,7 +7895,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &6946989101658907119
 Transform:
   m_ObjectHideFlags: 0
@@ -7970,8 +7931,6 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
-  m_ForceMeshLod: -1
-  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -7993,7 +7952,6 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -9438,7 +9396,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &7475784310821069248
 Transform:
   m_ObjectHideFlags: 0
@@ -9474,8 +9432,6 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
-  m_ForceMeshLod: -1
-  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -9497,7 +9453,6 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -9832,7 +9787,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &6639435361770023042
 Transform:
   m_ObjectHideFlags: 0
@@ -9868,8 +9823,6 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
-  m_ForceMeshLod: -1
-  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -9891,7 +9844,6 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -10132,7 +10084,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &7339709843304742716
 Transform:
   m_ObjectHideFlags: 0
@@ -10168,8 +10120,6 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
-  m_ForceMeshLod: -1
-  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -10191,7 +10141,6 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -10527,7 +10476,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &4460752270917361234
 Transform:
   m_ObjectHideFlags: 0
@@ -10563,8 +10512,6 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
-  m_ForceMeshLod: -1
-  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -10586,7 +10533,6 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -10894,8 +10840,6 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
-  m_ForceMeshLod: -1
-  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -10919,7 +10863,6 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -15170,7 +15113,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &4981330755590518788
 Transform:
   m_ObjectHideFlags: 0
@@ -15206,8 +15149,6 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
-  m_ForceMeshLod: -1
-  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -15229,7 +15170,6 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -15744,7 +15684,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &7142648602022021285
 Transform:
   m_ObjectHideFlags: 0
@@ -15780,8 +15720,6 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
-  m_ForceMeshLod: -1
-  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -15803,7 +15741,6 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -16969,7 +16906,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &2629997696485605850
 Transform:
   m_ObjectHideFlags: 0
@@ -17005,8 +16942,6 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
-  m_ForceMeshLod: -1
-  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -17028,7 +16963,6 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -17476,7 +17410,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &579259519631965632
 Transform:
   m_ObjectHideFlags: 0
@@ -17512,8 +17446,6 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
-  m_ForceMeshLod: -1
-  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -17535,7 +17467,6 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -17994,8 +17925,6 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
-  m_ForceMeshLod: -1
-  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -18017,7 +17946,6 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0

--- a/moorestech_client/Assets/AddressableResources/Character/Chr001.prefab
+++ b/moorestech_client/Assets/AddressableResources/Character/Chr001.prefab
@@ -439,7 +439,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &4636086845486516408
 Transform:
   m_ObjectHideFlags: 0
@@ -475,6 +475,8 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -496,6 +498,7 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -1484,7 +1487,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &1578322976130945714
 Transform:
   m_ObjectHideFlags: 0
@@ -1520,6 +1523,8 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1541,6 +1546,7 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -1812,7 +1818,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &3984490849597388871
 Transform:
   m_ObjectHideFlags: 0
@@ -1848,6 +1854,8 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1869,6 +1877,7 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -2045,7 +2054,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &7101801678347656921
 Transform:
   m_ObjectHideFlags: 0
@@ -2081,6 +2090,8 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -2102,6 +2113,7 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -2864,7 +2876,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &8483756609392695530
 Transform:
   m_ObjectHideFlags: 0
@@ -2900,6 +2912,8 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -2921,6 +2935,7 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -3159,7 +3174,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &4889879641202985741
 Transform:
   m_ObjectHideFlags: 0
@@ -3195,6 +3210,8 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -3216,6 +3233,7 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -3494,6 +3512,8 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -3515,6 +3535,7 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -3792,6 +3813,8 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -3813,6 +3836,7 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -4053,7 +4077,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &5720658862019006506
 Transform:
   m_ObjectHideFlags: 0
@@ -4089,6 +4113,8 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -4110,6 +4136,7 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -4350,7 +4377,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &8720448209975741269
 Transform:
   m_ObjectHideFlags: 0
@@ -4386,6 +4413,8 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -4407,6 +4436,7 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -4711,7 +4741,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &6582561434112519223
 Transform:
   m_ObjectHideFlags: 0
@@ -4747,6 +4777,8 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -4769,6 +4801,7 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -5352,7 +5385,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &7242753336521834983
 Transform:
   m_ObjectHideFlags: 0
@@ -5388,6 +5421,8 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -5409,6 +5444,7 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -7122,7 +7158,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &1360656686078197166
 Transform:
   m_ObjectHideFlags: 0
@@ -7158,6 +7194,8 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -7179,6 +7217,7 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -7895,7 +7934,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &6946989101658907119
 Transform:
   m_ObjectHideFlags: 0
@@ -7931,6 +7970,8 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -7952,6 +7993,7 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -9396,7 +9438,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &7475784310821069248
 Transform:
   m_ObjectHideFlags: 0
@@ -9432,6 +9474,8 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -9453,6 +9497,7 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -9787,7 +9832,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &6639435361770023042
 Transform:
   m_ObjectHideFlags: 0
@@ -9823,6 +9868,8 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -9844,6 +9891,7 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -10084,7 +10132,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &7339709843304742716
 Transform:
   m_ObjectHideFlags: 0
@@ -10120,6 +10168,8 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -10141,6 +10191,7 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -10476,7 +10527,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &4460752270917361234
 Transform:
   m_ObjectHideFlags: 0
@@ -10512,6 +10563,8 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -10533,6 +10586,7 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -10840,6 +10894,8 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -10863,6 +10919,7 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -15113,7 +15170,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &4981330755590518788
 Transform:
   m_ObjectHideFlags: 0
@@ -15149,6 +15206,8 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -15170,6 +15229,7 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -15684,7 +15744,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &7142648602022021285
 Transform:
   m_ObjectHideFlags: 0
@@ -15720,6 +15780,8 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -15741,6 +15803,7 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -16906,7 +16969,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &2629997696485605850
 Transform:
   m_ObjectHideFlags: 0
@@ -16942,6 +17005,8 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -16963,6 +17028,7 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -17410,7 +17476,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &579259519631965632
 Transform:
   m_ObjectHideFlags: 0
@@ -17446,6 +17512,8 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -17467,6 +17535,7 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -17925,6 +17994,8 @@ SkinnedMeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -17946,6 +18017,7 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0

--- a/moorestech_client/Assets/Asset/Block/Materials/EngineGenerator/Engine_2.008_blue.mat
+++ b/moorestech_client/Assets/Asset/Block/Materials/EngineGenerator/Engine_2.008_blue.mat
@@ -1,0 +1,142 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Engine_2.008_blue
+  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords:
+  - _NORMALMAP
+  - _OCCLUSIONMAP
+  - _PARALLAXMAP
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap:
+    RenderType: Opaque
+  disabledShaderPasses:
+  - MOTIONVECTORS
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 2800000, guid: fcf88689a0fc211468648935ec6851e7, type: 3}
+        m_Scale: {x: 3, y: 3}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 2800000, guid: 920afe03b185aa3458314b44c9da7888, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 2800000, guid: fcf88689a0fc211468648935ec6851e7, type: 3}
+        m_Scale: {x: 3, y: 3}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 2800000, guid: a51a2e56f8abd3e4db9a4b58fef4303a, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 2800000, guid: da443cd5ab0418b4daef28f9c1162b78, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AddPrecomputedVelocity: 0
+    - _AlphaClip: 0
+    - _AlphaToMask: 0
+    - _Blend: 0
+    - _BlendModePreserveSpecular: 1
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _DstBlendAlpha: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
+    - _Surface: 0
+    - _UVSec: 0
+    - _WorkflowMode: 1
+    - _XRMotionVectorsPass: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 0.36863655, g: 0.7169812, b: 0.6869282, a: 1}
+    - _Color: {r: 0.36863652, g: 0.7169812, b: 0.6869282, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 0}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+  m_BuildTextureStacks: []
+  m_AllowLocking: 1
+--- !u!114 &7321195047770779858
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.RenderPipelines.Universal.Editor::UnityEditor.Rendering.Universal.AssetVersion
+  version: 10

--- a/moorestech_client/Assets/Asset/Block/Materials/EngineGenerator/Engine_2.008_blue.mat.meta
+++ b/moorestech_client/Assets/Asset/Block/Materials/EngineGenerator/Engine_2.008_blue.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 25f27c30593ea42a2b5d6a018b099edd
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/moorestech_client/Assets/Dependencies/GenerateTerrain/GeneratedTerrain5x5.prefab
+++ b/moorestech_client/Assets/Dependencies/GenerateTerrain/GeneratedTerrain5x5.prefab
@@ -11,7 +11,8 @@ GameObject:
   - component: {fileID: 707198914220913348}
   - component: {fileID: 5753750153514555964}
   - component: {fileID: 2342641385665283819}
-  m_Layer: 0
+  - component: {fileID: 3256696663648454375}
+  m_Layer: 9
   m_Name: Terrain_0_-1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -93,6 +94,18 @@ TerrainCollider:
   serializedVersion: 2
   m_TerrainData: {fileID: 15600000, guid: ac733fbd580bf4e829321d516e456c68, type: 2}
   m_EnableTreeColliders: 1
+--- !u!114 &3256696663648454375
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 127688200802271047}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c6dbd479f18647efa68f96831c8ee001, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.GroundGameObject
 --- !u!1 &304176383787628783
 GameObject:
   m_ObjectHideFlags: 0
@@ -104,7 +117,8 @@ GameObject:
   - component: {fileID: 1426215607895239692}
   - component: {fileID: 4105421572925557467}
   - component: {fileID: 1118602015503288747}
-  m_Layer: 0
+  - component: {fileID: 3728265013494814720}
+  m_Layer: 9
   m_Name: Terrain_-2_2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -186,6 +200,18 @@ TerrainCollider:
   serializedVersion: 2
   m_TerrainData: {fileID: 15600000, guid: 6db73e5f065c44b1abdc863595c667b1, type: 2}
   m_EnableTreeColliders: 1
+--- !u!114 &3728265013494814720
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 304176383787628783}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c6dbd479f18647efa68f96831c8ee001, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.GroundGameObject
 --- !u!1 &406466995732776943
 GameObject:
   m_ObjectHideFlags: 0
@@ -197,7 +223,8 @@ GameObject:
   - component: {fileID: 5226323212694074731}
   - component: {fileID: 3134315745802650863}
   - component: {fileID: 8575716175381912202}
-  m_Layer: 0
+  - component: {fileID: 6007544412298536074}
+  m_Layer: 9
   m_Name: Terrain_-1_1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -279,6 +306,18 @@ TerrainCollider:
   serializedVersion: 2
   m_TerrainData: {fileID: 15600000, guid: fe413b2366b314ec5b2a33973c1b97e3, type: 2}
   m_EnableTreeColliders: 1
+--- !u!114 &6007544412298536074
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 406466995732776943}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c6dbd479f18647efa68f96831c8ee001, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.GroundGameObject
 --- !u!1 &640119048719078141
 GameObject:
   m_ObjectHideFlags: 0
@@ -290,7 +329,8 @@ GameObject:
   - component: {fileID: 5571545215836494452}
   - component: {fileID: 2759176396646757662}
   - component: {fileID: 4547781673285480315}
-  m_Layer: 0
+  - component: {fileID: 6036311149807047411}
+  m_Layer: 9
   m_Name: Terrain_1_-1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -372,6 +412,18 @@ TerrainCollider:
   serializedVersion: 2
   m_TerrainData: {fileID: 15600000, guid: dc156d6245ce749d18d1fbc06a5c78cc, type: 2}
   m_EnableTreeColliders: 1
+--- !u!114 &6036311149807047411
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 640119048719078141}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c6dbd479f18647efa68f96831c8ee001, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.GroundGameObject
 --- !u!1 &894403425675535063
 GameObject:
   m_ObjectHideFlags: 0
@@ -383,7 +435,8 @@ GameObject:
   - component: {fileID: 799904352685996169}
   - component: {fileID: 933308108055728980}
   - component: {fileID: 4854036770476494635}
-  m_Layer: 0
+  - component: {fileID: 5282327082015369770}
+  m_Layer: 9
   m_Name: Terrain_-2_1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -465,6 +518,18 @@ TerrainCollider:
   serializedVersion: 2
   m_TerrainData: {fileID: 15600000, guid: ecd8a159eab5c4018a9fd1f8623c2b09, type: 2}
   m_EnableTreeColliders: 1
+--- !u!114 &5282327082015369770
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 894403425675535063}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c6dbd479f18647efa68f96831c8ee001, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.GroundGameObject
 --- !u!1 &1545842248921868356
 GameObject:
   m_ObjectHideFlags: 0
@@ -476,7 +541,8 @@ GameObject:
   - component: {fileID: 4041510863285109602}
   - component: {fileID: 3170139753866412348}
   - component: {fileID: 6283671389368822401}
-  m_Layer: 0
+  - component: {fileID: 9067133814011504623}
+  m_Layer: 9
   m_Name: Terrain_1_2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -558,6 +624,18 @@ TerrainCollider:
   serializedVersion: 2
   m_TerrainData: {fileID: 15600000, guid: bafc1429496b44081adcccad934f8f2c, type: 2}
   m_EnableTreeColliders: 1
+--- !u!114 &9067133814011504623
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1545842248921868356}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c6dbd479f18647efa68f96831c8ee001, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.GroundGameObject
 --- !u!1 &2545189340199696870
 GameObject:
   m_ObjectHideFlags: 0
@@ -569,7 +647,8 @@ GameObject:
   - component: {fileID: 4859757924813154328}
   - component: {fileID: 1378906227196705251}
   - component: {fileID: 2574398028592825689}
-  m_Layer: 0
+  - component: {fileID: 1956247315804721355}
+  m_Layer: 9
   m_Name: Terrain_0_-2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -651,6 +730,18 @@ TerrainCollider:
   serializedVersion: 2
   m_TerrainData: {fileID: 15600000, guid: 4b7b97d5543bf42ae93bfcf22e065693, type: 2}
   m_EnableTreeColliders: 1
+--- !u!114 &1956247315804721355
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2545189340199696870}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c6dbd479f18647efa68f96831c8ee001, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.GroundGameObject
 --- !u!1 &2883066202740006441
 GameObject:
   m_ObjectHideFlags: 0
@@ -662,7 +753,8 @@ GameObject:
   - component: {fileID: 1992849290936752735}
   - component: {fileID: 2321884162478542496}
   - component: {fileID: 5908428893076415172}
-  m_Layer: 0
+  - component: {fileID: 6161767876213698831}
+  m_Layer: 9
   m_Name: Terrain_0_0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -744,6 +836,18 @@ TerrainCollider:
   serializedVersion: 2
   m_TerrainData: {fileID: 15600000, guid: 21c229356a0f64d72a0c51b09de341b6, type: 2}
   m_EnableTreeColliders: 1
+--- !u!114 &6161767876213698831
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2883066202740006441}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c6dbd479f18647efa68f96831c8ee001, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.GroundGameObject
 --- !u!1 &3193340445861632378
 GameObject:
   m_ObjectHideFlags: 0
@@ -755,7 +859,8 @@ GameObject:
   - component: {fileID: 7944723420111548896}
   - component: {fileID: 3043728174638059794}
   - component: {fileID: 7394071687163563652}
-  m_Layer: 0
+  - component: {fileID: 5467073152606786418}
+  m_Layer: 9
   m_Name: Terrain_-1_-1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -837,6 +942,18 @@ TerrainCollider:
   serializedVersion: 2
   m_TerrainData: {fileID: 15600000, guid: da8a52afab2834d5bb6e8b0a8527d8be, type: 2}
   m_EnableTreeColliders: 1
+--- !u!114 &5467073152606786418
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3193340445861632378}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c6dbd479f18647efa68f96831c8ee001, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.GroundGameObject
 --- !u!1 &3212591542573505523
 GameObject:
   m_ObjectHideFlags: 0
@@ -848,7 +965,8 @@ GameObject:
   - component: {fileID: 3999591461176705513}
   - component: {fileID: 4997519888340910471}
   - component: {fileID: 8792898935638749342}
-  m_Layer: 0
+  - component: {fileID: 9144900019504071004}
+  m_Layer: 9
   m_Name: Terrain_-2_-1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -930,6 +1048,18 @@ TerrainCollider:
   serializedVersion: 2
   m_TerrainData: {fileID: 15600000, guid: 4d61796dc76304c1cb72979d74ce839d, type: 2}
   m_EnableTreeColliders: 1
+--- !u!114 &9144900019504071004
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3212591542573505523}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c6dbd479f18647efa68f96831c8ee001, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.GroundGameObject
 --- !u!1 &3499256060416765120
 GameObject:
   m_ObjectHideFlags: 0
@@ -941,7 +1071,8 @@ GameObject:
   - component: {fileID: 7236141080228000654}
   - component: {fileID: 688690927325459810}
   - component: {fileID: 6407385133684758468}
-  m_Layer: 0
+  - component: {fileID: 8129248748675117664}
+  m_Layer: 9
   m_Name: Terrain_-1_-2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1023,6 +1154,18 @@ TerrainCollider:
   serializedVersion: 2
   m_TerrainData: {fileID: 15600000, guid: 4cbb70609b3b040efa46a0497c2c950a, type: 2}
   m_EnableTreeColliders: 1
+--- !u!114 &8129248748675117664
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3499256060416765120}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c6dbd479f18647efa68f96831c8ee001, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.GroundGameObject
 --- !u!1 &3872675649551019526
 GameObject:
   m_ObjectHideFlags: 0
@@ -1034,7 +1177,8 @@ GameObject:
   - component: {fileID: 8831183370376092504}
   - component: {fileID: 1795318830594914035}
   - component: {fileID: 7746047601802373932}
-  m_Layer: 0
+  - component: {fileID: 4068112568885044096}
+  m_Layer: 9
   m_Name: Terrain_-2_-2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1116,6 +1260,18 @@ TerrainCollider:
   serializedVersion: 2
   m_TerrainData: {fileID: 15600000, guid: 3884e1113c2104b4ca4131736aa44b90, type: 2}
   m_EnableTreeColliders: 1
+--- !u!114 &4068112568885044096
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3872675649551019526}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c6dbd479f18647efa68f96831c8ee001, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.GroundGameObject
 --- !u!1 &3930585791909013176
 GameObject:
   m_ObjectHideFlags: 0
@@ -1127,7 +1283,8 @@ GameObject:
   - component: {fileID: 8912456025246776665}
   - component: {fileID: 3653400816318760615}
   - component: {fileID: 1648001702155215398}
-  m_Layer: 0
+  - component: {fileID: 2728145753459586236}
+  m_Layer: 9
   m_Name: Terrain_2_2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1209,6 +1366,18 @@ TerrainCollider:
   serializedVersion: 2
   m_TerrainData: {fileID: 15600000, guid: c18e963d26722438f97a1321f02df4c3, type: 2}
   m_EnableTreeColliders: 1
+--- !u!114 &2728145753459586236
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3930585791909013176}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c6dbd479f18647efa68f96831c8ee001, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.GroundGameObject
 --- !u!1 &4109525655090221180
 GameObject:
   m_ObjectHideFlags: 0
@@ -1220,7 +1389,8 @@ GameObject:
   - component: {fileID: 931730552670209693}
   - component: {fileID: 5545753668270801478}
   - component: {fileID: 6695274062288501991}
-  m_Layer: 0
+  - component: {fileID: 3942491973075570379}
+  m_Layer: 9
   m_Name: Terrain_-1_2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1302,6 +1472,18 @@ TerrainCollider:
   serializedVersion: 2
   m_TerrainData: {fileID: 15600000, guid: 4576d789cbd6d46f99e4bd26012d0baf, type: 2}
   m_EnableTreeColliders: 1
+--- !u!114 &3942491973075570379
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4109525655090221180}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c6dbd479f18647efa68f96831c8ee001, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.GroundGameObject
 --- !u!1 &4759373784143528231
 GameObject:
   m_ObjectHideFlags: 0
@@ -1313,7 +1495,8 @@ GameObject:
   - component: {fileID: 6147538371135570421}
   - component: {fileID: 8195503772989052907}
   - component: {fileID: 6802955094873292940}
-  m_Layer: 0
+  - component: {fileID: 6219016936498975365}
+  m_Layer: 9
   m_Name: Terrain_1_0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1395,6 +1578,18 @@ TerrainCollider:
   serializedVersion: 2
   m_TerrainData: {fileID: 15600000, guid: 4a9d6c4b54e3f4527b8c9639fdd42ca7, type: 2}
   m_EnableTreeColliders: 1
+--- !u!114 &6219016936498975365
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759373784143528231}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c6dbd479f18647efa68f96831c8ee001, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.GroundGameObject
 --- !u!1 &5185609357475565919
 GameObject:
   m_ObjectHideFlags: 0
@@ -1406,7 +1601,8 @@ GameObject:
   - component: {fileID: 515908604538133346}
   - component: {fileID: 501903422210369576}
   - component: {fileID: 1769662594520635832}
-  m_Layer: 0
+  - component: {fileID: 2478436163588081404}
+  m_Layer: 9
   m_Name: Terrain_2_-2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1488,6 +1684,18 @@ TerrainCollider:
   serializedVersion: 2
   m_TerrainData: {fileID: 15600000, guid: 08d1eb68220f045c5a2435794f260fb3, type: 2}
   m_EnableTreeColliders: 1
+--- !u!114 &2478436163588081404
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5185609357475565919}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c6dbd479f18647efa68f96831c8ee001, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.GroundGameObject
 --- !u!1 &5750121106653337977
 GameObject:
   m_ObjectHideFlags: 0
@@ -1499,7 +1707,8 @@ GameObject:
   - component: {fileID: 9183629407871237154}
   - component: {fileID: 3989220510115323624}
   - component: {fileID: 7298577669543509727}
-  m_Layer: 0
+  - component: {fileID: 1678796938685183131}
+  m_Layer: 9
   m_Name: Terrain_0_1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1581,6 +1790,18 @@ TerrainCollider:
   serializedVersion: 2
   m_TerrainData: {fileID: 15600000, guid: 623c86ebdf7934730ba06137fad3d28b, type: 2}
   m_EnableTreeColliders: 1
+--- !u!114 &1678796938685183131
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5750121106653337977}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c6dbd479f18647efa68f96831c8ee001, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.GroundGameObject
 --- !u!1 &5805098070580874337
 GameObject:
   m_ObjectHideFlags: 0
@@ -1592,7 +1813,8 @@ GameObject:
   - component: {fileID: 6880946433906271517}
   - component: {fileID: 691153402422757708}
   - component: {fileID: 2532628388415827181}
-  m_Layer: 0
+  - component: {fileID: 7158852366585212951}
+  m_Layer: 9
   m_Name: Terrain_2_-1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1674,6 +1896,18 @@ TerrainCollider:
   serializedVersion: 2
   m_TerrainData: {fileID: 15600000, guid: 5ebc9c4e81dba4f7fa90a07471ffdc65, type: 2}
   m_EnableTreeColliders: 1
+--- !u!114 &7158852366585212951
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5805098070580874337}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c6dbd479f18647efa68f96831c8ee001, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.GroundGameObject
 --- !u!1 &6336316145367461941
 GameObject:
   m_ObjectHideFlags: 0
@@ -1685,7 +1919,8 @@ GameObject:
   - component: {fileID: 5354013852049011308}
   - component: {fileID: 7082287048293834863}
   - component: {fileID: 6787931890490570799}
-  m_Layer: 0
+  - component: {fileID: 3412703641690181737}
+  m_Layer: 9
   m_Name: Terrain_-2_0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1767,6 +2002,18 @@ TerrainCollider:
   serializedVersion: 2
   m_TerrainData: {fileID: 15600000, guid: 4f5e45d4800e0409197834b42b5c660d, type: 2}
   m_EnableTreeColliders: 1
+--- !u!114 &3412703641690181737
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6336316145367461941}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c6dbd479f18647efa68f96831c8ee001, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.GroundGameObject
 --- !u!1 &6349496744885944404
 GameObject:
   m_ObjectHideFlags: 0
@@ -1778,7 +2025,8 @@ GameObject:
   - component: {fileID: 2257714781154801392}
   - component: {fileID: 1857218421775459996}
   - component: {fileID: 4306484343652488143}
-  m_Layer: 0
+  - component: {fileID: 8968048098577394090}
+  m_Layer: 9
   m_Name: Terrain_2_1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1860,6 +2108,18 @@ TerrainCollider:
   serializedVersion: 2
   m_TerrainData: {fileID: 15600000, guid: 29fdfdb7d1f334b91b2998f505064fcd, type: 2}
   m_EnableTreeColliders: 1
+--- !u!114 &8968048098577394090
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6349496744885944404}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c6dbd479f18647efa68f96831c8ee001, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.GroundGameObject
 --- !u!1 &6672168902277312759
 GameObject:
   m_ObjectHideFlags: 0
@@ -1929,7 +2189,8 @@ GameObject:
   - component: {fileID: 8715414849521180070}
   - component: {fileID: 7816120379668441790}
   - component: {fileID: 4411390952429301854}
-  m_Layer: 0
+  - component: {fileID: 1075948211780593897}
+  m_Layer: 9
   m_Name: Terrain_0_2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2011,6 +2272,18 @@ TerrainCollider:
   serializedVersion: 2
   m_TerrainData: {fileID: 15600000, guid: bc35bd39f9d574b58b8375b4e301bc30, type: 2}
   m_EnableTreeColliders: 1
+--- !u!114 &1075948211780593897
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6721009145398169707}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c6dbd479f18647efa68f96831c8ee001, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.GroundGameObject
 --- !u!1 &7251302040117161870
 GameObject:
   m_ObjectHideFlags: 0
@@ -2022,7 +2295,8 @@ GameObject:
   - component: {fileID: 6486350297533713552}
   - component: {fileID: 6310203311030591193}
   - component: {fileID: 409275446982659696}
-  m_Layer: 0
+  - component: {fileID: 8156461662999493726}
+  m_Layer: 9
   m_Name: Terrain_-1_0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2104,6 +2378,18 @@ TerrainCollider:
   serializedVersion: 2
   m_TerrainData: {fileID: 15600000, guid: 3e16c377c9aa748929ee5463411cc64e, type: 2}
   m_EnableTreeColliders: 1
+--- !u!114 &8156461662999493726
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7251302040117161870}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c6dbd479f18647efa68f96831c8ee001, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.GroundGameObject
 --- !u!1 &8056550516744638879
 GameObject:
   m_ObjectHideFlags: 0
@@ -2115,7 +2401,8 @@ GameObject:
   - component: {fileID: 7521064329523348104}
   - component: {fileID: 6177931292540291526}
   - component: {fileID: 2534068406452705957}
-  m_Layer: 0
+  - component: {fileID: 4709641351919599113}
+  m_Layer: 9
   m_Name: Terrain_1_1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2197,6 +2484,18 @@ TerrainCollider:
   serializedVersion: 2
   m_TerrainData: {fileID: 15600000, guid: 34830d123f2414a029709f9445d38d7c, type: 2}
   m_EnableTreeColliders: 1
+--- !u!114 &4709641351919599113
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8056550516744638879}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c6dbd479f18647efa68f96831c8ee001, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.GroundGameObject
 --- !u!1 &8339737633240639010
 GameObject:
   m_ObjectHideFlags: 0
@@ -2208,7 +2507,8 @@ GameObject:
   - component: {fileID: 8340775088578647462}
   - component: {fileID: 7249464896356343214}
   - component: {fileID: 494683283115251659}
-  m_Layer: 0
+  - component: {fileID: 6528010466354586122}
+  m_Layer: 9
   m_Name: Terrain_1_-2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2290,6 +2590,18 @@ TerrainCollider:
   serializedVersion: 2
   m_TerrainData: {fileID: 15600000, guid: f4068fe2a6f6d4bc2a6140a260ff9bc7, type: 2}
   m_EnableTreeColliders: 1
+--- !u!114 &6528010466354586122
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8339737633240639010}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c6dbd479f18647efa68f96831c8ee001, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.GroundGameObject
 --- !u!1 &9079117098080209535
 GameObject:
   m_ObjectHideFlags: 0
@@ -2301,7 +2613,8 @@ GameObject:
   - component: {fileID: 5743474075305969954}
   - component: {fileID: 4809352954625378269}
   - component: {fileID: 1400116588146537416}
-  m_Layer: 0
+  - component: {fileID: 6831098017749554167}
+  m_Layer: 9
   m_Name: Terrain_2_0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2383,6 +2696,18 @@ TerrainCollider:
   serializedVersion: 2
   m_TerrainData: {fileID: 15600000, guid: 808d8a75355604d17be35184defb4ce9, type: 2}
   m_EnableTreeColliders: 1
+--- !u!114 &6831098017749554167
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9079117098080209535}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c6dbd479f18647efa68f96831c8ee001, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.BlockSystem.GroundGameObject
 --- !u!1001 &2867721262460347243
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/moorestech_client/Assets/Scenes/Other/BlockSetup.unity
+++ b/moorestech_client/Assets/Scenes/Other/BlockSetup.unity
@@ -1677,6 +1677,63 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a9ec6a2b0adb44ff3934771ef5d2c77a, type: 3}
+--- !u!1001 &1876809794688196348
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 415565409591131857, guid: a9ec6a2b0adb44ff3934771ef5d2c77a, type: 3}
+      propertyPath: m_Name
+      value: Oxygen_generator_2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1416632361609516136, guid: a9ec6a2b0adb44ff3934771ef5d2c77a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1416632361609516136, guid: a9ec6a2b0adb44ff3934771ef5d2c77a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1416632361609516136, guid: a9ec6a2b0adb44ff3934771ef5d2c77a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1416632361609516136, guid: a9ec6a2b0adb44ff3934771ef5d2c77a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1416632361609516136, guid: a9ec6a2b0adb44ff3934771ef5d2c77a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1416632361609516136, guid: a9ec6a2b0adb44ff3934771ef5d2c77a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1416632361609516136, guid: a9ec6a2b0adb44ff3934771ef5d2c77a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1416632361609516136, guid: a9ec6a2b0adb44ff3934771ef5d2c77a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1416632361609516136, guid: a9ec6a2b0adb44ff3934771ef5d2c77a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1416632361609516136, guid: a9ec6a2b0adb44ff3934771ef5d2c77a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a9ec6a2b0adb44ff3934771ef5d2c77a, type: 3}
 --- !u!1001 &2294760600596169148
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1753,6 +1810,10 @@ PrefabInstance:
     - target: {fileID: 415565409591131857, guid: a9ec6a2b0adb44ff3934771ef5d2c77a, type: 3}
       propertyPath: m_Name
       value: Oxygen_generator_1
+      objectReference: {fileID: 0}
+    - target: {fileID: 415565409591131857, guid: a9ec6a2b0adb44ff3934771ef5d2c77a, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1416632361609516136, guid: a9ec6a2b0adb44ff3934771ef5d2c77a, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2125,3 +2186,4 @@ SceneRoots:
   - {fileID: 716524917}
   - {fileID: 7452556849205233810}
   - {fileID: 3341926797368429862}
+  - {fileID: 1876809794688196348}

--- a/moorestech_client/Assets/Scripts/Client.DebugSystem/DebugSheet/DebugSheetControllerExtension.cs
+++ b/moorestech_client/Assets/Scripts/Client.DebugSystem/DebugSheet/DebugSheetControllerExtension.cs
@@ -1,6 +1,8 @@
 using System;
 using Common.Debug;
 using UnityDebugSheet.Runtime.Core.Scripts;
+using UnityDebugSheet.Runtime.Core.Scripts.DefaultImpl.Cells;
+using UnityEngine;
 
 namespace Client.DebugSystem
 {
@@ -8,14 +10,48 @@ namespace Client.DebugSystem
     {
         public static void AddEnumPickerWithSave<TEnum>(this DebugPage debugPage, TEnum defaultValue, string label, string key, Action<TEnum> valueChangedOrInitialize) where TEnum : Enum
         {
-            var value = (TEnum)Enum.ToObject(typeof(TEnum), DebugParameters.GetValueOrDefaultInt(key, Convert.ToInt32(defaultValue)));
+            // 保存値が現在のenum定義に存在しない場合はデフォルトへフォールバックする
+            // Fall back to default if the saved value isn't a defined member of the current enum
+            var savedInt = DebugParameters.GetValueOrDefaultInt(key, Convert.ToInt32(defaultValue));
+            var value = Enum.IsDefined(typeof(TEnum), savedInt) ? (TEnum)Enum.ToObject(typeof(TEnum), savedInt) : defaultValue;
             valueChangedOrInitialize(value);
-            
-            debugPage.AddEnumPicker(value, label, activeValueChanged: d =>
+
+            // モデルを生成し、値変更時の保存と再通知を購読する
+            // Build the model and subscribe save + re-notify on value change
+            var model = new EnumPickerCellModel(value) { Text = label };
+            model.ActiveValueChanged += d =>
             {
                 DebugParameters.SaveInt(key, Convert.ToInt32(d));
                 valueChangedOrInitialize((TEnum)d);
-            });
+            };
+
+            // enum型専用のプレハブキー（=専用プール）に登録し、型混在によるEnumPickerCellの添字例外を防ぐ
+            // Register under an enum-type-specific prefab key (= dedicated pool) to prevent EnumPickerCell's index exception from mixed types
+            var prefabKey = RegisterPerTypePrefabKey();
+            debugPage.AddItem(prefabKey, model);
+
+            #region Internal
+
+            string RegisterPerTypePrefabKey()
+            {
+                // EnumPickerCellは値リストをインスタンスに一度だけキャッシュするため、1プールにつき単一enum型のみを割り当てる
+                // EnumPickerCell caches its value list once per instance, so we allocate only a single enum type per pool
+                var typeKey = "EnumPickerCell_" + typeof(TEnum).FullName;
+                var container = debugPage.GetComponent<PrefabContainer>();
+                if (container.TryGetPrefab(typeKey, out _)) return typeKey;
+
+                // ベースのEnumPickerCellプレハブを複製し、専用キー名の非アクティブテンプレートとして登録する
+                // Clone the base EnumPickerCell prefab and register it as an inactive template under the dedicated key
+                var basePrefab = container.GetPrefab("EnumPickerCell");
+                var template = UnityEngine.Object.Instantiate(basePrefab, debugPage.transform);
+                template.name = typeKey;
+                template.SetActive(false);
+                container.AddPrefab(template);
+
+                return typeKey;
+            }
+
+            #endregion
         }
         
         public static void AddBoolWithSave(this DebugPage debugPage, bool defaultValue, string label, string key, Action<bool> valueChangedOrInitialize = null)

--- a/moorestech_client/Assets/Scripts/Client.DebugSystem/DebugSheet/DebugSheetControllerExtension.cs
+++ b/moorestech_client/Assets/Scripts/Client.DebugSystem/DebugSheet/DebugSheetControllerExtension.cs
@@ -43,7 +43,8 @@ namespace Client.DebugSystem
                 // ベースのEnumPickerCellプレハブを複製し、専用キー名の非アクティブテンプレートとして登録する
                 // Clone the base EnumPickerCell prefab and register it as an inactive template under the dedicated key
                 var basePrefab = container.GetPrefab("EnumPickerCell");
-                var template = UnityEngine.Object.Instantiate(basePrefab, debugPage.transform);
+                var template = UnityEngine.Object.Instantiate(basePrefab);
+                template.transform.SetParent(debugPage.transform, false);
                 template.name = typeKey;
                 template.SetActive(false);
                 container.AddPrefab(template);

--- a/moorestech_client/ProjectSettings/QualitySettings.asset
+++ b/moorestech_client/ProjectSettings/QualitySettings.asset
@@ -4,7 +4,7 @@
 QualitySettings:
   m_ObjectHideFlags: 0
   serializedVersion: 5
-  m_CurrentQuality: 0
+  m_CurrentQuality: 2
   m_QualitySettings:
   - serializedVersion: 5
     name: Low

--- a/moorestech_client/ProjectSettings/QualitySettings.asset
+++ b/moorestech_client/ProjectSettings/QualitySettings.asset
@@ -4,7 +4,7 @@
 QualitySettings:
   m_ObjectHideFlags: 0
   serializedVersion: 5
-  m_CurrentQuality: 2
+  m_CurrentQuality: 0
   m_QualitySettings:
   - serializedVersion: 5
     name: Low

--- a/moorestech_server/Assets/Scripts/Game.Block/Blocks/FilterSplitter/VanillaFilterSplitterComponent.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Blocks/FilterSplitter/VanillaFilterSplitterComponent.cs
@@ -329,7 +329,7 @@ namespace Game.Block.Blocks.FilterSplitter
         {
             public readonly Guid ConnectorGuid;
             public readonly ItemId[] FilterItems;
-            public FilterSplitterMode Mode = FilterSplitterMode.Default;
+            public FilterSplitterMode Mode = FilterSplitterMode.Whitelist;
             public IItemStack BufferedItem;
 
             public DirectionState(Guid connectorGuid, int slotCount)

--- a/moorestech_server/Assets/Scripts/Tests/CombinedTest/Core/FilterSplitterTest.cs
+++ b/moorestech_server/Assets/Scripts/Tests/CombinedTest/Core/FilterSplitterTest.cs
@@ -31,8 +31,12 @@ namespace Tests.CombinedTest.Core
             var (_, _) = new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
             var (_, component, dummies) = CreateSplitterWithDummies(new BlockInstanceId(1));
 
-            // 全方向 Default のまま 3 アイテム挿入 → 各方向に 1 個ずつラウンドロビン
-            // All directions stay Default; 3 inserts should round-robin one item each
+            // 初期値は Whitelist のため、全方向を明示的に Default に設定する
+            // Initial mode is Whitelist, so explicitly set every direction to Default
+            for (var d = 0; d < component.DirectionCount; d++) component.SetMode(d, FilterSplitterMode.Default);
+
+            // 全方向 Default で 3 アイテム挿入 → 各方向に 1 個ずつラウンドロビン
+            // All directions Default; 3 inserts should round-robin one item each
             for (var i = 0; i < 3; i++)
             {
                 var stack = ServerContext.ItemStackFactory.Create(ForUnitTestItemId.ItemId1, 1);
@@ -78,10 +82,12 @@ namespace Tests.CombinedTest.Core
             var (_, _) = new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
             var (_, component, dummies) = CreateSplitterWithDummies(new BlockInstanceId(3));
 
-            // dir0 を Blacklist[ItemId1]、dir1/dir2 は Default
-            // dir0 = Blacklist[ItemId1], dir1/dir2 = Default
+            // dir0 を Blacklist[ItemId1]、dir1/dir2 は Default（初期値 Whitelist から明示変更）
+            // dir0 = Blacklist[ItemId1], dir1/dir2 = Default (explicitly changed from initial Whitelist)
             component.SetMode(0, FilterSplitterMode.Blacklist);
             component.SetFilterItem(0, 0, ForUnitTestItemId.ItemId1);
+            component.SetMode(1, FilterSplitterMode.Default);
+            component.SetMode(2, FilterSplitterMode.Default);
 
             // ItemId1 は dir0 では拒否され Default 方向 (dir1/dir2) にラウンドロビンで流れる
             // ItemId1 is rejected by dir0; it round-robins through Default (dir1/dir2)
@@ -111,6 +117,10 @@ namespace Tests.CombinedTest.Core
         {
             var (_, _) = new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
             var (splitter, component, dummies) = CreateSplitterWithDummies(new BlockInstanceId(4));
+
+            // 初期値は Whitelist のため、全方向を明示的に Default に設定する
+            // Initial mode is Whitelist, so explicitly set every direction to Default
+            for (var d = 0; d < component.DirectionCount; d++) component.SetMode(d, FilterSplitterMode.Default);
 
             // dir1 の接続を外す
             // Disconnect dir1 from the splitter

--- a/moorestech_server/Assets/Scripts/Tests/CombinedTest/Server/PacketTest/FilterSplitterStateProtocolTest.cs
+++ b/moorestech_server/Assets/Scripts/Tests/CombinedTest/Server/PacketTest/FilterSplitterStateProtocolTest.cs
@@ -33,11 +33,11 @@ namespace Tests.CombinedTest.Server.PacketTest
             Assert.IsTrue(response.Success);
             Assert.AreEqual(3, response.DirectionCount);
             Assert.AreEqual(4, response.FilterSlotCountPerDirection);
-            // 初期状態は全方向 Default
-            // Initial state is Default for all directions
+            // 初期状態は全方向 Whitelist
+            // Initial state is Whitelist for all directions
             for (var d = 0; d < response.DirectionCount; d++)
             {
-                Assert.AreEqual(FilterSplitterMode.Default, response.Directions[d].Mode);
+                Assert.AreEqual(FilterSplitterMode.Whitelist, response.Directions[d].Mode);
             }
         }
 
@@ -72,11 +72,13 @@ namespace Tests.CombinedTest.Server.PacketTest
             var (packet, _) = new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
             PlaceFilterSplitter();
 
-            var response = Send(packet, FilterSplitterStateProtocol.FilterSplitterStateRequest.CreateSetModeRequest(SplitterPos, 1, FilterSplitterMode.Whitelist));
+            // dir1 のみ Blacklist へ変更（初期値 Whitelist との差分で「dir1 だけ変わる」ことを検証）
+            // Change only dir1 to Blacklist; dir0 must stay at the initial Whitelist
+            var response = Send(packet, FilterSplitterStateProtocol.FilterSplitterStateRequest.CreateSetModeRequest(SplitterPos, 1, FilterSplitterMode.Blacklist));
 
             Assert.IsTrue(response.Success);
-            Assert.AreEqual(FilterSplitterMode.Whitelist, response.Directions[1].Mode);
-            Assert.AreEqual(FilterSplitterMode.Default, response.Directions[0].Mode);
+            Assert.AreEqual(FilterSplitterMode.Blacklist, response.Directions[1].Mode);
+            Assert.AreEqual(FilterSplitterMode.Whitelist, response.Directions[0].Mode);
         }
 
         [Test]


### PR DESCRIPTION
## Summary
- EnumPickerの型混在で発生していた `IndexOutOfRange` 例外を、enum型ごとに専用プレハブプールを割り当てることで修正
- フィルター分岐器の出力モード初期値を `Default` から `Whitelist` に変更
- 各種3Dモデル・プレハブ・マテリアル（ベルトコンベア付き小型チェスト、ロータリーモルタル、地形生成プレハブ等）と軽量化向け設定を更新

## Test plan
- [ ] DebugSheetで複数のenum型ピッカーを開いても例外が出ないことを確認
- [ ] フィルター分岐器を新規設置した際、出力モードがWhitelistになっていることを確認
- [ ] 更新した3Dモデル/プレハブがシーン上で正しく表示されることを確認

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added block assets for Iron conveyor mini chest, Rotary mortar, and engine materials.

* **Improvements**
  * Enhanced debug enum picker with safer value persistence and per-type prefab handling.
  * Filter splitter now defaults to Whitelist mode for more predictable routing.

* **Chores**
  * Simplified research sort-priority recalculation tool.

* **Tests**
  * Updated tests to match the new filter splitter defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->