### PR TITLE
fix(machine): CodeRabbitレビュー指摘対応（加工ステートクリア・負スロット拒否）

### DIFF
--- a/moorestech_server/Assets/Scripts/Game.Block/Blocks/Machine/Inventory/VanillaMachineBlockInventoryComponent.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Blocks/Machine/Inventory/VanillaMachineBlockInventoryComponent.cs
@@ -171,13 +171,21 @@ namespace Game.Block.Blocks.Machine.Inventory
         // Resolve a slot number to its sub-inventory and local index
         private (IVanillaMachineSubInventory subInventory, int localSlot) ResolveSlot(int slot)
         {
+            // 負のスロットは境界で弾き、ローカル番号が負になるのを防ぐ
+            // Reject negative slots at the boundary to avoid a negative local index
+            if (slot < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(slot), slot, "スロット番号が負の値です。 The slot number is negative.");
+            }
+
+            var requestedSlot = slot;
             foreach (var subInventory in _subInventories)
             {
                 if (slot < subInventory.Items.Count) return (subInventory, slot);
                 slot -= subInventory.Items.Count;
             }
 
-            throw new ArgumentOutOfRangeException(nameof(slot), slot, "スロット番号がインベントリサイズを超えています。 The slot number exceeds the inventory size.");
+            throw new ArgumentOutOfRangeException(nameof(slot), requestedSlot, "スロット番号がインベントリサイズを超えています。 The slot number exceeds the inventory size.");
         }
 
         public bool IsDestroy { get; private set; }

--- a/moorestech_server/Assets/Scripts/Game.Block/Blocks/Machine/State/ProcessingMachineProcessState.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Blocks/Machine/State/ProcessingMachineProcessState.cs
@@ -89,7 +89,13 @@ namespace Game.Block.Blocks.Machine.State
         {
             var outputs = _pendingOutputs ?? MachineOutputFactoryUtil.CreateRealizedOutputs(_recipe, _context.EffectComponent.AggregateCurrent());
             _context.OutputInventory.InsertOutputSlot(outputs, MachineOutputFactoryUtil.CreateFluidOutputs(_recipe));
+
+            // 加工情報をクリアしてIdleが古いレシピ/進捗を報告・保存しないようにする
+            // Clear the processing snapshot so idle does not report or serialize stale recipe/progress
             _pendingOutputs = null;
+            _recipe = null;
+            TotalTicks = 0;
+            RemainingTicks = 0;
         }
     }
 }


### PR DESCRIPTION
## Summary
PR #935 への CodeRabbit レビュー指摘のうち2件を対応。

- **加工完了時のステートクリア**: `ProcessingMachineProcessState.OnExit` で `_recipe` / `TotalTicks` / `RemainingTicks` をクリア。`_processingState` は使い回しインスタンスのため、完了後の Idle 中に古いレシピ・進捗（`processingRate=1.0`）を報告・保存してしまう問題を解消。
- **負スロットの境界拒否**: `VanillaMachineBlockInventoryComponent.ResolveSlot` で負のスロット番号を `ArgumentOutOfRangeException` で弾き、`(subInventory, -1)` を返して下流の `GetItem`/`SetItem`/`ReplaceItem` で不明瞭な例外になるのを防止。あわせて超過時の例外メッセージが減算済みの値でなく要求スロット値を報告するよう修正。

## Test plan
- [x] `uloop compile` でコンパイルが通ることを確認（エラー0）
- [x] 機械関連テスト30件全パス（MachineModuleSlot / QualityModuleOutput / MachineSaveLoad / GearMachineSaveLoad / FluidMachineSaveLoad / MachineModuleEffect）

🤖 Generated with [Claude Code](https://claude.com/claude-code)