### PR TITLE
機械レシピのアンロック機能を追加

### DIFF
--- a/VanillaSchema/machineRecipes.yml
+++ b/VanillaSchema/machineRecipes.yml
@@ -87,3 +87,6 @@ properties:
             displayElementPath: /data/[*]/name
         - key: amount
           type: number
+    - key: initialUnlocked
+      type: boolean
+      default: true

--- a/VanillaSchema/ref/gameAction.yml
+++ b/VanillaSchema/ref/gameAction.yml
@@ -14,6 +14,7 @@ items:
     - unlockCraftRecipe
     - unlockItemRecipeView
     - unlockChallengeCategory
+    - unlockMachineRecipe
     - playSkit
     - playBackgroundSkit
   - key: gameActionParam
@@ -47,6 +48,18 @@ items:
             schemaId: items
             foreignKeyIdPath: /data/[*]/itemGuid
             displayElementPath: /data/[*]/name
+    - when: unlockMachineRecipe
+      type: object
+      isDefaultOpen: true
+      properties:
+      - key: unlockMachineRecipeGuids
+        type: array
+        items:
+          type: uuid
+          foreignKey:
+            schemaId: machineRecipes
+            foreignKeyIdPath: /data/[*]/machineRecipeGuid
+            displayElementPath: /data/[*]/machineRecipeGuid
     - when: unlockChallengeCategory
       type: object
       isDefaultOpen: true

--- a/moorestech_client/Assets/Scripts/Client.DebugSystem/CharacterTestDebug.cs
+++ b/moorestech_client/Assets/Scripts/Client.DebugSystem/CharacterTestDebug.cs
@@ -39,7 +39,7 @@ namespace Client.DebugSystem
                 var handshake = new InitialHandshakeProtocol.ResponseInitialHandshakeMessagePack(new Vector3MessagePack(playerPos), null, -1);
                 var worldData = new WorldDataResponse(new List<BlockInfo>(), new List<EntityResponse>());
                 var inventory = new PlayerInventoryResponse(new List<IItemStack>(), null);
-                var unlockState = new UnlockStateResponse(new List<Guid>(), new List<Guid>(), new List<ItemId>(), new List<ItemId>(), new List<Guid>(), new List<Guid>());
+                var unlockState = new UnlockStateResponse(new List<Guid>(), new List<Guid>(), new List<ItemId>(), new List<ItemId>(), new List<Guid>(), new List<Guid>(), new List<Guid>(), new List<Guid>());
                 var craftTree = new CraftTreeResponse(new List<CraftTreeNode>(), Guid.Empty);
                 
                 // テストプレイ用の空レスポンスを構築

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/CraftTree/TreeView/CraftTreeEditorNodeItem.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/CraftTree/TreeView/CraftTreeEditorNodeItem.cs
@@ -130,9 +130,12 @@ namespace Client.Game.InGame.CraftTree.TreeView
             List<CraftTreeNode> GetMaterialItems(RecipeViewerItemRecipes recipes)
             {
                 var materials = new List<CraftTreeNode>();
-                if (recipes.UnlockedCraftRecipes().Count == 0 && recipes.MachineRecipes.Count != 0)
+                var unlockedMachineRecipes = recipes.UnlockedMachineRecipes();
+                if (recipes.UnlockedCraftRecipes().Count == 0 && unlockedMachineRecipes.Count != 0)
                 {
-                    var machineRecipe = recipes.MachineRecipes.FirstOrDefault();
+                    // アンロック済み機械レシピだけをクラフトツリーに展開
+                    // Expand only unlocked machine recipes into the craft tree
+                    var machineRecipe = unlockedMachineRecipes.FirstOrDefault();
                     foreach (var inputItem in machineRecipe.Value.First().InputItems)
                     {
                         var itemId = MasterHolder.ItemMaster.GetItemId(inputItem.ItemGuid);

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Craft/ItemListView.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Craft/ItemListView.cs
@@ -92,16 +92,17 @@ namespace Client.Game.InGame.UI.Inventory.Craft
                 
                 if (itemMaster.RecipeViewType is ItemMasterElement.RecipeViewTypeConst.Default)
                 {
-                    // デフォルトはアンロックされていてレシピがあれば表示する
-                    // Default is to display if unlocked and has a recipe
+                    // デフォルトはアンロックされていてレシピがあれば表示する（クラフトまたは機械レシピ）
+                    // Default is to display if unlocked and has a recipe (craft or machine)
                     var state = _gameUnlockStateData.ItemUnlockStateInfos[itemId];
                     var isItemUnlocked = state.IsUnlocked;
-                    
+
                     var itemRecipes = _itemRecipeViewerDataContainer.GetItem(itemId);
-                    var unlockRecipes = itemRecipes.UnlockedCraftRecipes();
-                    var isRecipeItemUnlocked = unlockRecipes.Count != 0;
-                    
-                    return isItemUnlocked && isRecipeItemUnlocked;
+                    var hasUnlockedCraftRecipe = itemRecipes.UnlockedCraftRecipes().Count != 0;
+                    var hasUnlockedMachineRecipe = itemRecipes.UnlockedMachineRecipes().Count != 0;
+                    var hasAnyUnlockedRecipe = hasUnlockedCraftRecipe || hasUnlockedMachineRecipe;
+
+                    return isItemUnlocked && hasAnyUnlockedRecipe;
                 }
 
                 if (itemMaster.RecipeViewType is ItemMasterElement.RecipeViewTypeConst.IsUnlocked)

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/RecipeViewer/ItemRecipeViewerDataContainer.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/RecipeViewer/ItemRecipeViewerDataContainer.cs
@@ -106,11 +106,34 @@ namespace Client.Game.InGame.UI.Inventory.RecipeViewer
         
         /// <summary>
         /// アンロック済みのクラフトレシピを取得
+        /// Get unlocked craft recipes
         /// </summary>
         public List<CraftRecipeMasterElement> UnlockedCraftRecipes()
         {
             var infos = _gameUnlockStateData.CraftRecipeUnlockStateInfos;
             return AllCraftRecipes.Where(c => infos[c.CraftRecipeGuid].IsUnlocked).ToList();
+        }
+
+        /// <summary>
+        /// アンロック済みの機械レシピを機械ごとに取得
+        /// Get unlocked machine recipes grouped by block
+        /// </summary>
+        public Dictionary<BlockId, List<MachineRecipeMasterElement>> UnlockedMachineRecipes()
+        {
+            var infos = _gameUnlockStateData.MachineRecipeUnlockStateInfos;
+            var result = new Dictionary<BlockId, List<MachineRecipeMasterElement>>();
+            foreach (var kv in MachineRecipes)
+            {
+                var blockId = kv.Key;
+                var unlockedRecipes = kv.Value
+                    .Where(m => !infos.TryGetValue(m.MachineRecipeGuid, out var info) || info.IsUnlocked)
+                    .ToList();
+                if (unlockedRecipes.Count > 0)
+                {
+                    result.Add(blockId, unlockedRecipes);
+                }
+            }
+            return result;
         }
     }
 }

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/RecipeViewer/ItemRecipeViewerDataContainer.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/RecipeViewer/ItemRecipeViewerDataContainer.cs
@@ -126,7 +126,7 @@ namespace Client.Game.InGame.UI.Inventory.RecipeViewer
             {
                 var blockId = kv.Key;
                 var unlockedRecipes = kv.Value
-                    .Where(m => !infos.TryGetValue(m.MachineRecipeGuid, out var info) || info.IsUnlocked)
+                    .Where(m => infos[m.MachineRecipeGuid].IsUnlocked)
                     .ToList();
                 if (unlockedRecipes.Count > 0)
                 {

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/RecipeViewer/ItemRecipeViewerDataContainer.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/RecipeViewer/ItemRecipeViewerDataContainer.cs
@@ -128,7 +128,7 @@ namespace Client.Game.InGame.UI.Inventory.RecipeViewer
                 var unlockedRecipes = kv.Value
                     .Where(m => infos[m.MachineRecipeGuid].IsUnlocked)
                     .ToList();
-                if (unlockedRecipes.Count > 0)
+                if (0 < unlockedRecipes.Count)
                 {
                     result.Add(blockId, unlockedRecipes);
                 }

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/RecipeViewer/MachineRecipeView.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/RecipeViewer/MachineRecipeView.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Client.Game.InGame.Context;
 using Client.Game.InGame.UI.Inventory.Common;
 using Core.Master;
+using Mooresmaster.Model.MachineRecipesModule;
 using TMPro;
 using UniRx;
 using UnityEngine;
@@ -33,7 +34,7 @@ namespace Client.Game.InGame.UI.Inventory.RecipeViewer
         
         private int MachineRecipeCount => _currentUnlockedMachineRecipes[_currentBlockId].Count;
         private RecipeViewerItemRecipes _currentItemRecipes;
-        private Dictionary<BlockId, List<Mooresmaster.Model.MachineRecipesModule.MachineRecipeMasterElement>> _currentUnlockedMachineRecipes = new();
+        private Dictionary<BlockId, List<MachineRecipeMasterElement>> _currentUnlockedMachineRecipes = new();
         private BlockId _currentBlockId;
         private int _currentIndex;
         
@@ -58,10 +59,10 @@ namespace Client.Game.InGame.UI.Inventory.RecipeViewer
             });
         }
         
-        public void SetRecipes(RecipeViewerItemRecipes recipeViewerItemRecipes)
+        public void SetRecipes(RecipeViewerItemRecipes recipeViewerItemRecipes, Dictionary<BlockId, List<MachineRecipeMasterElement>> unlockedMachineRecipes)
         {
             _currentItemRecipes = recipeViewerItemRecipes;
-            _currentUnlockedMachineRecipes = recipeViewerItemRecipes.UnlockedMachineRecipes();
+            _currentUnlockedMachineRecipes = unlockedMachineRecipes;
             _currentIndex = 0;
             if (_currentUnlockedMachineRecipes.Count != 0)
             {

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/RecipeViewer/MachineRecipeView.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/RecipeViewer/MachineRecipeView.cs
@@ -31,8 +31,9 @@ namespace Client.Game.InGame.UI.Inventory.RecipeViewer
         private readonly List<ItemSlotView> _outputSlotList = new();
         [Inject] private ItemRecipeViewerDataContainer _itemRecipeViewerDataContainer;
         
-        private int MachineRecipeCount => _currentItemRecipes.MachineRecipes[_currentBlockId].Count;
+        private int MachineRecipeCount => _currentUnlockedMachineRecipes[_currentBlockId].Count;
         private RecipeViewerItemRecipes _currentItemRecipes;
+        private Dictionary<BlockId, List<Mooresmaster.Model.MachineRecipesModule.MachineRecipeMasterElement>> _currentUnlockedMachineRecipes = new();
         private BlockId _currentBlockId;
         private int _currentIndex;
         
@@ -60,10 +61,11 @@ namespace Client.Game.InGame.UI.Inventory.RecipeViewer
         public void SetRecipes(RecipeViewerItemRecipes recipeViewerItemRecipes)
         {
             _currentItemRecipes = recipeViewerItemRecipes;
+            _currentUnlockedMachineRecipes = recipeViewerItemRecipes.UnlockedMachineRecipes();
             _currentIndex = 0;
-            if (recipeViewerItemRecipes.MachineRecipes.Count != 0)
+            if (_currentUnlockedMachineRecipes.Count != 0)
             {
-                _currentBlockId = recipeViewerItemRecipes.MachineRecipes.First().Key;
+                _currentBlockId = _currentUnlockedMachineRecipes.First().Key;
             }
         }
         
@@ -76,7 +78,7 @@ namespace Client.Game.InGame.UI.Inventory.RecipeViewer
         
         public void DisplayRecipe(int index)
         {
-            var machineRecipes = _currentItemRecipes.MachineRecipes[_currentBlockId][index];
+            var machineRecipes = _currentUnlockedMachineRecipes[_currentBlockId][index];
             
             ClearSlotObject();
             

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/RecipeViewer/RecipeTabView.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/RecipeViewer/RecipeTabView.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Client.Game.InGame.Context;
 using Client.Game.InGame.UnlockState;
 using Core.Master;
+using Mooresmaster.Model.MachineRecipesModule;
 using UniRx;
 using UnityEngine;
 using UnityEngine.UI;
@@ -21,16 +22,16 @@ namespace Client.Game.InGame.UI.Inventory.RecipeViewer
         
         private readonly List<RecipeViewerTabElement> _currentTabs = new();
         
-        public void SetRecipeTabView(RecipeViewerItemRecipes recipes)
+        public void SetRecipeTabView(RecipeViewerItemRecipes recipes, Dictionary<BlockId, List<MachineRecipeMasterElement>> unlockedMachineRecipes)
         {
             foreach (var tab in _currentTabs)
             {
                 Destroy(tab.gameObject);
             }
-            
+
             _currentTabs.Clear();
-            
-            // クラフトタブがあればそれを優先的異選択
+
+            // クラフトタブがあればそれを優先的に選択
             // If there is a craft tab, select it preferentially
             var isFirstCraft = false;
             var unlockedRecipe = recipes.UnlockedCraftRecipes();
@@ -44,10 +45,9 @@ namespace Client.Game.InGame.UI.Inventory.RecipeViewer
                 _currentTabs.Add(tabElement);
                 isFirstCraft = true;
             }
-            
+
             // アンロック済みの機械レシピのみタブに表示
             // Only show unlocked machine recipes in tabs
-            var unlockedMachineRecipes = recipes.UnlockedMachineRecipes();
             var isFirst = true;
             foreach (var machineRecipe in unlockedMachineRecipes)
             {

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/RecipeViewer/RecipeTabView.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/RecipeViewer/RecipeTabView.cs
@@ -45,8 +45,11 @@ namespace Client.Game.InGame.UI.Inventory.RecipeViewer
                 isFirstCraft = true;
             }
             
+            // アンロック済みの機械レシピのみタブに表示
+            // Only show unlocked machine recipes in tabs
+            var unlockedMachineRecipes = recipes.UnlockedMachineRecipes();
             var isFirst = true;
-            foreach (var machineRecipe in recipes.MachineRecipes)
+            foreach (var machineRecipe in unlockedMachineRecipes)
             {
                 var blockId = machineRecipe.Key;
                 var itemId = MasterHolder.BlockMaster.GetItemId(blockId);

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/RecipeViewer/RecipeViewerView.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/RecipeViewer/RecipeViewerView.cs
@@ -47,21 +47,24 @@ namespace Client.Game.InGame.UI.Inventory.RecipeViewer
             }
             
             _currentRecipe = recipeViewerItemRecipes;
-            
+
+            // アンロック済みレシピを1回だけ取得して各ビューに渡す
+            // Compute unlocked machine recipes once and pass to each view
+            var unlockedMachineRecipes = recipeViewerItemRecipes.UnlockedMachineRecipes();
+
             craftInventoryView.SetRecipes(recipeViewerItemRecipes);
-            machineRecipeView.SetRecipes(recipeViewerItemRecipes);
-            recipeTabView.SetRecipeTabView(recipeViewerItemRecipes);
-            
+            machineRecipeView.SetRecipes(recipeViewerItemRecipes, unlockedMachineRecipes);
+            recipeTabView.SetRecipeTabView(recipeViewerItemRecipes, unlockedMachineRecipes);
+
             // クラフトレシピがある場合はそれを最初に表示する
+            // Show craft recipes first if available
             var isFirstCraft = recipeViewerItemRecipes.UnlockedCraftRecipes().Count != 0;
             craftInventoryView.SetActive(isFirstCraft);
             machineRecipeView.SetActive(!isFirstCraft);
-            
-            // SetRecipesの中で最初のレシピが自動選択されるようになったので
-            // DisplayRecipe(0)の呼び出しは不要
+
             // アンロック済み機械レシピがあれば表示
             // Show unlocked machine recipes if available
-            if (!isFirstCraft && recipeViewerItemRecipes.UnlockedMachineRecipes().Count != 0)
+            if (!isFirstCraft && unlockedMachineRecipes.Count != 0)
             {
                 machineRecipeView.DisplayRecipe(0);
             }

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/RecipeViewer/RecipeViewerView.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/RecipeViewer/RecipeViewerView.cs
@@ -59,7 +59,9 @@ namespace Client.Game.InGame.UI.Inventory.RecipeViewer
             
             // SetRecipesの中で最初のレシピが自動選択されるようになったので
             // DisplayRecipe(0)の呼び出しは不要
-            if (!isFirstCraft && recipeViewerItemRecipes.MachineRecipes.Count != 0)
+            // アンロック済み機械レシピがあれば表示
+            // Show unlocked machine recipes if available
+            if (!isFirstCraft && recipeViewerItemRecipes.UnlockedMachineRecipes().Count != 0)
             {
                 machineRecipeView.DisplayRecipe(0);
             }

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/RecipeViewer/RecipeViewerView.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/RecipeViewer/RecipeViewerView.cs
@@ -59,12 +59,13 @@ namespace Client.Game.InGame.UI.Inventory.RecipeViewer
             // クラフトレシピがある場合はそれを最初に表示する
             // Show craft recipes first if available
             var isFirstCraft = recipeViewerItemRecipes.UnlockedCraftRecipes().Count != 0;
+            var hasUnlockedMachineRecipe = unlockedMachineRecipes.Count != 0;
             craftInventoryView.SetActive(isFirstCraft);
-            machineRecipeView.SetActive(!isFirstCraft);
+            machineRecipeView.SetActive(!isFirstCraft && hasUnlockedMachineRecipe);
 
             // アンロック済み機械レシピがあれば表示
             // Show unlocked machine recipes if available
-            if (!isFirstCraft && unlockedMachineRecipes.Count != 0)
+            if (!isFirstCraft && hasUnlockedMachineRecipe)
             {
                 machineRecipeView.DisplayRecipe(0);
             }

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UnlockState/ClientGameUnlockStateDatastore.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UnlockState/ClientGameUnlockStateDatastore.cs
@@ -15,11 +15,13 @@ namespace Client.Game.InGame.UnlockState
         public IReadOnlyDictionary<Guid, CraftRecipeUnlockStateInfo> CraftRecipeUnlockStateInfos => _recipeUnlockStateInfos;
         public IReadOnlyDictionary<ItemId, ItemUnlockStateInfo> ItemUnlockStateInfos => _itemUnlockStateInfos;
         public IReadOnlyDictionary<Guid, ChallengeCategoryUnlockStateInfo> ChallengeCategoryUnlockStateInfos => _challengeCategoryUnlockStateInfos;
-        
-        
+        public IReadOnlyDictionary<Guid, MachineRecipeUnlockStateInfo> MachineRecipeUnlockStateInfos => _machineRecipeUnlockStateInfos;
+
+
         private readonly Dictionary<Guid, CraftRecipeUnlockStateInfo> _recipeUnlockStateInfos = new();
         private readonly Dictionary<ItemId, ItemUnlockStateInfo> _itemUnlockStateInfos = new();
         private readonly Dictionary<Guid, ChallengeCategoryUnlockStateInfo> _challengeCategoryUnlockStateInfos = new();
+        private readonly Dictionary<Guid, MachineRecipeUnlockStateInfo> _machineRecipeUnlockStateInfos = new();
         
         public ClientGameUnlockStateData(InitialHandshakeResponse initialHandshakeResponse)
         {
@@ -50,7 +52,18 @@ namespace Client.Game.InGame.UnlockState
             {
                 _challengeCategoryUnlockStateInfos[unlockedChallengeId] = new ChallengeCategoryUnlockStateInfo(unlockedChallengeId, true);
             }
-            
+
+            // 機械レシピのアンロック状態を初期化
+            // Initialize machine recipe unlock states
+            foreach (var lockedGuid in unlockState.LockedMachineRecipeGuids)
+            {
+                _machineRecipeUnlockStateInfos[lockedGuid] = new MachineRecipeUnlockStateInfo(lockedGuid, false);
+            }
+            foreach (var unlockedGuid in unlockState.UnlockedMachineRecipeGuids)
+            {
+                _machineRecipeUnlockStateInfos[unlockedGuid] = new MachineRecipeUnlockStateInfo(unlockedGuid, true);
+            }
+
             ClientContext.VanillaApi.Event.SubscribeEventResponse(UnlockedEventPacket.EventTag, OnUpdateUnlock);
         }
         
@@ -71,6 +84,10 @@ namespace Client.Game.InGame.UnlockState
                  case UnlockEventType.ChallengeCategory:
                      var challengeId = message.UnlockedChallengeCategoryGuid;
                      _challengeCategoryUnlockStateInfos[challengeId] = new ChallengeCategoryUnlockStateInfo(challengeId, true);
+                     break;
+                 case UnlockEventType.MachineRecipe:
+                     var machineRecipeGuid = message.UnlockedMachineRecipeGuid;
+                     _machineRecipeUnlockStateInfos[machineRecipeGuid] = new MachineRecipeUnlockStateInfo(machineRecipeGuid, true);
                      break;
                  default:
                      throw new ArgumentOutOfRangeException();

--- a/moorestech_client/Assets/Scripts/Client.Network/API/Responses.cs
+++ b/moorestech_client/Assets/Scripts/Client.Network/API/Responses.cs
@@ -149,11 +149,15 @@ namespace Client.Network.API
 
         public readonly List<Guid> LockedChallengeCategoryGuids;
         public readonly List<Guid> UnlockedChallengeCategoryGuids;
-        
+
+        public readonly List<Guid> LockedMachineRecipeGuids;
+        public readonly List<Guid> UnlockedMachineRecipeGuids;
+
         public UnlockStateResponse(
             List<Guid> lockedCraftRecipeGuids, List<Guid> unlockedCraftRecipeGuids,
             List<ItemId> lockedItemIds, List<ItemId> unlockedItemIds,
-            List<Guid> lockedChallengeCategoryGuids, List<Guid> unlockedChallengeCategoryGuids)
+            List<Guid> lockedChallengeCategoryGuids, List<Guid> unlockedChallengeCategoryGuids,
+            List<Guid> lockedMachineRecipeGuids, List<Guid> unlockedMachineRecipeGuids)
         {
             LockedCraftRecipeGuids = lockedCraftRecipeGuids;
             UnlockedCraftRecipeGuids = unlockedCraftRecipeGuids;
@@ -161,6 +165,8 @@ namespace Client.Network.API
             UnlockedItemIds = unlockedItemIds;
             LockedChallengeCategoryGuids = lockedChallengeCategoryGuids;
             UnlockedChallengeCategoryGuids = unlockedChallengeCategoryGuids;
+            LockedMachineRecipeGuids = lockedMachineRecipeGuids;
+            UnlockedMachineRecipeGuids = unlockedMachineRecipeGuids;
         }
     }
     

--- a/moorestech_client/Assets/Scripts/Client.Network/API/VanillaApiWithResponse.cs
+++ b/moorestech_client/Assets/Scripts/Client.Network/API/VanillaApiWithResponse.cs
@@ -223,7 +223,8 @@ namespace Client.Network.API
             return new UnlockStateResponse(
                 response.LockedCraftRecipeGuids, response.UnlockedCraftRecipeGuids,
                 response.LockedItemIds, response.UnlockedItemIds,
-                response.LockedCategoryChallengeGuids, response.UnlockedCategoryChallengeGuids);
+                response.LockedCategoryChallengeGuids, response.UnlockedCategoryChallengeGuids,
+                response.LockedMachineRecipeGuids, response.UnlockedMachineRecipeGuids);
         }
 
         public async UniTask<Dictionary<Guid, ResearchNodeState>> GetResearchNodeStates(CancellationToken ct)

--- a/moorestech_server/Assets/Scripts/Core.Master/Validator/ChallengeMasterUtil.cs
+++ b/moorestech_server/Assets/Scripts/Core.Master/Validator/ChallengeMasterUtil.cs
@@ -216,6 +216,21 @@ namespace Core.Master.Validator
                             }
                             break;
                         }
+                        case UnlockMachineRecipeGameActionParam unlockMachineRecipe:
+                        {
+                            if (unlockMachineRecipe.UnlockMachineRecipeGuids == null) break;
+                            foreach (var machineRecipeGuid in unlockMachineRecipe.UnlockMachineRecipeGuids)
+                            {
+                                // 機械レシピの参照先が存在することを検証
+                                // Validate that the referenced machine recipe exists
+                                var recipe = MasterHolder.MachineRecipesMaster.GetRecipeElement(machineRecipeGuid);
+                                if (recipe == null)
+                                {
+                                    logs += $"[ChallengeMaster] Challenge:{challengeTitle} {actionType} has invalid UnlockMachineRecipeGuid:{machineRecipeGuid}\n";
+                                }
+                            }
+                            break;
+                        }
                         case GiveItemGameActionParam giveItem:
                         {
                             if (giveItem.RewardItems == null) break;

--- a/moorestech_server/Assets/Scripts/Core.Master/Validator/ResearchMasterUtil.cs
+++ b/moorestech_server/Assets/Scripts/Core.Master/Validator/ResearchMasterUtil.cs
@@ -105,6 +105,21 @@ namespace Core.Master.Validator
                             }
                             break;
                         }
+                        case UnlockMachineRecipeGameActionParam unlockMachineRecipe:
+                        {
+                            if (unlockMachineRecipe.UnlockMachineRecipeGuids == null) break;
+                            foreach (var machineRecipeGuid in unlockMachineRecipe.UnlockMachineRecipeGuids)
+                            {
+                                // 機械レシピの参照先が存在することを検証
+                                // Validate that the referenced machine recipe exists
+                                var recipe = MasterHolder.MachineRecipesMaster.GetRecipeElement(machineRecipeGuid);
+                                if (recipe == null)
+                                {
+                                    localErrors += $"[ResearchMaster] Research:{researchName} has invalid ClearedAction.UnlockMachineRecipeGuid:{machineRecipeGuid}\n";
+                                }
+                            }
+                            break;
+                        }
                         case GiveItemGameActionParam giveItem:
                         {
                             if (giveItem.RewardItems == null) break;

--- a/moorestech_server/Assets/Scripts/Game.Action/GameActionExecutor.cs
+++ b/moorestech_server/Assets/Scripts/Game.Action/GameActionExecutor.cs
@@ -33,6 +33,7 @@ namespace Game.Action
                     case GameActionElement.GameActionTypeConst.unlockCraftRecipe:
                     case GameActionElement.GameActionTypeConst.unlockItemRecipeView:
                     case GameActionElement.GameActionTypeConst.unlockChallengeCategory:
+                    case GameActionElement.GameActionTypeConst.unlockMachineRecipe:
                         ExecuteAction(action, context);
                         break;
                 }
@@ -64,6 +65,10 @@ namespace Game.Action
 
                 case GameActionElement.GameActionTypeConst.unlockChallengeCategory:
                     UnlockChallengeCategory();
+                    break;
+
+                case GameActionElement.GameActionTypeConst.unlockMachineRecipe:
+                    UnlockMachineRecipe();
                     break;
 
                 case GameActionElement.GameActionTypeConst.giveItem:
@@ -98,6 +103,15 @@ namespace Game.Action
                 foreach (var guid in challenges)
                 {
                     _gameUnlockStateDataController.UnlockChallenge(guid);
+                }
+            }
+
+            void UnlockMachineRecipe()
+            {
+                var machineRecipeGuids = ((UnlockMachineRecipeGameActionParam)action.GameActionParam).UnlockMachineRecipeGuids;
+                foreach (var guid in machineRecipeGuids)
+                {
+                    _gameUnlockStateDataController.UnlockMachineRecipe(guid);
                 }
             }
 

--- a/moorestech_server/Assets/Scripts/Game.Block/Blocks/Machine/Inventory/VanillaMachineInputInventory.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Blocks/Machine/Inventory/VanillaMachineInputInventory.cs
@@ -7,6 +7,7 @@ using Game.Block.Interface;
 using Game.Block.Interface.Event;
 using Game.Context;
 using Game.Fluid;
+using Game.UnlockState;
 using Mooresmaster.Model.MachineRecipesModule;
 
 namespace Game.Block.Blocks.Machine.Inventory
@@ -25,13 +26,22 @@ namespace Game.Block.Blocks.Machine.Inventory
         
         private readonly BlockOpenableInventoryUpdateEvent _blockInventoryUpdate;
         private readonly FluidContainer[] _fluidContainers;
+        private readonly IGameUnlockStateData _gameUnlockStateData;
         private readonly OpenableInventoryItemDataStoreService _itemDataStoreService;
         
-        public VanillaMachineInputInventory(BlockId blockId, int inputSlot, int innerTankCount, float innerTankCapacity, BlockOpenableInventoryUpdateEvent blockInventoryUpdate, BlockInstanceId blockInstanceId)
+        public VanillaMachineInputInventory(
+            BlockId blockId,
+            int inputSlot,
+            int innerTankCount,
+            float innerTankCapacity,
+            BlockOpenableInventoryUpdateEvent blockInventoryUpdate,
+            BlockInstanceId blockInstanceId,
+            IGameUnlockStateData gameUnlockStateData)
         {
             _blockId = blockId;
             _blockInventoryUpdate = blockInventoryUpdate;
             _blockInstanceId = blockInstanceId;
+            _gameUnlockStateData = gameUnlockStateData;
             
             var option = new OpenableInventoryItemDataStoreServiceOption()
             {
@@ -69,7 +79,15 @@ namespace Game.Block.Blocks.Machine.Inventory
         
         public bool TryGetRecipeElement(out MachineRecipeMasterElement recipe)
         {
-            return MachineRecipeMasterUtil.TryGetRecipeElement(_blockId, InputSlot, FluidInputSlot, out recipe);
+            if (!MachineRecipeMasterUtil.TryGetRecipeElement(_blockId, InputSlot, FluidInputSlot, out recipe)) return false;
+
+            // アンロックされていないレシピは機械で使用不可にする
+            // Locked recipes cannot be used by machines
+            var unlockInfo = _gameUnlockStateData.MachineRecipeUnlockStateInfos[recipe.MachineRecipeGuid];
+            if (unlockInfo.IsUnlocked) return true;
+
+            recipe = null;
+            return false;
         }
         
         public void ReduceInputSlot(MachineRecipeMasterElement recipe)

--- a/moorestech_server/Assets/Scripts/Game.Block/Blocks/Machine/Inventory/VanillaMachineInputInventory.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Blocks/Machine/Inventory/VanillaMachineInputInventory.cs
@@ -83,7 +83,11 @@ namespace Game.Block.Blocks.Machine.Inventory
 
             // アンロックされていないレシピは機械で使用不可にする
             // Locked recipes cannot be used by machines
-            var unlockInfo = _gameUnlockStateData.MachineRecipeUnlockStateInfos[recipe.MachineRecipeGuid];
+            if (!_gameUnlockStateData.MachineRecipeUnlockStateInfos.TryGetValue(recipe.MachineRecipeGuid, out var unlockInfo))
+            {
+                recipe = null;
+                return false;
+            }
             if (unlockInfo.IsUnlocked) return true;
 
             recipe = null;

--- a/moorestech_server/Assets/Scripts/Game.Block/Blocks/Machine/MachineRecipeMaster.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Blocks/Machine/MachineRecipeMaster.cs
@@ -10,6 +10,8 @@ namespace Core.Master
 {
     public static class MachineRecipeMasterUtil
     {
+        private static IGameUnlockStateDataController _cachedUnlockState;
+
         public static bool TryGetRecipeElement(
             BlockId blockId,
             IReadOnlyList<IItemStack> inputSlot,
@@ -34,11 +36,11 @@ namespace Core.Master
 
             // アンロックされていないレシピは使用不可
             // Locked recipes cannot be used
-            if (found && ServerContext.IsInitialized)
+            if (found)
             {
-                var unlockState = ServerContext.GetService<IGameUnlockStateDataController>();
-                if (unlockState != null &&
-                    unlockState.MachineRecipeUnlockStateInfos.TryGetValue(recipe.MachineRecipeGuid, out var info) &&
+                _cachedUnlockState ??= ServerContext.IsInitialized ? ServerContext.GetService<IGameUnlockStateDataController>() : null;
+                if (_cachedUnlockState != null &&
+                    _cachedUnlockState.MachineRecipeUnlockStateInfos.TryGetValue(recipe.MachineRecipeGuid, out var info) &&
                     !info.IsUnlocked)
                 {
                     recipe = null;

--- a/moorestech_server/Assets/Scripts/Game.Block/Blocks/Machine/MachineRecipeMaster.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Blocks/Machine/MachineRecipeMaster.cs
@@ -1,7 +1,9 @@
 using System.Collections.Generic;
 using System.Linq;
 using Core.Item.Interface;
+using Game.Context;
 using Game.Fluid;
+using Game.UnlockState;
 using Mooresmaster.Model.MachineRecipesModule;
 
 namespace Core.Master
@@ -28,7 +30,23 @@ namespace Core.Master
                 fluidIds.Add(fluidContainer.FluidId);
             }
             
-            return MasterHolder.MachineRecipesMaster.TryGetRecipeElement(blockId, itemIds, fluidIds,out recipe);
+            var found = MasterHolder.MachineRecipesMaster.TryGetRecipeElement(blockId, itemIds, fluidIds, out recipe);
+
+            // アンロックされていないレシピは使用不可
+            // Locked recipes cannot be used
+            if (found && ServerContext.IsInitialized)
+            {
+                var unlockState = ServerContext.GetService<IGameUnlockStateDataController>();
+                if (unlockState != null &&
+                    unlockState.MachineRecipeUnlockStateInfos.TryGetValue(recipe.MachineRecipeGuid, out var info) &&
+                    !info.IsUnlocked)
+                {
+                    recipe = null;
+                    return false;
+                }
+            }
+
+            return found;
         }
         
         public static bool RecipeConfirmation(

--- a/moorestech_server/Assets/Scripts/Game.Block/Blocks/Machine/MachineRecipeMaster.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Blocks/Machine/MachineRecipeMaster.cs
@@ -1,17 +1,13 @@
 using System.Collections.Generic;
 using System.Linq;
 using Core.Item.Interface;
-using Game.Context;
 using Game.Fluid;
-using Game.UnlockState;
 using Mooresmaster.Model.MachineRecipesModule;
 
 namespace Core.Master
 {
     public static class MachineRecipeMasterUtil
     {
-        private static IGameUnlockStateDataController _cachedUnlockState;
-
         public static bool TryGetRecipeElement(
             BlockId blockId,
             IReadOnlyList<IItemStack> inputSlot,
@@ -32,23 +28,7 @@ namespace Core.Master
                 fluidIds.Add(fluidContainer.FluidId);
             }
             
-            var found = MasterHolder.MachineRecipesMaster.TryGetRecipeElement(blockId, itemIds, fluidIds, out recipe);
-
-            // アンロックされていないレシピは使用不可
-            // Locked recipes cannot be used
-            if (found)
-            {
-                _cachedUnlockState ??= ServerContext.IsInitialized ? ServerContext.GetService<IGameUnlockStateDataController>() : null;
-                if (_cachedUnlockState != null &&
-                    _cachedUnlockState.MachineRecipeUnlockStateInfos.TryGetValue(recipe.MachineRecipeGuid, out var info) &&
-                    !info.IsUnlocked)
-                {
-                    recipe = null;
-                    return false;
-                }
-            }
-
-            return found;
+            return MasterHolder.MachineRecipesMaster.TryGetRecipeElement(blockId, itemIds, fluidIds, out recipe);
         }
         
         public static bool RecipeConfirmation(

--- a/moorestech_server/Assets/Scripts/Game.Block/Factory/BlockTemplate/BlockTemplateUtil.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Factory/BlockTemplate/BlockTemplateUtil.cs
@@ -10,6 +10,7 @@ using Game.Block.Event;
 using Game.Block.Interface;
 using Game.Block.Interface.Component;
 using Game.Context;
+using Game.UnlockState;
 using Mooresmaster.Model.BlocksModule;
 using Mooresmaster.Model.InventoryConnectsModule;
 using Newtonsoft.Json;
@@ -52,7 +53,8 @@ namespace Game.Block.Factory.BlockTemplate
                 inputTankCount,
                 innerTankCapacity,
                 blockInventoryUpdateEvent,
-                blockInstanceId
+                blockInstanceId,
+                ServerContext.GetService<IGameUnlockStateDataController>()
             );
             
             var output = new VanillaMachineOutputInventory(

--- a/moorestech_server/Assets/Scripts/Game.Block/Game.Block.asmdef
+++ b/moorestech_server/Assets/Scripts/Game.Block/Game.Block.asmdef
@@ -21,7 +21,8 @@
         "Core.Master",
         "Game.Fluid",
         "Server.Util",
-        "ClassLibrary"
+        "ClassLibrary",
+        "Game.UnlockState"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/moorestech_server/Assets/Scripts/Game.UnlockState/GameUnlockStateDatastoreController.cs
+++ b/moorestech_server/Assets/Scripts/Game.UnlockState/GameUnlockStateDatastoreController.cs
@@ -44,6 +44,17 @@ namespace Game.UnlockState
                     _challengeCategoryUnlockStateInfos.Add(guid, new ChallengeCategoryUnlockStateInfo(guid, challenge.InitialUnlocked));
                 }
             }
+
+            // 機械レシピのアンロック状態を初期化
+            // Initialize machine recipe unlock states
+            foreach (var machineRecipe in MasterHolder.MachineRecipesMaster.MachineRecipes.Data)
+            {
+                var guid = machineRecipe.MachineRecipeGuid;
+                if (!MachineRecipeUnlockStateInfos.ContainsKey(guid))
+                {
+                    _machineRecipeUnlockStateInfos.Add(guid, new MachineRecipeUnlockStateInfo(guid, machineRecipe.InitialUnlocked));
+                }
+            }
         }
         
         
@@ -86,8 +97,25 @@ namespace Game.UnlockState
             ChallengeCategoryUnlockStateInfos[categoryGuid].Unlock();
             _onUnlockChallengeCategory.OnNext(categoryGuid);
         }
-        
-        
+
+
+        public IObservable<Guid> OnUnlockMachineRecipe => _onUnlockMachineRecipe;
+        public IReadOnlyDictionary<Guid, MachineRecipeUnlockStateInfo> MachineRecipeUnlockStateInfos => _machineRecipeUnlockStateInfos;
+
+        private readonly Subject<Guid> _onUnlockMachineRecipe = new();
+        private readonly Dictionary<Guid, MachineRecipeUnlockStateInfo> _machineRecipeUnlockStateInfos = new();
+        public void UnlockMachineRecipe(Guid machineRecipeGuid)
+        {
+            if (!MachineRecipeUnlockStateInfos.ContainsKey(machineRecipeGuid))
+            {
+                Debug.LogError($"[UnlockMachineRecipe] Machine recipe not found: {machineRecipeGuid}");
+                return;
+            }
+            MachineRecipeUnlockStateInfos[machineRecipeGuid].Unlock();
+            _onUnlockMachineRecipe.OnNext(machineRecipeGuid);
+        }
+
+
         #region SaveLoad
         
         public void LoadUnlockState(GameUnlockStateJsonObject stateJsonObject)
@@ -95,9 +123,10 @@ namespace Game.UnlockState
             LoadRecipeUnlockStateInfos();
             LoadItemUnlockStateInfos();
             LoadChallengeCategoryUnlockStateInfos();
-            
+            LoadMachineRecipeUnlockStateInfos();
+
             #region Internal
-            
+
             void LoadRecipeUnlockStateInfos()
             {
                 foreach (var recipeUnlockStateInfo in stateJsonObject.CraftRecipeUnlockStateInfos)
@@ -106,14 +135,15 @@ namespace Game.UnlockState
                     _recipeUnlockStateInfos[recipeGuid] = new CraftRecipeUnlockStateInfo(recipeUnlockStateInfo);
                 }
             }
-            
+
             void LoadItemUnlockStateInfos()
             {
                 foreach (var itemUnlockStateInfo in stateJsonObject.ItemUnlockStateInfos)
                 {
                     // マスタに存在しないアイテムはスキップ
+                    // Skip items that don't exist in master
                     if (!MasterHolder.ItemMaster.ExistItemId(Guid.Parse(itemUnlockStateInfo.ItemGuid))) continue;
-                    
+
                     var state = new ItemUnlockStateInfo(itemUnlockStateInfo);
                     _itemUnlockStateInfos[state.ItemId] = state;
                 }
@@ -127,7 +157,17 @@ namespace Game.UnlockState
                     _challengeCategoryUnlockStateInfos[state.ChallengeCategoryGuid] = state;
                 }
             }
-            
+
+            void LoadMachineRecipeUnlockStateInfos()
+            {
+                if (stateJsonObject.MachineRecipeUnlockStateInfos == null) return;
+                foreach (var machineRecipeUnlockStateInfo in stateJsonObject.MachineRecipeUnlockStateInfos)
+                {
+                    var state = new MachineRecipeUnlockStateInfo(machineRecipeUnlockStateInfo);
+                    _machineRecipeUnlockStateInfos[state.MachineRecipeGuid] = state;
+                }
+            }
+
             #endregion
         }
         
@@ -136,11 +176,13 @@ namespace Game.UnlockState
             var recipeUnlockStateInfos = CraftRecipeUnlockStateInfos.Values.Select(r => new CraftRecipeUnlockStateInfoJsonObject(r)).ToList();
             var itemUnlockStateInfos = ItemUnlockStateInfos.Values.Select(i => new ItemUnlockStateInfoJsonObject(i)).ToList();
             var challengeUnlockStateInfos = ChallengeCategoryUnlockStateInfos.Values.Select(c => new ChallengeUnlockStateInfoJsonObject(c)).ToList();
+            var machineRecipeUnlockStateInfos = MachineRecipeUnlockStateInfos.Values.Select(m => new MachineRecipeUnlockStateInfoJsonObject(m)).ToList();
             return new GameUnlockStateJsonObject
             {
                 CraftRecipeUnlockStateInfos = recipeUnlockStateInfos,
                 ItemUnlockStateInfos = itemUnlockStateInfos,
-                ChallengeCategoryUnlockStateInfos = challengeUnlockStateInfos, // Added for challenge unlock
+                ChallengeCategoryUnlockStateInfos = challengeUnlockStateInfos,
+                MachineRecipeUnlockStateInfos = machineRecipeUnlockStateInfos,
             };
         }
         
@@ -152,5 +194,6 @@ namespace Game.UnlockState
         [JsonProperty("craftRecipeUnlockStateInfos")] public List<CraftRecipeUnlockStateInfoJsonObject> CraftRecipeUnlockStateInfos;
         [JsonProperty("itemUnlockStateInfos")] public List<ItemUnlockStateInfoJsonObject> ItemUnlockStateInfos;
         [JsonProperty("challengeCategoryUnlockStateInfos")] public List<ChallengeUnlockStateInfoJsonObject> ChallengeCategoryUnlockStateInfos;
+        [JsonProperty("machineRecipeUnlockStateInfos")] public List<MachineRecipeUnlockStateInfoJsonObject> MachineRecipeUnlockStateInfos;
     }
 }

--- a/moorestech_server/Assets/Scripts/Game.UnlockState/GameUnlockStateDatastoreController.cs
+++ b/moorestech_server/Assets/Scripts/Game.UnlockState/GameUnlockStateDatastoreController.cs
@@ -124,6 +124,7 @@ namespace Game.UnlockState
             LoadItemUnlockStateInfos();
             LoadChallengeCategoryUnlockStateInfos();
             LoadMachineRecipeUnlockStateInfos();
+            BackfillMachineRecipeUnlockStateInfos();
 
             #region Internal
 
@@ -165,6 +166,19 @@ namespace Game.UnlockState
                 {
                     var state = new MachineRecipeUnlockStateInfo(machineRecipeUnlockStateInfo);
                     _machineRecipeUnlockStateInfos[state.MachineRecipeGuid] = state;
+                }
+            }
+
+            void BackfillMachineRecipeUnlockStateInfos()
+            {
+                foreach (var machineRecipe in MasterHolder.MachineRecipesMaster.MachineRecipes.Data)
+                {
+                    var guid = machineRecipe.MachineRecipeGuid;
+                    if (MachineRecipeUnlockStateInfos.ContainsKey(guid)) continue;
+
+                    // セーブに存在しない機械レシピはマスタ定義から補完する
+                    // Backfill machine recipes missing from saved unlock state
+                    _machineRecipeUnlockStateInfos.Add(guid, new MachineRecipeUnlockStateInfo(guid, machineRecipe.InitialUnlocked));
                 }
             }
 

--- a/moorestech_server/Assets/Scripts/Game.UnlockState/IGameUnlockStateDatastoreController.cs
+++ b/moorestech_server/Assets/Scripts/Game.UnlockState/IGameUnlockStateDatastoreController.cs
@@ -17,6 +17,7 @@ namespace Game.UnlockState
         public IReadOnlyDictionary<Guid, CraftRecipeUnlockStateInfo> CraftRecipeUnlockStateInfos { get; }
         public IReadOnlyDictionary<ItemId, ItemUnlockStateInfo> ItemUnlockStateInfos { get; }
         public IReadOnlyDictionary<Guid, ChallengeCategoryUnlockStateInfo> ChallengeCategoryUnlockStateInfos { get; }
+        public IReadOnlyDictionary<Guid, MachineRecipeUnlockStateInfo> MachineRecipeUnlockStateInfos { get; }
     }
     
     /// <summary>
@@ -34,8 +35,11 @@ namespace Game.UnlockState
         public IObservable<ItemId> OnUnlockItem { get; }
         void UnlockItem(ItemId itemId);
 
-        public IObservable<Guid> OnUnlockChallengeCategory { get; } // Added for challenge unlock
-        void UnlockChallenge(Guid categoryGuid); // Added for challenge unlock
+        public IObservable<Guid> OnUnlockChallengeCategory { get; }
+        void UnlockChallenge(Guid categoryGuid);
+
+        public IObservable<Guid> OnUnlockMachineRecipe { get; }
+        void UnlockMachineRecipe(Guid machineRecipeGuid);
         
         void LoadUnlockState(GameUnlockStateJsonObject stateJsonObject);
         GameUnlockStateJsonObject GetSaveJsonObject();

--- a/moorestech_server/Assets/Scripts/Game.UnlockState/States/MachineRecipeUnlockStateInfo.cs
+++ b/moorestech_server/Assets/Scripts/Game.UnlockState/States/MachineRecipeUnlockStateInfo.cs
@@ -1,0 +1,43 @@
+using System;
+using Newtonsoft.Json;
+
+namespace Game.UnlockState.States
+{
+    public class MachineRecipeUnlockStateInfo
+    {
+        public Guid MachineRecipeGuid { get; }
+        public bool IsUnlocked { get; private set; }
+
+        public MachineRecipeUnlockStateInfo(Guid machineRecipeGuid, bool isUnlocked)
+        {
+            MachineRecipeGuid = machineRecipeGuid;
+            IsUnlocked = isUnlocked;
+        }
+
+        public MachineRecipeUnlockStateInfo(MachineRecipeUnlockStateInfoJsonObject jsonObject)
+        {
+            MachineRecipeGuid = Guid.Parse(jsonObject.MachineRecipeGuid);
+            IsUnlocked = jsonObject.IsUnlocked;
+        }
+
+
+        public void Unlock()
+        {
+            IsUnlocked = true;
+        }
+    }
+
+    public class MachineRecipeUnlockStateInfoJsonObject
+    {
+        [JsonProperty("guid")] public string MachineRecipeGuid;
+        [JsonProperty("isUnlocked")] public bool IsUnlocked;
+
+        public MachineRecipeUnlockStateInfoJsonObject() { }
+
+        public MachineRecipeUnlockStateInfoJsonObject(MachineRecipeUnlockStateInfo machineRecipeUnlockStateInfo)
+        {
+            MachineRecipeGuid = machineRecipeUnlockStateInfo.MachineRecipeGuid.ToString();
+            IsUnlocked = machineRecipeUnlockStateInfo.IsUnlocked;
+        }
+    }
+}

--- a/moorestech_server/Assets/Scripts/Game.UnlockState/States/MachineRecipeUnlockStateInfo.cs.meta
+++ b/moorestech_server/Assets/Scripts/Game.UnlockState/States/MachineRecipeUnlockStateInfo.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5cbc5fbef72c74253b794d36159eda64

--- a/moorestech_server/Assets/Scripts/Server.Event/EventReceive/UnlockedEventPacket.cs
+++ b/moorestech_server/Assets/Scripts/Server.Event/EventReceive/UnlockedEventPacket.cs
@@ -62,19 +62,19 @@ namespace Server.Event.EventReceive
             UnlockedItemIdInt = (int)itemId;
         }
         
-        public UnlockEventMessagePack(UnlockEventType unlockEventType,Guid unlockedChallengeCategoryGuid)
+        public UnlockEventMessagePack(UnlockEventType unlockEventType, Guid guid)
         {
             UnlockEventTypeInt = (int)unlockEventType;
             switch (unlockEventType)
             {
                 case UnlockEventType.ChallengeCategory:
-                    UnlockedChallengeCategoryGuidStr = unlockedChallengeCategoryGuid.ToString();
+                    UnlockedChallengeCategoryGuidStr = guid.ToString();
                     break;
                 case UnlockEventType.CraftRecipe:
-                    UnlockedCraftRecipeGuidStr = unlockedChallengeCategoryGuid.ToString();
+                    UnlockedCraftRecipeGuidStr = guid.ToString();
                     break;
                 case UnlockEventType.MachineRecipe:
-                    UnlockedMachineRecipeGuidStr = unlockedChallengeCategoryGuid.ToString();
+                    UnlockedMachineRecipeGuidStr = guid.ToString();
                     break;
             }
         }

--- a/moorestech_server/Assets/Scripts/Server.Event/EventReceive/UnlockedEventPacket.cs
+++ b/moorestech_server/Assets/Scripts/Server.Event/EventReceive/UnlockedEventPacket.cs
@@ -22,9 +22,10 @@ namespace Server.Event.EventReceive
         {
             _eventProtocolProvider = eventProtocolProvider;
             
-            unlockState.OnUnlockCraftRecipe.Subscribe(c => AddBroadcastEvent(new UnlockEventMessagePack(UnlockEventType.CraftRecipe ,c)));
+            unlockState.OnUnlockCraftRecipe.Subscribe(c => AddBroadcastEvent(new UnlockEventMessagePack(UnlockEventType.CraftRecipe, c)));
             unlockState.OnUnlockItem.Subscribe(i => AddBroadcastEvent(new UnlockEventMessagePack(i)));
-            unlockState.OnUnlockChallengeCategory.Subscribe(c => AddBroadcastEvent(new UnlockEventMessagePack(UnlockEventType.ChallengeCategory ,c)));
+            unlockState.OnUnlockChallengeCategory.Subscribe(c => AddBroadcastEvent(new UnlockEventMessagePack(UnlockEventType.ChallengeCategory, c)));
+            unlockState.OnUnlockMachineRecipe.Subscribe(m => AddBroadcastEvent(new UnlockEventMessagePack(UnlockEventType.MachineRecipe, m)));
         }
         
         private void AddBroadcastEvent(UnlockEventMessagePack unlockEventMessagePack)
@@ -42,11 +43,13 @@ namespace Server.Event.EventReceive
         [IgnoreMember] public Guid UnlockedCraftRecipeGuid => Guid.Parse(UnlockedCraftRecipeGuidStr);
         [IgnoreMember] public ItemId UnlockedItemId => new(UnlockedItemIdInt);
         [IgnoreMember] public Guid UnlockedChallengeCategoryGuid => Guid.Parse(UnlockedChallengeCategoryGuidStr);
-        
+        [IgnoreMember] public Guid UnlockedMachineRecipeGuid => Guid.Parse(UnlockedMachineRecipeGuidStr);
+
         [Key(0)] public int UnlockEventTypeInt { get; set; }
         [Key(1)] public string UnlockedCraftRecipeGuidStr { get; set; }
-        [Key(2)] public int UnlockedItemIdInt { get; set; } 
+        [Key(2)] public int UnlockedItemIdInt { get; set; }
         [Key(3)] public string UnlockedChallengeCategoryGuidStr { get; set; }
+        [Key(4)] public string UnlockedMachineRecipeGuidStr { get; set; }
         
         
         
@@ -70,14 +73,18 @@ namespace Server.Event.EventReceive
                 case UnlockEventType.CraftRecipe:
                     UnlockedCraftRecipeGuidStr = unlockedChallengeCategoryGuid.ToString();
                     break;
+                case UnlockEventType.MachineRecipe:
+                    UnlockedMachineRecipeGuidStr = unlockedChallengeCategoryGuid.ToString();
+                    break;
             }
         }
     }
-    
+
     public enum UnlockEventType
     {
         CraftRecipe,
         Item,
-        ChallengeCategory
+        ChallengeCategory,
+        MachineRecipe,
     }
 }

--- a/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/GetGameUnlockStateProtocol.cs
+++ b/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/GetGameUnlockStateProtocol.cs
@@ -67,8 +67,27 @@ namespace Server.Protocol.PacketResponse
                 }
             }
             
-            // Pass challenge unlock states to the constructor
-            return new ResponseGameUnlockStateProtocolMessagePack(unlockedCraftRecipe, lockedCraftRecipe, lockedItem, unlockedItem, lockedChallengeCategory, unlockedChallengeCategory);
+            // 機械レシピのアンロック状態を取得
+            // Get machine recipe unlock states
+            var lockedMachineRecipe = new List<string>();
+            var unlockedMachineRecipe = new List<string>();
+            foreach (var machineRecipe in gameUnlockStateData.MachineRecipeUnlockStateInfos.Values)
+            {
+                if (machineRecipe.IsUnlocked)
+                {
+                    unlockedMachineRecipe.Add(machineRecipe.MachineRecipeGuid.ToString());
+                }
+                else
+                {
+                    lockedMachineRecipe.Add(machineRecipe.MachineRecipeGuid.ToString());
+                }
+            }
+
+            return new ResponseGameUnlockStateProtocolMessagePack(
+                unlockedCraftRecipe, lockedCraftRecipe,
+                lockedItem, unlockedItem,
+                lockedChallengeCategory, unlockedChallengeCategory,
+                lockedMachineRecipe, unlockedMachineRecipe);
         }
         
         
@@ -90,31 +109,39 @@ namespace Server.Protocol.PacketResponse
             [IgnoreMember] public List<ItemId> LockedItemIds => LockedItemIdsInt.Select(i => new ItemId(i)).ToList();
             [IgnoreMember] public List<Guid> UnlockedCategoryChallengeGuids => UnlockedChallengeCategoryGuidsStr.Select(Guid.Parse).ToList();
             [IgnoreMember] public List<Guid> LockedCategoryChallengeGuids => LockedChallengeCategoryGuidsStr.Select(Guid.Parse).ToList();
-            
+            [IgnoreMember] public List<Guid> UnlockedMachineRecipeGuids => UnlockedMachineRecipeGuidsStr.Select(Guid.Parse).ToList();
+            [IgnoreMember] public List<Guid> LockedMachineRecipeGuids => LockedMachineRecipeGuidsStr.Select(Guid.Parse).ToList();
+
             [Key(2)] public List<string> UnlockedCraftRecipeGuidsStr { get; set; }
             [Key(3)] public List<string> LockedCraftRecipeGuidsStr { get; set; }
-            
+
             [Key(4)] public List<int> LockedItemIdsInt { get; set; }
             [Key(5)] public List<int> UnlockedItemIdsInt { get; set; }
 
             [Key(6)] public List<string> LockedChallengeCategoryGuidsStr { get; set; }
             [Key(7)] public List<string> UnlockedChallengeCategoryGuidsStr { get; set; }
-            
-            
+
+            [Key(8)] public List<string> LockedMachineRecipeGuidsStr { get; set; }
+            [Key(9)] public List<string> UnlockedMachineRecipeGuidsStr { get; set; }
+
+
             [Obsolete("デシリアライズ用のコンストラクタです。基本的に使用しないでください。")]
             public ResponseGameUnlockStateProtocolMessagePack() { }
             public ResponseGameUnlockStateProtocolMessagePack(
                 List<string> unlockedCraftRecipeGuidsStr, List<string> lockedCraftRecipeGuidsStr,
                 List<int> lockedItemIds, List<int> unlockedItemIds,
-                List<string> lockedChallengeCategoryGuidsStr, List<string> unlockedChallengeCategoryGuidsStr) // Added challenge parameters
+                List<string> lockedChallengeCategoryGuidsStr, List<string> unlockedChallengeCategoryGuidsStr,
+                List<string> lockedMachineRecipeGuidsStr, List<string> unlockedMachineRecipeGuidsStr)
             {
                 Tag = ProtocolTag;
                 UnlockedCraftRecipeGuidsStr = unlockedCraftRecipeGuidsStr;
                 LockedCraftRecipeGuidsStr = lockedCraftRecipeGuidsStr;
                 LockedItemIdsInt = lockedItemIds;
                 UnlockedItemIdsInt = unlockedItemIds;
-                LockedChallengeCategoryGuidsStr = lockedChallengeCategoryGuidsStr; // Added assignment
-                UnlockedChallengeCategoryGuidsStr = unlockedChallengeCategoryGuidsStr; // Added assignment
+                LockedChallengeCategoryGuidsStr = lockedChallengeCategoryGuidsStr;
+                UnlockedChallengeCategoryGuidsStr = unlockedChallengeCategoryGuidsStr;
+                LockedMachineRecipeGuidsStr = lockedMachineRecipeGuidsStr;
+                UnlockedMachineRecipeGuidsStr = unlockedMachineRecipeGuidsStr;
             }
         }
     }

--- a/moorestech_server/Assets/Scripts/Tests.Module/TestMod/ForUnitTest/mods/forUnitTest/master/machineRecipes.json
+++ b/moorestech_server/Assets/Scripts/Tests.Module/TestMod/ForUnitTest/mods/forUnitTest/master/machineRecipes.json
@@ -3,6 +3,7 @@
     {
       "time": 1.5,
       "blockGuid": "00000000-0000-0000-0000-000000000001",
+      "initialUnlocked": true,
       "inputItems": [
         {
           "count": 3,
@@ -27,6 +28,7 @@
     {
       "time": 1.5,
       "blockGuid": "00000000-0000-0000-0000-000000000002",
+      "initialUnlocked": true,
       "inputItems": [
         {
           "count": 3,
@@ -51,6 +53,7 @@
     {
       "time": 1.5,
       "blockGuid": "00000000-0000-0000-0000-000000000003",
+      "initialUnlocked": true,
       "inputItems": [
         {
           "count": 2,
@@ -79,6 +82,7 @@
     {
       "time": 1.5,
       "blockGuid": "00000000-0000-0000-0000-00000000000f",
+      "initialUnlocked": true,
       "inputItems": [
         {
           "count": 3,
@@ -103,6 +107,7 @@
     {
       "time": 1.5,
       "blockGuid": "00000000-0000-0000-0000-000000000019",
+      "initialUnlocked": true,
       "inputItems": [
         {
           "count": 3,
@@ -127,6 +132,7 @@
     {
       "time": 1.5,
       "blockGuid": "00000000-0000-0000-0000-00000000001a",
+      "initialUnlocked": true,
       "inputItems": [
         {
           "count": 3,
@@ -151,6 +157,7 @@
     {
       "time": 1.5,
       "blockGuid": "00000000-0000-0000-0000-00000000001b",
+      "initialUnlocked": true,
       "inputItems": [
         {
           "count": 2,
@@ -184,6 +191,7 @@
     {
       "time": 1,
       "blockGuid": "00000000-0000-0000-0000-000000000019",
+      "initialUnlocked": true,
       "inputItems": [
         {
           "count": 2,
@@ -208,6 +216,7 @@
     },
     {
       "machineRecipeGuid": "38dfacce-1234-4612-8c7c-29112c12409a",
+      "initialUnlocked": false,
       "time": 1,
       "inputItems": [
         {

--- a/moorestech_server/Assets/Scripts/Tests.Module/TestMod/ForUnitTestMachineRecipeId.cs
+++ b/moorestech_server/Assets/Scripts/Tests.Module/TestMod/ForUnitTestMachineRecipeId.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Tests.Module.TestMod
+{
+    public class ForUnitTestMachineRecipeId
+    {
+        public static readonly Guid UnlockedMachineRecipe = new("f79c7ee0-1ebe-4fcc-b1ec-5bcb296d9c1a");
+        public static readonly Guid LockedMachineRecipe = new("38dfacce-1234-4612-8c7c-29112c12409a");
+    }
+}

--- a/moorestech_server/Assets/Scripts/Tests.Module/TestMod/ForUnitTestMachineRecipeId.cs.meta
+++ b/moorestech_server/Assets/Scripts/Tests.Module/TestMod/ForUnitTestMachineRecipeId.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7f265c127307e46febb5e9bf671e3e9c

--- a/moorestech_server/Assets/Scripts/Tests/UnitTest/Game/SaveLoad/FluidMachineSaveLoadTest.cs
+++ b/moorestech_server/Assets/Scripts/Tests/UnitTest/Game/SaveLoad/FluidMachineSaveLoadTest.cs
@@ -10,6 +10,7 @@ using Game.Fluid;
 using Game.PlayerInventory;
 using Game.SaveLoad.Interface;
 using Game.SaveLoad.Json;
+using Game.UnlockState;
 using Game.World.Interface.DataStore;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
@@ -31,6 +32,11 @@ namespace Tests.UnitTest.Game.SaveLoad
             //機械の追加
             var (blockFactory, worldBlockDatastore, _, assembleSaveJsonText, _) = CreateBlockTestModule();
             var itemStackFactory = ServerContext.ItemStackFactory;
+
+            // ロック済みテストレシピを使うため明示的にアンロックする
+            // Unlock the locked test recipe before starting machine processing
+            var unlockState = ServerContext.GetService<IGameUnlockStateDataController>();
+            unlockState.UnlockMachineRecipe(ForUnitTestMachineRecipeId.LockedMachineRecipe);
             
             worldBlockDatastore.TryAddBlock(ForUnitTestModBlockId.FluidMachineId, new Vector3Int(0, 0), BlockDirection.North, Array.Empty<BlockCreateParam>(), out var machineBlock);
             var machineInventory = machineBlock.GetComponent<VanillaMachineBlockInventoryComponent>();


### PR DESCRIPTION
## Summary
- 機械レシピに `initialUnlocked` と `unlockMachineRecipe` gameAction を追加
- サーバー UnlockState、イベント、GetGameUnlockState、クライアント RecipeViewer に機械レシピのロック状態を反映
- 機械稼働・クラフトツリー・master validation がロック済み機械レシピを扱わないよう補強

## Test plan
- [x] `uloop compile --project-path ./moorestech_server --wait-for-domain-reload true`
- [x] `uloop run-tests --project-path ./moorestech_server --filter-type regex --filter-value "(GetGameUnlockStateProtocolTest|UnlockedEventPacketTest|ResearchDataStoreTest|MachineRecipeConfigTest|MasterValidation)"`

Generated with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Machine recipe unlocks: players can unlock machine recipes; unlocks persist, are included in initial game state, and emit unlock events.
  * Recipe viewer adds machine-recipe tabs and per-machine recipe lists.

* **Improvements**
  * Crafting and machine UIs now respect machine-recipe unlock state when listing and displaying items/recipes.
  * Validation and save/load for machine-recipe unlocks improved to prevent invalid references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->