### PR TITLE
設置プレビューの個数制限を選択中ホットバースロットの所持数で判定

### DIFF
--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/Common/CommonBlockPlaceSystem.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/Common/CommonBlockPlaceSystem.cs
@@ -10,6 +10,7 @@ using Client.Input;
 using Common.Debug;
 using Core.Master;
 using Game.Block.Interface;
+using Game.PlayerInventory.Interface;
 using Server.Protocol.PacketResponse;
 using UnityEngine;
 using UnityEngine.EventSystems;
@@ -198,9 +199,10 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.Common
 
             void MarkInsufficientItemPreviewsAsNotPlaceable()
             {
-                // インベントリ内の所持数を取得
-                // Get the total count of the holding item in inventory
-                var availableCount = _localPlayerInventory.GetMainInventoryItemCount(context.HoldingItemId);
+                // 設置は選択中ホットバースロット1枠からのみ消費されるため、その枠の所持数で判定する
+                // Placement consumes only from the selected hotbar slot, so judge by that slot's count
+                var holdingSlotIndex = PlayerInventoryConst.HotBarSlotToInventorySlot(context.CurrentSelectHotbarSlotIndex);
+                var availableCount = _localPlayerInventory[holdingSlotIndex].Count;
 
                 // 設置可能なブロック数をカウントし、所持数を超えたら設置不可にする
                 // Count placeable blocks and mark as not placeable when exceeding available count


### PR DESCRIPTION
## Summary
- ドラッグ連続設置時、所持数を超えた分のプレビューが赤く（設置不可）ならない不具合を修正
- 原因: 個数制限の判定に `GetMainInventoryItemCount`（メインインベントリ全スロット合計）を使っていたが、サーバーの設置処理（`PlaceBlockFromHotBarProtocol`）は選択中ホットバースロット1枠からのみ消費する。別スロットにも同じアイテムを所持していると `availableCount` が過大になり、制限が発動しなかった
- 修正: 選択中ホットバースロットの所持数（`_localPlayerInventory[HotBarSlotToInventorySlot(CurrentSelectHotbarSlotIndex)].Count`）で判定し、サーバーの消費挙動と一致させた

## Test plan
- [ ] 同じアイテムをホットバースロットとバックパックの両方に所持した状態で、ホットバーの所持数を超える長さをドラッグし、超過分のプレビューが赤くなることを確認
- [ ] ホットバーの所持数以内のドラッグでは全プレビューが正常に設置可能（赤くならない）ことを確認
- [ ] 実際にドラッグ設置を確定し、消費数とプレビュー表示が一致することを確認

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed block placement preview to correctly check available items in the selected hotbar slot instead of counting total inventory items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->