### PR TITLE
fix: 複数電力セグメントへ二重登録された機械の電力が0になる不具合を修正

### DIFF
--- a/.claude/skills/moorestech-save-migration/SKILL.md
+++ b/.claude/skills/moorestech-save-migration/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: moorestech-save-migration
+description: moorestech のセーブ(JSON)を、コード変更で変わった新シリアライズ形式へ安全に移行する。揮発int→GUID解決、MessagePack/flat→JSON変換、実ロード検証まで行う。Use When — 「セーブが旧形式でロードできない」「ブランチでセーブ形式が変わった」「save_N.json をマイグレーションして」「ロード時にNRE/JSONパースエラーが出る」「保存周りを変えたから既存セーブを直して」と言われた場合。
+---
+
+# moorestech Save Migration
+
+## 概要
+moorestech は開発フェーズのため、コード変更でセーブのシリアライズ形式を頻繁に破壊的変更する（AGENTS方針: 旧セーブ互換不要）。本スキルは、形式変更で読めなくなった既存セーブファイルを新形式へ一括移行する手順。**コード側に互換コードを足すのではなく、セーブファイルを変換する**方針。
+
+セーブ実体は `~/Library/Application Support/moorestech/saves/save_N.json`（mac、`GameSystemPaths.SaveFileDirectory`）。
+
+## 前提条件
+- Unity エディタが起動中で `uloop` が通ること（`uloop execute-dynamic-code --project-path ./moorestech_client`）。
+- 変換対象セーブを作成したのと**同じ mod**（通常 `../../moorestech_master/server_v8`、`ServerDirectory.GetDirectory()` が返す）。揮発 int id はこの mod のロード順で決まるため、別 mod だと id がズレて別アイテムに化ける。
+- Python3（標準ライブラリのみ。base64/struct/json）。
+- 変換前後の比較用に git の merge-base（ブランチ分岐点）が分かること。
+
+## 手順
+
+### Step 1: 全形式変更を diff で「網羅列挙」する（最重要・最初にやる）
+**クラッシュを1つずつ潰す方法は禁止。** ロードエラーは1ブロックで止まるので、直しても次が出るだけ。最初に変更された全セーブ形式を列挙する。
+
+```bash
+mb=$(git merge-base HEAD origin/master)
+git diff --name-only $mb..HEAD -- '***.cs' | while read f; do
+  git diff $mb..HEAD -- "$f" | grep -qiE "GetSaveState|LoadRailDirection|DeserializeObject|MessagePackSerializer|StateDetail|SaveJsonObject|componentStates|fluidId|itemId" && echo "$f"
+done
+```
+ヒットした各ファイルで「旧形式 → 新形式」を確定する。旧形式は **merge-base のコード**（`git show $mb:path`）と**実セーブの中身**の両方で、新形式は HEAD のセーブオブジェクトクラスで確認する。
+
+### Step 2: セーブ内の影響ブロック/状態を棚卸し
+対象セーブを Python で読み、各 `world[].state{}` のキー別件数と、`trainUnits` を集計。どの形式が何件あるか把握する（0件なら無視してよい）。旧形式の典型マーカー: 状態値内の `\"fluidId\":` `\"FluidId\":` `\"itemId\":`、base64文字列（`k`等で始まりJSONでない）。
+
+### Step 3: 揮発 id → GUID マップを「独立マスタ」から取得（Unity）
+**グローバル `MasterHolder` を使うな。** 実行中エディタには別の（テスト用）マスタが載っていることがあり、その場合 `ExistItemId(58)` が false を返し解決できない。`ServerDirectory.GetDirectory()` から v8 マスタを**独立にロード**して引く（グローバルに触れない）。`references/dump_id_maps.cs` を `uloop` で実行し、全 item/fluid の id→GUID と `DefaultContainerTypeConst` 定数を取得して `/tmp/id_maps.json` に保存する。
+
+### Step 4: 各新形式を実クラスから確認
+変換先は**ゲームの実シリアライザ出力を正確に模倣**する。新セーブオブジェクトクラスを Read し、`[JsonProperty]` のキー名を厳密に合わせる（順序は不問、キー名は厳密）。代表例:
+- `FluidContainerSaveJsonObject` → `{"fluidGuid":"<g>","amount":<double>}`（capacity は持たない＝ロード時に master から取得）
+- `ItemStackSaveJsonObject` → `{"itemGuid":"<g>","count":<int>}`（空は Guid.Empty / count 0）
+- 揮発 id 0（空）→ GUID は `00000000-0000-0000-0000-000000000000`
+
+### Step 5: Python で実変換（backup → 変換 → 安全スキャン → 書き戻し）
+`references/migrate_save_template.py` をベースに、Step 1 で列挙した形式ごとの変換関数を実装。必ず:
+1. 変換前にタイムスタンプ付きバックアップディレクトリへコピー。
+2. 解決できない id があれば**中断**（`ExistItemId` 相当: マップに無ければ abort）。mod ズレの早期検出。
+3. **安全スキャン**: 変換後、全 `world[].state` 値が valid JSON か検査。非JSONが残れば未対応の base64/MessagePack 形式 → Step 1 の見落とし。
+4. 書き戻しは全体 re-dump（compact JSON）で可。C# は型でパースするため float 整形差は無害。
+
+### Step 6: 実ロードで検証（必須・「変換成功」≠「ロード可能」）
+**デシリアライズ単体の確認では不十分。** ゲーム起動と同じ経路でフルロードする。`references/load_test.cs` を `uloop` で実行（`MoorestechServerDIContainerGenerator.Create` → `IWorldSaveDataLoader.LoadOrInitialize()`）。`LOAD OK | blocks=N` が出れば成功。失敗時は例外メッセージで次の未対応形式が分かる → Step 1 へ戻り列挙を補強。
+さらに重要データ（列車インベントリ等）を `references/verify_loaded.cs` で実値確認し、サイレントなデータ欠損が無いか見る。
+
+### Step 7: 完了後
+ユーザーがゲームを起動してロードすると、以降は**純正の新形式で再セーブ**されるので移行は一度きり。逆に、検証ロード後にゲームが再セーブすると切り詰め等が確定するので注意（下記 Gotchas）。検証ロードはエディタの `ServerContext` にワールドを載せるため、**検証後は Unity 再起動を推奨**。
+
+## Gotchas
+- **クラッシュ駆動で直すな。** ロードは最初の失敗ブロックで止まる。Step 1 の diff 網羅列挙を先にやらないと、FuelGearGenerator を直したら次は Rail、と無限に出る（実際にそうなった）。
+- **「移行した」と言う前に必ず実ロード（Step 6）。** デシリアライズ単体テストだけで「完了」と報告するのは誤り。形式は他にも変わっている可能性がある。
+- **グローバル MasterHolder ≠ 対象 mod。** `loaded=false`（既ロード）で `missing:[58,79]`（解決不能）が出たら、別マスタが載っている。独立マスタ構築（Step 3）が必須。
+- **揮発 int は mod ロード順依存。** save 作成時と同じ mod でないと id が別アイテムに化ける。マップに無い id があれば中断する（黙って続行しない）。
+- **`uloop execute-dynamic-code` は `System.IO` 全面禁止**（File/Directory/**Path も**）。ファイル入出力は Python/bash 側で行う。スニペット内のパス連結は `Path.Combine` でなく文字列連結（`dir.EndsWith("/") ? dir+"mods" : dir+"/mods"`）。
+- **C# の char リテラル `'/'` はシェルの single quote と衝突**して壊れる。スニペットは一時 `.cs` ファイルに書き、`--code "$(cat file.cs)"` で渡す（ダブルクォート内コマンド置換は内容を再解釈しない）。大きな入力は base64 で埋め込む。
+- **base64-MessagePack 状態がある**（例 RailComponentStateDetail = `kZP...`）。`json.loads` が失敗する state は MessagePack。`[[x,y,z]]` 等を手デコードして JSON 化する。安全スキャン（Step 5-3）で取りこぼしを検出。
+- **コンテナのスロット数 > master.InventorySlots だとロード時に切り詰められデータ欠損**（旧 MessagePack は切り詰めず復元していた＝ブランチの新挙動）。変換ファイル自体は全スロット保持できるが、ロードで落ちる。事前検出してユーザーに警告し、master のスロット数修正で回避可能か確認する。
+- **マスタ参照値（capacity/スロット数）は新形式に含めない**。新シリアライザがそれらを出力しないので、模倣する変換も出力しない。ロード時に master から解決される。
+- **id 0（空）の GUID は `Guid.Empty`**（`GetItemGuid/GetFluidGuid(Empty*) == Guid.Empty`）。マップには 0 が無いので明示的に空 GUID を割り当てる。
+
+## Available scripts (references/)
+呼び出し時に Read して用途に合わせ調整する（対象 save 番号・形式関数は都度書き換え）。
+- `references/dump_id_maps.cs` — 独立 v8 マスタから item/fluid の id→GUID 全マップ＋定数を JSON で返す（Step 3）。`uloop execute-dynamic-code --project-path ./moorestech_client --code "$(cat ...)"`。
+- `references/migrate_save_template.py` — backup→形式別変換→安全スキャン→書き戻しの雛形（Step 5）。形式ごとの `t_*` 関数を実装して使う。
+- `references/load_test.cs` — DI フルロードで `LOAD OK | blocks=N` を確認（Step 6）。
+- `references/verify_loaded.cs` — ロード後の列車インベントリ等を実値ダンプし欠損検査（Step 6）。

--- a/.claude/skills/moorestech-save-migration/references/dump_id_maps.cs
+++ b/.claude/skills/moorestech-save-migration/references/dump_id_maps.cs
@@ -1,0 +1,32 @@
+// Step 3: 独立 v8 マスタから item/fluid の id->GUID 全マップ + 定数を取得する。
+// グローバル MasterHolder には触れない（別 mod が載っていることがあるため）。
+// 実行: uloop execute-dynamic-code --project-path ./moorestech_client --code "$(cat references/dump_id_maps.cs)"
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Core.Master;
+using Mooresmaster.Model.TrainModule;
+using Server.Boot;
+using Mod.Loader;
+using Mod.Config;
+
+var dir = ServerDirectory.GetDirectory();
+var modDir = dir.EndsWith("/") ? dir + "mods" : dir + "/mods";   // Path.Combine は uloop で禁止
+var container = new MasterJsonFileContainer(ModJsonStringLoader.GetMasterString(new ModsResource(modDir)));
+JToken Tok(string name) => (JToken)JsonConvert.DeserializeObject(container.ConfigJsons[0].JsonContents[new JsonFileName(name)]);
+
+var im = new ItemMaster(Tok("items")); im.Initialize();
+var fm = new FluidMaster(Tok("fluids")); fm.Initialize();
+
+var itemMap = new Dictionary<string,string>();
+foreach (var id in im.GetItemAllIds()) itemMap[id.AsPrimitive().ToString()] = im.GetItemGuid(id).ToString();
+var fluidMap = new Dictionary<string,string>();
+foreach (var fid in fm.GetAllFluidIds()) fluidMap[fid.AsPrimitive().ToString()] = fm.GetFluidGuid(fid).ToString();
+
+return JsonConvert.SerializeObject(new Dictionary<string,object>{
+    ["items"]=itemMap, ["fluids"]=fluidMap,
+    ["itemConst"]=TrainCarMasterElement.DefaultContainerTypeConst.Item,
+    ["fluidConst"]=TrainCarMasterElement.DefaultContainerTypeConst.Fluid,
+});
+// 結果 .Result(JSON文字列) を Python 側で /tmp/id_maps.json に保存して使う。

--- a/.claude/skills/moorestech-save-migration/references/load_test.cs
+++ b/.claude/skills/moorestech-save-migration/references/load_test.cs
@@ -1,0 +1,24 @@
+// Step 6: ゲーム起動と同じ経路でセーブをフルロードし、成否を返す。
+// 「変換成功」≠「ロード可能」。デシリアライズ単体ではなく必ずこれで検証する。
+// 失敗時は例外メッセージで次の未対応形式が分かる -> Step 1 の列挙を補強する。
+// 実行: uloop execute-dynamic-code --project-path ./moorestech_client --code "$(cat references/load_test.cs)"
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Server.Boot;
+using Game.SaveLoad.Interface;
+using Game.Context;
+
+try
+{
+    // DefaultSaveJsonFilePath が save_1.json を指す。別番号なら options.saveJsonFilePath を差し替える。
+    var options = new MoorestechServerDIContainerOptions(ServerDirectory.GetDirectory());
+    var (packet, sp) = new MoorestechServerDIContainerGenerator().Create(options);
+    sp.GetService<IWorldSaveDataLoader>().LoadOrInitialize();
+    return "LOAD OK | blocks=" + ServerContext.WorldBlockDatastore.BlockMasterDictionary.Count;
+}
+catch (Exception e)
+{
+    var inner = e.InnerException != null ? (" || INNER: " + e.InnerException.Message) : "";
+    return "LOAD FAILED: " + e.Message + inner;
+}
+// 注意: これはエディタの ServerContext にワールドを載せる。検証後は Unity 再起動推奨。

--- a/.claude/skills/moorestech-save-migration/references/migrate_save_template.py
+++ b/.claude/skills/moorestech-save-migration/references/migrate_save_template.py
@@ -1,0 +1,109 @@
+"""Step 5: moorestech セーブ移行の雛形。
+- /tmp/id_maps.json (dump_id_maps.cs の出力) を読む
+- 形式ごとの t_* 関数を「Step 1 で列挙した変更」に合わせて実装する（下記は実例）
+- backup -> 変換 -> 安全スキャン -> 書き戻し
+使い方: SAVE と stats 対象の形式関数を調整して python3 migrate_save_template.py
+"""
+import json, os, shutil, datetime, sys, base64, struct
+
+SAVE = os.path.expanduser("~/Library/Application Support/moorestech/saves/save_1.json")
+MAPS = json.load(open("/tmp/id_maps.json"))
+ITEM, FLUID = MAPS["items"], MAPS["fluids"]
+ITEM_CONST = MAPS.get("itemConst", "Item")
+EMPTY = "00000000-0000-0000-0000-000000000000"
+missing_items, missing_fluids = set(), set()
+
+def iguid(i):
+    i=int(i)
+    if i==0: return EMPTY
+    g=ITEM.get(str(i));  return g if g is not None else (missing_items.add(i) or None)
+def fguid(i):
+    i=int(i)
+    if i==0: return EMPTY
+    g=FLUID.get(str(i)); return g if g is not None else (missing_fluids.add(i) or None)
+
+stats={}
+def bump(k): stats[k]=stats.get(k,0)+1
+
+# ---- 形式別変換（Step 1 の列挙に合わせて足し引きする。以下は実例） ----
+def t_fuelgear_fluid(o):  # flat {FluidId,Amount,...} -> {Fluid:{fluidGuid,amount},...}
+    return {"Fluid":{"fluidGuid":fguid(o.get("FluidId",0)),"amount":o.get("Amount",0.0)},
+            "WasRefilledThisUpdate":o.get("WasRefilledThisUpdate",False),
+            "ConsecutiveUpdatesWithoutRefill":o.get("ConsecutiveUpdatesWithoutRefill",0),
+            "WasEverDisconnected":o.get("WasEverDisconnected",False)}
+def t_fluid_container(o):  # FluidPipe/Pump {fluidId,amount,capacity} -> {fluidGuid,amount}
+    return {"fluidGuid":fguid(o.get("fluidId",0)),"amount":o.get("amount",0.0)}
+def t_machine(o):          # inputFluidSlot/outputFluidSlot の {fluidId,amount} -> {fluidGuid,amount}
+    for s in ("inputFluidSlot","outputFluidSlot"):
+        if o.get(s): o[s]=[{"fluidGuid":fguid(x.get("fluidId",0)),"amount":x.get("amount",0.0)} for x in o[s]]
+    return o
+def t_gearchain(o):        # connections の itemId -> itemGuid
+    for c in o.get("connections",[]):
+        if "itemId" in c: c["itemGuid"]=iguid(c.pop("itemId"))
+    return o
+def t_trainplatform_item(o):  # MessagePack [[pairs]] -> {items:[{itemGuid,count}]}
+    return {"items":[{"itemGuid":iguid(p[0]),"count":p[1]} for p in o[0]]}
+
+def _mp(b,i):
+    t=b[i]; i+=1
+    if t==0xCA: return struct.unpack('>f',b[i:i+4])[0],i+4
+    if t==0xCB: return struct.unpack('>d',b[i:i+8])[0],i+8
+    if t==0xD2: return struct.unpack('>i',b[i:i+4])[0],i+4
+    if t<0x80:  return t,i
+    if t>=0xE0: return t-256,i
+    raise ValueError("msgpack tag %s"%hex(t))
+def t_rail(b64):           # base64 MessagePack [[x,y,z]] -> {"x","y","z"}
+    b=base64.b64decode(b64); i=2  # 0x91 array1, 0x93 array3
+    x,i=_mp(b,i); y,i=_mp(b,i); z,i=_mp(b,i)
+    return json.dumps({"x":x,"y":y,"z":z},separators=(",",":"),ensure_ascii=False)
+def t_train_container(v0):  # ["TypeName",[[id,count]...]] -> {"containerType","containerState"}
+    arr=json.loads(v0)
+    if "ItemTrainCarContainer" not in arr[0]: return None
+    items=[{"itemGuid":iguid(p[0]),"count":p[1]} for p in arr[1]]
+    state=json.dumps(items,separators=(",",":"),ensure_ascii=False)
+    return json.dumps({"containerType":ITEM_CONST,"containerState":state},separators=(",",":"),ensure_ascii=False)
+
+raw=open(SAVE,encoding="utf-8").read(); d=json.loads(raw)
+for b in d.get("world",[]):
+    st=b.get("state",{})
+    for k in list(st.keys()):
+        v=st[k]
+        if not isinstance(v,str): continue
+        if k.endswith("RailComponentStateDetailComponent"): st[k]=t_rail(v); bump("Rail"); continue
+        try: o=json.loads(v)
+        except Exception: continue
+        new=None
+        if   k=="fuelGearGeneratorFluid": new=t_fuelgear_fluid(o); bump("FuelGearFluid")
+        elif k.endswith("FluidPipeSaveComponent"): new=t_fluid_container(o); bump("FluidPipe")
+        elif k.endswith("PumpFluidOutputComponent"): new=t_fluid_container(o); bump("Pump")
+        elif k.endswith("VanillaMachineSaveComponent"):
+            if o.get("inputFluidSlot") or o.get("outputFluidSlot"): bump("MachineFluid")
+            new=t_machine(o)
+        elif k=="GearChainPoleComponent": new=t_gearchain(o); bump("GearChain")
+        elif k.endswith("TrainPlatformItemContainerComponent"): new=t_trainplatform_item(o); bump("PlatformItem")
+        if new is not None: st[k]=json.dumps(new,separators=(",",":"),ensure_ascii=False)
+
+for u in d.get("trainUnits",[]):
+    for c in u.get("Cars",[]):
+        cs=c.get("ContainerSaveData")
+        if isinstance(cs,str) and cs.strip().startswith("["):
+            nv=t_train_container(cs)
+            if nv is not None: c["ContainerSaveData"]=nv; bump("TrainCar")
+
+# 安全スキャン: 全 state 値が valid JSON でなければ未対応の base64/MessagePack 形式
+non_json={}
+for b in d.get("world",[]):
+    for k,v in b.get("state",{}).items():
+        if isinstance(v,str):
+            try: json.loads(v)
+            except Exception: non_json[k]=non_json.get(k,0)+1
+if non_json: print("WARNING unhandled non-JSON states:", non_json, file=sys.stderr)
+if missing_items or missing_fluids:
+    print("ABORT unresolved ids items=%s fluids=%s"%(sorted(missing_items),sorted(missing_fluids)),file=sys.stderr); sys.exit(1)
+
+print("planned:", stats)
+ts=datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+bdir=os.path.join(os.path.dirname(SAVE), f"Backup_{ts}_pre-migration"); os.makedirs(bdir,exist_ok=True)
+shutil.copy2(SAVE, os.path.join(bdir,os.path.basename(SAVE))); print("BACKUP ->",bdir)
+out=json.dumps(d,separators=(",",":"),ensure_ascii=False)
+open(SAVE,"w",encoding="utf-8").write(out); print("WROTE",SAVE,len(raw),"->",len(out))

--- a/.claude/skills/moorestech-save-migration/references/verify_loaded.cs
+++ b/.claude/skills/moorestech-save-migration/references/verify_loaded.cs
@@ -1,0 +1,35 @@
+// Step 6: ロード後の重要データ(列車インベントリ)を実値ダンプし、サイレントなデータ欠損を検査する。
+// 例: コンテナのスロット数 > master.InventorySlots だとロード時に切り詰められる -> ここで件数が減って見える。
+// 実行: uloop execute-dynamic-code --project-path ./moorestech_client --code "$(cat references/verify_loaded.cs)"
+using System;
+using System.Linq;
+using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+using Server.Boot;
+using Game.SaveLoad.Interface;
+using Game.Train.Unit;
+using Game.Train.Unit.Containers;
+using Core.Master;
+
+var options = new MoorestechServerDIContainerOptions(ServerDirectory.GetDirectory());
+var (packet, sp) = new MoorestechServerDIContainerGenerator().Create(options);
+sp.GetService<IWorldSaveDataLoader>().LoadOrInitialize();
+
+var sb = new StringBuilder();
+var trains = sp.GetService<ITrainUnitLookupDatastore>().GetRegisteredTrains();
+sb.Append("trains=" + trains.Count + "\n");
+foreach (var t in trains)
+    for (int ci = 0; ci < t.Cars.Count; ci++)
+    {
+        var car = t.Cars[ci];
+        if (car.Container is ItemTrainCarContainer item)
+        {
+            var items = item.InventoryItems;
+            var ne = items.Where(s => s.Id != ItemMaster.EmptyItemId)
+                          .GroupBy(s => s.Id.AsPrimitive())
+                          .Select(g => "id" + g.Key + "x" + g.Sum(s => s.Count) + "(" + g.Count() + "slots)");
+            sb.Append($"  car{ci}: slots={items.Count} total={items.Sum(s => s.Count)} | {string.Join(",", ne)}\n");
+        }
+        else sb.Append($"  car{ci}: {(car.Container == null ? "null" : car.Container.GetType().Name)}\n");
+    }
+return sb.ToString();

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/Electric/DisplayEnergizedRange.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/Electric/DisplayEnergizedRange.cs
@@ -90,13 +90,24 @@ namespace Client.Game.InGame.Electric
                     ? electricPoleParam.MachineConnectionHeightRange
                     : electricPoleParam.PoleConnectionHeightRange;
                 
-                var rangeObject = Instantiate(rangePrefab, electricalPole.transform.position, Quaternion.identity, transform);
+                // サーバの接続範囲ボックス(floor(range/2)起点)に合わせて中心をずらす。偶数は対称、奇数は+0.5セル
+                // Offset the center to match the server's connection box (anchored at floor(range/2)): even = symmetric, odd = +0.5 cell
+                var centerOffset = new Vector3(CellCenterOffset(horizontalRange), CellCenterOffset(heightRange), CellCenterOffset(horizontalRange));
+                var rangeObject = Instantiate(rangePrefab, electricalPole.transform.position + centerOffset, Quaternion.identity, transform);
                 rangeObject.SetRange(horizontalRange, heightRange);
                 rangeObjects.Add(rangeObject);
             }
             
             #region Internal
-            
+
+            // サーバの EnumerateRange は floor(range/2) を起点にするため、奇数レンジで中心が+0.5セルずれる
+            // Server's EnumerateRange anchors at floor(range/2), so the center shifts +0.5 cell for odd ranges
+            float CellCenterOffset(int range)
+            {
+                var clamped = Mathf.Max(range, 1);
+                return clamped / 2f - clamped / 2;
+            }
+
             (bool isElectricalBlock, bool isPole) IsDisplay()
             {
                 var hotBarSlot = _hotBarView.SelectIndex;

--- a/moorestech_server/Assets/Scripts/Game.Block/Blocks/Machine/State/MachineProcessContext.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Blocks/Machine/State/MachineProcessContext.cs
@@ -12,8 +12,10 @@ namespace Game.Block.Blocks.Machine.State
         public readonly MachineModuleEffectComponent EffectComponent;
         public readonly float RequestPower;
 
+        // このtickで各電力セグメントから供給された電力の加算器（次のUpdateでCurrentPowerへ確定）
+        // Accumulator of power supplied by each energy segment this tick (latched into CurrentPower on the next Update)
+        public float SuppliedPower;
         public float CurrentPower;
-        public bool UsedPower;
 
         public MachineProcessContext(
             VanillaMachineInputInventory inputInventory,

--- a/moorestech_server/Assets/Scripts/Game.Block/Blocks/Machine/State/ProcessingMachineProcessState.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Blocks/Machine/State/ProcessingMachineProcessState.cs
@@ -69,10 +69,6 @@ namespace Game.Block.Blocks.Machine.State
             var effectiveRequestPower = _context.RequestPower * _context.EffectComponent.AggregateCurrent().PowerMultiplier;
             var subTicks = MachineCurrentPowerToSubSecond.GetSubTicks(_context.CurrentPower, effectiveRequestPower);
 
-            // 電力を消費する
-            // Consume power
-            _context.UsedPower = true;
-
             // 残りtickを使い切ったら完了して待機へ
             // Once remaining ticks are exhausted, finish and return to idle
             if (subTicks >= RemainingTicks)

--- a/moorestech_server/Assets/Scripts/Game.Block/Blocks/Machine/VanillaMachineProcessorComponent.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Blocks/Machine/VanillaMachineProcessorComponent.cs
@@ -20,6 +20,7 @@ namespace Game.Block.Blocks.Machine
     {
         public Guid RecipeGuid => _processingState.RecipeGuid;
         public float RequestPower => _context.RequestPower;
+        public float CurrentPower => _context.CurrentPower;
         public ProcessState CurrentState { get; private set; }
 
         // 加工中のみモジュールの電力倍率を適用した要求電力
@@ -87,8 +88,10 @@ namespace Game.Block.Blocks.Machine
         public void SupplyPower(float power)
         {
             BlockException.CheckDestroy(this);
-            _context.UsedPower = false;
-            _context.CurrentPower = power;
+
+            // 複数の電力セグメントから供給され得るため加算する（発電機なしセグメントの0供給で打ち消されない）
+            // Accumulate since multiple energy segments may supply power (a generator-less segment's zero must not cancel it)
+            _context.SuppliedPower += power;
 
             // アイドル中はエネルギーの供給を受けてもその情報がクライアントに伝わらないため、明示的に通知を行う
             // During idle, even if energy is supplied, the information is not transmitted to the client, so the client is notified explicitly.
@@ -101,12 +104,12 @@ namespace Game.Block.Blocks.Machine
         public void Update()
         {
             BlockException.CheckDestroy(this);
-            if (_context.UsedPower)
-            {
-                _context.UsedPower = false;
-                _context.CurrentPower = 0f;
-            }
-            
+
+            // 直前tickで蓄積された供給電力を確定し、加算器をリセットする（未供給なら0になり電力を失う）
+            // Latch the power accumulated during the previous tick and reset the accumulator (no supply -> 0, power is lost)
+            _context.CurrentPower = _context.SuppliedPower;
+            _context.SuppliedPower = 0f;
+
             // ステートのアップデートと変更処理
             // State update and transition handling
             var current = CurrentState;

--- a/moorestech_server/Assets/Scripts/Tests/CombinedTest/Game/Energy.meta
+++ b/moorestech_server/Assets/Scripts/Tests/CombinedTest/Game/Energy.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1943f984ee38c450c87be0e24baeee17
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/moorestech_server/Assets/Scripts/Tests/CombinedTest/Game/Energy/MachineMultiSegmentPowerSupplyTest.cs
+++ b/moorestech_server/Assets/Scripts/Tests/CombinedTest/Game/Energy/MachineMultiSegmentPowerSupplyTest.cs
@@ -1,0 +1,66 @@
+using System;
+using Core.Update;
+using Game.Block.Blocks.Machine;
+using Game.Block.Interface;
+using Game.Block.Interface.Extension;
+using Game.Context;
+using Game.EnergySystem;
+using Game.World.Interface.DataStore;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Server.Boot;
+using Tests.Module;
+using Tests.Module.TestMod;
+using UnityEngine;
+using static Tests.Module.TestMod.ForUnitTestModBlockId;
+
+namespace Tests.CombinedTest.Game.Energy
+{
+    /// <summary>
+    ///     1つの機械が複数の電力セグメントに登録されたときの電力供給を検証する
+    ///     Verify power supply when a single machine is registered in multiple energy segments
+    /// </summary>
+    public class MachineMultiSegmentPowerSupplyTest
+    {
+        // 発電機なしセグメントの0供給が、発電機ありセグメントからの供給を打ち消さないこと
+        // A generator-less segment's zero supply must not cancel the supply from a segment that has a generator
+        [Test]
+        public void GeneratorlessSegmentDoesNotZeroOutSharedMachinePower()
+        {
+            var (_, serviceProvider) =
+                new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
+            var worldBlockDatastore = ServerContext.WorldBlockDatastore;
+
+            // 機械を設置（電柱を置かないので自動セグメント生成は発生しない）
+            // Place a machine (no pole placed, so no automatic segment is created)
+            worldBlockDatastore.TryAddBlock(MachineId, new Vector3Int(0, 0, 0), BlockDirection.North, Array.Empty<BlockCreateParam>(), out var machineBlock);
+            var consumer = machineBlock.GetComponent<IElectricConsumer>();
+            var processor = machineBlock.GetComponent<VanillaMachineProcessorComponent>();
+
+            Assert.Greater(processor.RequestPower, 0f, "テスト機械の要求電力が0だと検証が成立しない");
+
+            // 機械の要求電力を十分賄えるテスト用無限発電機を用意する
+            // Prepare an infinite test generator that fully covers the machine's request power
+            var generator = new TestElectricGenerator(new ElectricPower(processor.RequestPower * 10f), BlockInstanceId.Create());
+
+            var segmentDatastore = serviceProvider.GetService<IWorldEnergySegmentDatastore<EnergySegment>>();
+
+            // 機械を「発電機ありセグメント」と「発電機なしセグメント」の両方に登録（二重登録の再現）
+            // Register the machine into both a segment with a generator and one without (reproducing double-registration)
+            var segmentWithGenerator = segmentDatastore.CreateEnergySegment();
+            segmentWithGenerator.AddEnergyConsumer(consumer);
+            segmentWithGenerator.AddGenerator(generator);
+
+            var segmentWithoutGenerator = segmentDatastore.CreateEnergySegment();
+            segmentWithoutGenerator.AddEnergyConsumer(consumer);
+
+            // 数tick進めて供給を安定させる
+            // Advance several ticks to stabilize the supply
+            for (var i = 0; i < 3; i++) GameUpdater.UpdateOneTick();
+
+            // 発電機なしセグメントに打ち消されず、要求電力を受け取れている
+            // The machine receives its requested power without being zeroed by the generator-less segment
+            Assert.AreEqual(processor.RequestPower, processor.CurrentPower, 0.001f);
+        }
+    }
+}

--- a/moorestech_server/Assets/Scripts/Tests/CombinedTest/Game/Energy/MachineMultiSegmentPowerSupplyTest.cs.meta
+++ b/moorestech_server/Assets/Scripts/Tests/CombinedTest/Game/Energy/MachineMultiSegmentPowerSupplyTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8e29546fc2f1648228a7e9fab070746a


### PR DESCRIPTION
## Summary
- 複数の電力セグメントにまたがって登録された機械が、発電機なしセグメントの `SupplyEnergy(0)` で `CurrentPower` を上書きされ、受電できず電力0になる不具合を修正
- 電力供給を「上書き」から「tick単位の加算 (`SuppliedPower`)」へ変更し、`Update` で確定 (latch) する方式に変更。これにより機械は全グリッドから受電でき、発電機なしセグメントの0供給は無害化される
- レンジ表示が奇数接続レンジでサーバ実ボックスと0.5セルずれる不具合をクライアント側で補正
- セーブデータ移行スキル (`moorestech-save-migration`) のドキュメントを追加

## 変更ファイル
- `VanillaMachineProcessorComponent.cs` / `MachineProcessContext.cs` / `ProcessingMachineProcessState.cs` — 加算+latch方式への変更
- `DisplayEnergizedRange.cs` — レンジ表示の0.5セルずれ補正
- `MachineMultiSegmentPowerSupplyTest.cs` — マルチセグメント受電の回帰テストを追加
- `.claude/skills/moorestech-save-migration/` — セーブ移行スキル追加

## Test plan
- [ ] `MachineMultiSegmentPowerSupplyTest` がパスすることを確認
- [ ] 複数電力セグメントにまたがる機械が正常に受電・稼働することを実機確認
- [ ] エナジーレンジ表示がサーバの実ボックスと一致することを確認

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed energized range display positioning to align correctly with server connection-box rules
  * Fixed machines registered in multiple energy segments from losing power supply

<!-- end of auto-generated comment: release notes by coderabbit.ai -->