### PR TITLE
電力ネットワーク情報UIの追加と多重セグメント所属の発電機破壊クラッシュ修正

### DIFF
--- a/moorestech_client/Assets/AddressableAssetsData/AssetGroups/Vanilla Asset Group.asset
+++ b/moorestech_client/Assets/AddressableAssetsData/AssetGroups/Vanilla Asset Group.asset
@@ -300,6 +300,11 @@ MonoBehaviour:
     m_ReadOnly: 0
     m_SerializedLabels: []
     FlaggedDuringContentUpdateRestriction: 0
+  - m_GUID: 48a7a1a619bcd4536a545efbbdc542c1
+    m_Address: Vanilla/UI/Block/ElectricPoleNetworkInfoUI
+    m_ReadOnly: 0
+    m_SerializedLabels: []
+    FlaggedDuringContentUpdateRestriction: 0
   - m_GUID: 4936fc7b570875c42905898d5f044465
     m_Address: Vanilla/Block/Fast_BeltConveyor_Straight
     m_ReadOnly: 0

--- a/moorestech_client/Assets/AddressableResources/UI/Block/ElectricPoleNetworkInfoUI.prefab
+++ b/moorestech_client/Assets/AddressableResources/UI/Block/ElectricPoleNetworkInfoUI.prefab
@@ -1,0 +1,496 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1308607206707915815
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6451880443534005059}
+  - component: {fileID: 2921470421532164796}
+  - component: {fileID: 4420750878030519587}
+  m_Layer: 5
+  m_Name: Network
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6451880443534005059
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1308607206707915815}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 26803458160757691}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -51}
+  m_SizeDelta: {x: 1000, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2921470421532164796
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1308607206707915815}
+  m_CullTransparentMesh: 1
+--- !u!114 &4420750878030519587
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1308607206707915815}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\u3042\u3042"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: b3b0ca3429eb0904486caf858eef334c, type: 2}
+  m_sharedMaterial: {fileID: -3211518950372240753, guid: b3b0ca3429eb0904486caf858eef334c, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 32.2
+  m_fontSizeBase: 32.2
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &1812586253541505108
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7020099031125800959}
+  - component: {fileID: 5449242248343782283}
+  - component: {fileID: 1859358517845354161}
+  m_Layer: 5
+  m_Name: BackGround
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7020099031125800959
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1812586253541505108}
+  m_LocalRotation: {x: -0, y: -0, z: 1, w: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 26803458160757691}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 180}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 6}
+  m_SizeDelta: {x: 540, y: 500}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5449242248343782283
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1812586253541505108}
+  m_CullTransparentMesh: 1
+--- !u!114 &1859358517845354161
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1812586253541505108}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: ef4dc7a3ae6e84cf79f526bcc9d1b47c, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &2335504904658401526
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2315420709793197774}
+  - component: {fileID: 6577184343677556422}
+  - component: {fileID: 1985438224930440234}
+  m_Layer: 5
+  m_Name: Line
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2315420709793197774
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2335504904658401526}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 26803458160757691}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 175.80006}
+  m_SizeDelta: {x: 361.5, y: 13}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6577184343677556422
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2335504904658401526}
+  m_CullTransparentMesh: 1
+--- !u!114 &1985438224930440234
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2335504904658401526}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 9b2b55954051545d49e41e2bc6ae364c, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4092011391682610413
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6928691466599855772}
+  - component: {fileID: 3260359714116618692}
+  - component: {fileID: 1896569409975918612}
+  m_Layer: 5
+  m_Name: BlockName
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6928691466599855772
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4092011391682610413}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 26803458160757691}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 207}
+  m_SizeDelta: {x: 500, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3260359714116618692
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4092011391682610413}
+  m_CullTransparentMesh: 1
+--- !u!114 &1896569409975918612
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4092011391682610413}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'Test Block Name
+
+'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: b3b0ca3429eb0904486caf858eef334c, type: 2}
+  m_sharedMaterial: {fileID: -3211518950372240753, guid: b3b0ca3429eb0904486caf858eef334c, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 24
+  m_fontSizeBase: 24
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &6092283996810409271
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 26803458160757691}
+  - component: {fileID: 4616087526709497935}
+  - component: {fileID: 9127776460181591211}
+  m_Layer: 5
+  m_Name: ElectricPoleNetworkInfoUI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &26803458160757691
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6092283996810409271}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7020099031125800959}
+  - {fileID: 6928691466599855772}
+  - {fileID: 2315420709793197774}
+  - {fileID: 6451880443534005059}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &4616087526709497935
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6092283996810409271}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 695bbae2c2faf44febfa9fc869a19d06, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.UI.Inventory.Block.ElectricNetworkInfoView
+  networkInfoText: {fileID: 4420750878030519587}
+--- !u!114 &9127776460181591211
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6092283996810409271}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 63f40e0865e574e9eb01610961a4e94e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.UI.Inventory.Block.ElectricPoleNetworkInfoUIView
+  blockNameText: {fileID: 1896569409975918612}
+  electricNetworkInfoView: {fileID: 4616087526709497935}

--- a/moorestech_client/Assets/AddressableResources/UI/Block/ElectricPoleNetworkInfoUI.prefab.meta
+++ b/moorestech_client/Assets/AddressableResources/UI/Block/ElectricPoleNetworkInfoUI.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 48a7a1a619bcd4536a545efbbdc542c1
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/moorestech_client/Assets/AddressableResources/UI/Block/GeneratorBlockInventory.prefab
+++ b/moorestech_client/Assets/AddressableResources/UI/Block/GeneratorBlockInventory.prefab
@@ -255,6 +255,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -610,6 +611,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -643,6 +645,157 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &6706147954133609064
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6018131640840704457}
+  - component: {fileID: 5921431399322799547}
+  - component: {fileID: 8655589357056726394}
+  - component: {fileID: 1018177870057326602}
+  m_Layer: 0
+  m_Name: ElectricNetworkInfo
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6018131640840704457
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6706147954133609064}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2437450158571823896}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 66.7}
+  m_SizeDelta: {x: 1200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5921431399322799547
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6706147954133609064}
+  m_CullTransparentMesh: 1
+--- !u!114 &8655589357056726394
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6706147954133609064}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: b3b0ca3429eb0904486caf858eef334c, type: 2}
+  m_sharedMaterial: {fileID: -3211518950372240753, guid: b3b0ca3429eb0904486caf858eef334c, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: 0
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 24
+  m_fontSizeBase: 24
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &1018177870057326602
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6706147954133609064}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 695bbae2c2faf44febfa9fc869a19d06, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.UI.Inventory.Block.ElectricNetworkInfoView
+  networkInfoText: {fileID: 8655589357056726394}
 --- !u!1 &8175287640852664675
 GameObject:
   m_ObjectHideFlags: 0
@@ -678,6 +831,7 @@ RectTransform:
   - {fileID: 6127340325990191575}
   - {fileID: 8605921226189647354}
   - {fileID: 1790695690408942132}
+  - {fileID: 6018131640840704457}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -701,6 +855,7 @@ MonoBehaviour:
   blockName: {fileID: 7894937848752220741}
   operatingRateText: {fileID: 8580646972609167145}
   fuelProgressSlider: {fileID: 1324108307313379890}
+  electricNetworkInfoView: {fileID: 1018177870057326602}
 --- !u!1 &8191650548186524093
 GameObject:
   m_ObjectHideFlags: 0

--- a/moorestech_client/Assets/AddressableResources/UI/Block/MachineBlockInventory.prefab
+++ b/moorestech_client/Assets/AddressableResources/UI/Block/MachineBlockInventory.prefab
@@ -404,6 +404,157 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &2840332562338108246
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2494512905636250186}
+  - component: {fileID: 2058792715753030710}
+  - component: {fileID: 8683976929766957962}
+  - component: {fileID: 470165812891113218}
+  m_Layer: 0
+  m_Name: ElectricNetworkInfo
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2494512905636250186
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2840332562338108246}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 26803458160757691}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 95}
+  m_SizeDelta: {x: 1200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2058792715753030710
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2840332562338108246}
+  m_CullTransparentMesh: 1
+--- !u!114 &8683976929766957962
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2840332562338108246}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: b3b0ca3429eb0904486caf858eef334c, type: 2}
+  m_sharedMaterial: {fileID: -3211518950372240753, guid: b3b0ca3429eb0904486caf858eef334c, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: 0
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 24
+  m_fontSizeBase: 24
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &470165812891113218
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2840332562338108246}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 695bbae2c2faf44febfa9fc869a19d06, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Client.Game::Client.Game.InGame.UI.Inventory.Block.ElectricNetworkInfoView
+  networkInfoText: {fileID: 8683976929766957962}
 --- !u!1 &3823504605584633391
 GameObject:
   m_ObjectHideFlags: 0
@@ -910,6 +1061,7 @@ RectTransform:
   - {fileID: 8898992423655121602}
   - {fileID: 2451872257152769005}
   - {fileID: 6497425431080949710}
+  - {fileID: 2494512905636250186}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -938,6 +1090,7 @@ MonoBehaviour:
   powerRateText: {fileID: 3562878083436755205}
   machineProgressArrow: {fileID: 140989436986467170}
   machineRecipeCount: {fileID: 2038990741139630874}
+  electricNetworkInfoView: {fileID: 470165812891113218}
 --- !u!1 &6129189798529970233
 GameObject:
   m_ObjectHideFlags: 0

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Block/ElectricNetworkInfoView.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Block/ElectricNetworkInfoView.cs
@@ -27,7 +27,7 @@ namespace Client.Game.InGame.UI.Inventory.Block
         public void Initialize(BlockInstanceId blockInstanceId)
         {
             _blockInstanceId = blockInstanceId;
-            // UIオープン中は定期的にネットワーク情報を取得し続ける
+            // UIオープン中は定期的に再取得し続ける
             // Keep fetching network info periodically while the UI is open
             FetchLoop().Forget();
         }
@@ -63,10 +63,12 @@ namespace Client.Game.InGame.UI.Inventory.Block
                 return $"発電量: {generate:F2} 要求量: {required:F2} 需要なし";
             }
 
-            var rate = snapshot.PowerRate;
-            var colorTag = rate < 1f ? "<color=red>" : string.Empty;
-            var resetTag = rate < 1f ? "</color>" : string.Empty;
-            return $"発電量: {generate:F2} 要求量: {required:F2} 供給率: {colorTag}{rate * 100f:F0}%{resetTag}";
+            // 表示する整数%で色判定し、丸めで100%表示なのに赤になる矛盾を防ぐ
+            // Decide the color from the displayed integer %, avoiding red on a value that rounds to 100%
+            var percent = Mathf.RoundToInt(snapshot.PowerRate * 100f);
+            var colorTag = percent < 100 ? "<color=red>" : string.Empty;
+            var resetTag = percent < 100 ? "</color>" : string.Empty;
+            return $"発電量: {generate:F2} 要求量: {required:F2} 供給率: {colorTag}{percent}%{resetTag}";
         }
     }
 }

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Block/ElectricNetworkInfoView.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Block/ElectricNetworkInfoView.cs
@@ -1,0 +1,72 @@
+using Client.Game.InGame.Context;
+using Cysharp.Threading.Tasks;
+using Game.Block.Interface;
+using Server.Protocol.PacketResponse;
+using TMPro;
+using UnityEngine;
+
+namespace Client.Game.InGame.UI.Inventory.Block
+{
+    /// <summary>
+    ///     電力ネットワークの集約情報(現在発電量/現在要求量/供給率)を表示する再利用コンポーネント。
+    ///     電気機械・発電機・電柱の各UIに付与して共通化する。
+    ///     Reusable component that displays aggregated electric network info (current generation/demand/supply rate);
+    ///     attached to electric machine, generator, and pole UIs to share the display.
+    /// </summary>
+    public class ElectricNetworkInfoView : MonoBehaviour
+    {
+        // ネットワークはマージ/分割や燃料切れで変化するため一定間隔で再取得する
+        // The network changes via merge/split and fuel depletion, so re-fetch at a fixed interval
+        private const int FetchIntervalMilliseconds = 1000;
+
+        [SerializeField] private TMP_Text networkInfoText;
+
+        private BlockInstanceId _blockInstanceId;
+        private GetElectricNetworkInfoProtocol.ResponseGetElectricNetworkInfoMessagePack _cachedInfo;
+
+        public void Initialize(BlockInstanceId blockInstanceId)
+        {
+            _blockInstanceId = blockInstanceId;
+            // UIオープン中は定期的にネットワーク情報を取得し続ける
+            // Keep fetching network info periodically while the UI is open
+            FetchLoop().Forget();
+        }
+
+        private async UniTask FetchLoop()
+        {
+            var ct = this.GetCancellationTokenOnDestroy();
+            while (!ct.IsCancellationRequested)
+            {
+                _cachedInfo = await ClientContext.VanillaApi.Response.GetElectricNetworkInfo(_blockInstanceId, ct);
+                await UniTask.Delay(FetchIntervalMilliseconds, cancellationToken: ct);
+            }
+        }
+
+        private void Update()
+        {
+            networkInfoText.text = BuildText(_cachedInfo?.Info);
+        }
+
+        // スナップショットから表示文字列を組み立てる。供給不足は赤、消費者0は「需要なし」
+        // Build the display text from the snapshot; shortage shown in red, zero consumers shows "no demand"
+        public static string BuildText(GetElectricNetworkInfoProtocol.ElectricNetworkInfoSnapshot snapshot)
+        {
+            if (snapshot == null) return string.Empty;
+
+            var generate = snapshot.TotalGeneratePower;
+            var required = snapshot.TotalRequiredPower;
+
+            // 消費者がいない場合は供給率(0%)ではなく需要なしを表示し供給不足との誤認を防ぐ
+            // With no consumers, show "no demand" instead of a 0% rate to avoid being mistaken for a shortage
+            if (snapshot.ConsumerCount == 0)
+            {
+                return $"発電量: {generate:F2} 要求量: {required:F2} 需要なし";
+            }
+
+            var rate = snapshot.PowerRate;
+            var colorTag = rate < 1f ? "<color=red>" : string.Empty;
+            var resetTag = rate < 1f ? "</color>" : string.Empty;
+            return $"発電量: {generate:F2} 要求量: {required:F2} 供給率: {colorTag}{rate * 100f:F0}%{resetTag}";
+        }
+    }
+}

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Block/ElectricNetworkInfoView.cs.meta
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Block/ElectricNetworkInfoView.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 695bbae2c2faf44febfa9fc869a19d06

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Block/ElectricPoleNetworkInfoUIView.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Block/ElectricPoleNetworkInfoUIView.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using Client.Game.InGame.Block;
+using Client.Game.InGame.UI.Inventory.Common;
+using Core.Item.Interface;
+using Game.PlayerInventory.Interface.Subscription;
+using TMPro;
+using UnityEngine;
+
+namespace Client.Game.InGame.UI.Inventory.Block
+{
+    /// <summary>
+    ///     電柱インタラクト時に開く電力ネットワーク情報専用UI(インベントリなし)。
+    ///     発電機UIと同じ ElectricNetworkInfoView を共有して情報表示を共通化する。
+    ///     Dedicated electric-network-info UI (no inventory) opened when interacting with an electric pole;
+    ///     shares the same ElectricNetworkInfoView as the generator UI to unify the display.
+    /// </summary>
+    public class ElectricPoleNetworkInfoUIView : MonoBehaviour, IBlockInventoryView
+    {
+        [SerializeField] private TMP_Text blockNameText;
+        [SerializeField] private ElectricNetworkInfoView electricNetworkInfoView;
+
+        public void Initialize(BlockGameObject blockGameObject)
+        {
+            blockNameText.text = blockGameObject.BlockMasterElement.Name;
+            electricNetworkInfoView.Initialize(blockGameObject.BlockInstanceId);
+        }
+
+        public IReadOnlyList<ItemSlotView> SubInventorySlotObjects { get; } = new List<ItemSlotView>();
+        public List<IItemStack> SubInventory { get; } = new();
+        public int Count => 0;
+        public ISubInventoryIdentifier ISubInventoryIdentifier { get; } = null; // インベントリはないのでnullを入れておく
+
+        public void UpdateItemList(List<IItemStack> response) { }
+        public void UpdateInventorySlot(int slot, IItemStack item) { }
+        public void DestroyUI()
+        {
+            Destroy(gameObject);
+        }
+    }
+}

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Block/ElectricPoleNetworkInfoUIView.cs.meta
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Block/ElectricPoleNetworkInfoUIView.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 63f40e0865e574e9eb01610961a4e94e

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Block/GeneratorBlockInventoryView.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Block/GeneratorBlockInventoryView.cs
@@ -18,7 +18,9 @@ namespace Client.Game.InGame.UI.Inventory.Block
         
         [SerializeField] private TMP_Text operatingRateText;
         [SerializeField] private Slider fuelProgressSlider;
-        
+
+        [SerializeField] private ElectricNetworkInfoView electricNetworkInfoView;
+
         private BlockGameObject _blockGameObject;
         
         public override void Initialize(BlockGameObject blockGameObject)
@@ -39,8 +41,12 @@ namespace Client.Game.InGame.UI.Inventory.Block
             }
             
             UpdateItemList(itemList);
+
+            // 燃料スロットは維持したまま、ネットワーク情報部分を電柱UIと共通化
+            // Keep the fuel slots while sharing the network-info portion with the electric pole UI
+            electricNetworkInfoView.Initialize(blockGameObject.BlockInstanceId);
         }
-        
+
         private void Update()
         {
             var state = _blockGameObject.GetStateDetail<PowerGeneratorStateDetail>(PowerGeneratorStateDetail.StateDetailKey);

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Block/MachineBlockInventoryView.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Block/MachineBlockInventoryView.cs
@@ -27,7 +27,11 @@ namespace Client.Game.InGame.UI.Inventory.Block
         [SerializeField] private TMP_Text powerRateText;
         [SerializeField] private ProgressArrowView machineProgressArrow;
         [SerializeField] private TMP_Text machineRecipeCount;
-        
+
+        // 電力機械プレハブでのみ配線する。歯車機械(継承先プレハブ)では未配線なのでnull許容
+        // Wired only on electric-machine prefabs; left unwired (null) on gear-machine prefabs that inherit this view
+        [SerializeField] private ElectricNetworkInfoView electricNetworkInfoView;
+
         protected BlockGameObject BlockGameObject;
         
         private readonly List<FluidSlotView> _fluidSlotViews = new();
@@ -46,7 +50,11 @@ namespace Client.Game.InGame.UI.Inventory.Block
             
             SetItemList();
             SetFluidList();
-            
+
+            // 電力機械プレハブでのみ電力ネットワーク情報を表示(歯車機械では未配線)
+            // Show electric network info only on electric-machine prefabs (unwired on gear machines)
+            if (electricNetworkInfoView != null) electricNetworkInfoView.Initialize(BlockGameObject.BlockInstanceId);
+
             #region Internal
             
             void SetItemList()

--- a/moorestech_client/Assets/Scripts/Client.Network/API/VanillaApiWithResponse.cs
+++ b/moorestech_client/Assets/Scripts/Client.Network/API/VanillaApiWithResponse.cs
@@ -281,6 +281,14 @@ namespace Client.Network.API
             return await _packetExchangeManager.GetPacketResponse<GetGearNetworkInfoProtocol.ResponseGetGearNetworkInfoMessagePack>(request, ct);
         }
 
+        // 指定ブロックが属する電力ネットワークの現時点の集約値を取得する
+        // Fetch current aggregate info of the electric network that the given block belongs to
+        public async UniTask<GetElectricNetworkInfoProtocol.ResponseGetElectricNetworkInfoMessagePack> GetElectricNetworkInfo(BlockInstanceId blockInstanceId, CancellationToken ct)
+        {
+            var request = new GetElectricNetworkInfoProtocol.RequestGetElectricNetworkInfoMessagePack(blockInstanceId);
+            return await _packetExchangeManager.GetPacketResponse<GetElectricNetworkInfoProtocol.ResponseGetElectricNetworkInfoMessagePack>(request, ct);
+        }
+
         // 貨物プラットフォームのロード/アンロードモードを切り替える
         // Switch the load/unload transfer mode of a train platform block
         public async UniTask<SetTrainPlatformTransferModeProtocol.SetTrainPlatformTransferModeResponse> SetTrainPlatformTransferMode(

--- a/moorestech_server/Assets/Scripts/Game.EnergySystem/ElectricNetworkStatistics.cs
+++ b/moorestech_server/Assets/Scripts/Game.EnergySystem/ElectricNetworkStatistics.cs
@@ -9,15 +9,13 @@ namespace Game.EnergySystem
         public readonly float TotalGeneratePower;
         public readonly float TotalRequiredPower;
         public readonly float PowerRate;
-        public readonly int GeneratorCount;
         public readonly int ConsumerCount;
 
-        public ElectricNetworkStatistics(float totalGeneratePower, float totalRequiredPower, float powerRate, int generatorCount, int consumerCount)
+        public ElectricNetworkStatistics(float totalGeneratePower, float totalRequiredPower, float powerRate, int consumerCount)
         {
             TotalGeneratePower = totalGeneratePower;
             TotalRequiredPower = totalRequiredPower;
             PowerRate = powerRate;
-            GeneratorCount = generatorCount;
             ConsumerCount = consumerCount;
         }
     }

--- a/moorestech_server/Assets/Scripts/Game.EnergySystem/ElectricNetworkStatistics.cs
+++ b/moorestech_server/Assets/Scripts/Game.EnergySystem/ElectricNetworkStatistics.cs
@@ -1,0 +1,24 @@
+namespace Game.EnergySystem
+{
+    /// <summary>
+    ///     電力ネットワークの集約統計。供給率は1.0クランプ済みで、ConsumerCountが0なら需要なしを表す
+    ///     Aggregated statistics of an energy network. PowerRate is clamped to 1.0, and ConsumerCount == 0 means no demand
+    /// </summary>
+    public readonly struct ElectricNetworkStatistics
+    {
+        public readonly float TotalGeneratePower;
+        public readonly float TotalRequiredPower;
+        public readonly float PowerRate;
+        public readonly int GeneratorCount;
+        public readonly int ConsumerCount;
+
+        public ElectricNetworkStatistics(float totalGeneratePower, float totalRequiredPower, float powerRate, int generatorCount, int consumerCount)
+        {
+            TotalGeneratePower = totalGeneratePower;
+            TotalRequiredPower = totalRequiredPower;
+            PowerRate = powerRate;
+            GeneratorCount = generatorCount;
+            ConsumerCount = consumerCount;
+        }
+    }
+}

--- a/moorestech_server/Assets/Scripts/Game.EnergySystem/ElectricNetworkStatistics.cs.meta
+++ b/moorestech_server/Assets/Scripts/Game.EnergySystem/ElectricNetworkStatistics.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8eef78fff0d5e471990ee579eda3b998

--- a/moorestech_server/Assets/Scripts/Game.EnergySystem/EnergySegment.cs
+++ b/moorestech_server/Assets/Scripts/Game.EnergySystem/EnergySegment.cs
@@ -43,7 +43,7 @@ namespace Game.EnergySystem
         {
             CheckDestroy();
 
-            // 集約統計を算出し、供給率に応じて各消費者へエネルギーを配分
+            // 供給率に応じて各消費者へ配分
             // Calculate aggregated statistics and distribute energy to each consumer by the supply rate
             var statistics = CalculateStatistics();
             var powerRate = new ElectricPower(statistics.PowerRate);
@@ -67,9 +67,9 @@ namespace Game.EnergySystem
             // Compute supply rate; when demand is 0, avoid division (NaN/Infinity) and treat as no demand with rate 1.0
             var requiredPrimitive = totalRequired.AsPrimitive();
             var powerRate = requiredPrimitive <= 0f ? 1f : totalGenerate.AsPrimitive() / requiredPrimitive;
-            if (powerRate > 1f) powerRate = 1f;
+            if (1f < powerRate) powerRate = 1f;
 
-            return new ElectricNetworkStatistics(totalGenerate.AsPrimitive(), requiredPrimitive, powerRate, _generators.Count, _consumers.Count);
+            return new ElectricNetworkStatistics(totalGenerate.AsPrimitive(), requiredPrimitive, powerRate, _consumers.Count);
         }
         
         public void AddEnergyConsumer(IElectricConsumer electricConsumer)

--- a/moorestech_server/Assets/Scripts/Game.EnergySystem/EnergySegment.cs
+++ b/moorestech_server/Assets/Scripts/Game.EnergySystem/EnergySegment.cs
@@ -31,25 +31,45 @@ namespace Game.EnergySystem
         public IReadOnlyDictionary<BlockInstanceId, IElectricTransformer> EnergyTransformers => _energyTransformers;
         
         
+        // 現時点のネットワーク集約統計を返す。SupplyEnergyを呼ばないので副作用はない
+        // Return the current aggregated network statistics; this never calls SupplyEnergy so it has no side effects
+        public ElectricNetworkStatistics GetCurrentStatistics()
+        {
+            CheckDestroy();
+            return CalculateStatistics();
+        }
+
         private void Update()
         {
             CheckDestroy();
 
+            // 集約統計を算出し、供給率に応じて各消費者へエネルギーを配分
+            // Calculate aggregated statistics and distribute energy to each consumer by the supply rate
+            var statistics = CalculateStatistics();
+            var powerRate = new ElectricPower(statistics.PowerRate);
+            foreach (var consumer in _consumers.Values)
+                consumer.SupplyEnergy(consumer.RequestEnergy * powerRate);
+        }
+
+        // 発電合計・要求合計・供給率を算出する純粋な計算。UpdateとGetCurrentStatisticsで共有
+        // Pure computation of total generation, total demand, and supply rate; shared by Update and GetCurrentStatistics
+        private ElectricNetworkStatistics CalculateStatistics()
+        {
             //供給されてる合計エネルギー量の算出
-            var powers = new ElectricPower(0);
-            foreach (var key in _generators.Keys) powers += _generators[key].OutputEnergy();
+            var totalGenerate = new ElectricPower(0);
+            foreach (var generator in _generators.Values) totalGenerate += generator.OutputEnergy();
 
             //エネルギーの需要量の算出
-            var requester = new ElectricPower(0);
-            foreach (var key in _consumers.Keys) requester += _consumers[key].RequestEnergy;
+            var totalRequired = new ElectricPower(0);
+            foreach (var consumer in _consumers.Values) totalRequired += consumer.RequestEnergy;
 
-            //エネルギー供給の割合の算出
-            var powerRate = powers / requester;
-            if (1 < powerRate.AsPrimitive()) powerRate = new ElectricPower(1);
+            // 供給率を算出。要求が0なら除算(NaN/Infinity)を避け、需要なしとして供給率1.0扱い
+            // Compute supply rate; when demand is 0, avoid division (NaN/Infinity) and treat as no demand with rate 1.0
+            var requiredPrimitive = totalRequired.AsPrimitive();
+            var powerRate = requiredPrimitive <= 0f ? 1f : totalGenerate.AsPrimitive() / requiredPrimitive;
+            if (powerRate > 1f) powerRate = 1f;
 
-            //エネルギーを供給
-            foreach (var key in _consumers.Keys)
-                _consumers[key].SupplyEnergy(_consumers[key].RequestEnergy * powerRate);
+            return new ElectricNetworkStatistics(totalGenerate.AsPrimitive(), requiredPrimitive, powerRate, _generators.Count, _consumers.Count);
         }
         
         public void AddEnergyConsumer(IElectricConsumer electricConsumer)

--- a/moorestech_server/Assets/Scripts/Game.World.EventHandler/EnergyEvent/DisconnectMachineFromElectricSegment.cs
+++ b/moorestech_server/Assets/Scripts/Game.World.EventHandler/EnergyEvent/DisconnectMachineFromElectricSegment.cs
@@ -47,7 +47,9 @@ namespace Game.World.EventHandler.EnergyEvent
         /// </summary>
         private void DisconnectGeneratorFromElectricPole(TGenerator generator)
         {
-            if (_worldEnergySegmentDatastore.TryGetEnergySegment(generator, out var segment))
+            // 1台が複数セグメントに所属し得るため全セグメントから削除。残すと破壊後のtickでOutputEnergyが落ちる
+            // A block can belong to multiple segments; remove from all, else a post-destroy tick crashes in OutputEnergy
+            while (_worldEnergySegmentDatastore.TryGetEnergySegment(generator, out var segment))
             {
                 segment.RemoveGenerator(generator);
             }
@@ -58,7 +60,9 @@ namespace Game.World.EventHandler.EnergyEvent
         /// </summary>
         private void DisconnectConsumerFromElectricPole(TConsumer consumer)
         {
-            if (_worldEnergySegmentDatastore.TryGetEnergySegment(consumer, out var segment))
+            // 消費機械も複数セグメントに所属し得るため全セグメントから削除する
+            // A consumer can also belong to multiple segments, so remove it from all of them
+            while (_worldEnergySegmentDatastore.TryGetEnergySegment(consumer, out var segment))
             {
                 segment.RemoveEnergyConsumer(consumer);
             }

--- a/moorestech_server/Assets/Scripts/Game.World.Interface/DataStore/IWorldEnergySegmentDatastore.cs
+++ b/moorestech_server/Assets/Scripts/Game.World.Interface/DataStore/IWorldEnergySegmentDatastore.cs
@@ -1,3 +1,4 @@
+using Game.Block.Interface;
 using Game.EnergySystem;
 
 namespace Game.World.Interface.DataStore
@@ -7,6 +8,10 @@ namespace Game.World.Interface.DataStore
         public TSegment GetEnergySegment(IElectricTransformer transformer);
         public bool TryGetEnergySegment(IElectricConsumer consumer, out TSegment segment);
         public bool TryGetEnergySegment(IElectricGenerator generator, out TSegment segment);
+
+        // 消費者・発電機・電柱いずれかのBlockInstanceIdから所属セグメントを引く
+        // Resolve the owning segment from a BlockInstanceId of a consumer, generator, or transformer
+        public bool TryGetEnergySegment(BlockInstanceId blockInstanceId, out TSegment segment);
         
         public TSegment GetEnergySegment(int index);
         public TSegment CreateEnergySegment();

--- a/moorestech_server/Assets/Scripts/Game.World.Interface/DataStore/IWorldEnergySegmentDatastore.cs
+++ b/moorestech_server/Assets/Scripts/Game.World.Interface/DataStore/IWorldEnergySegmentDatastore.cs
@@ -11,6 +11,8 @@ namespace Game.World.Interface.DataStore
 
         // 消費者・発電機・電柱いずれかのBlockInstanceIdから所属セグメントを引く
         // Resolve the owning segment from a BlockInstanceId of a consumer, generator, or transformer
+        // 既知制約: 1ブロックが複数セグメントに所属する場合は先頭の1つのみ返す(ネットワーク情報UIは単一ネットワーク表示)
+        // Known limitation: when a block belongs to multiple segments, only the first is returned (network-info UI shows a single network)
         public bool TryGetEnergySegment(BlockInstanceId blockInstanceId, out TSegment segment);
         
         public TSegment GetEnergySegment(int index);

--- a/moorestech_server/Assets/Scripts/Game.World/DataStore/WorldEnergySegmentDatastore.cs
+++ b/moorestech_server/Assets/Scripts/Game.World/DataStore/WorldEnergySegmentDatastore.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Game.Block.Interface;
 using Game.EnergySystem;
 using Game.World.Interface.DataStore;
 
@@ -37,6 +38,21 @@ namespace Game.World.DataStore
             foreach (var seg in _segmentDictionary)
             {
                 if (!seg.Generators.ContainsKey(generator.BlockInstanceId)) continue;
+                segment = seg;
+                return true;
+            }
+            segment = null;
+            return false;
+        }
+        public bool TryGetEnergySegment(BlockInstanceId blockInstanceId, out TSegment segment)
+        {
+            foreach (var seg in _segmentDictionary)
+            {
+                // 消費者・発電機・電柱のいずれかに含まれていればそのセグメントを返す
+                // Return the segment if it contains the block as a consumer, generator, or transformer
+                if (!seg.Consumers.ContainsKey(blockInstanceId) &&
+                    !seg.Generators.ContainsKey(blockInstanceId) &&
+                    !seg.EnergyTransformers.ContainsKey(blockInstanceId)) continue;
                 segment = seg;
                 return true;
             }

--- a/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/GetElectricNetworkInfoProtocol.cs
+++ b/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/GetElectricNetworkInfoProtocol.cs
@@ -1,0 +1,99 @@
+using System;
+using Game.Block.Interface;
+using Game.EnergySystem;
+using Game.World.Interface.DataStore;
+using MessagePack;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Server.Protocol.PacketResponse
+{
+    // 指定ブロックが属する電力ネットワークの現時点の集約情報を取得するプロトコル
+    // Protocol to fetch the current aggregate info of the electric network that a block belongs to
+    public class GetElectricNetworkInfoProtocol : IPacketResponse
+    {
+        public const string ProtocolTag = "va:getElectricNetInfo";
+
+        private readonly IWorldEnergySegmentDatastore<EnergySegment> _energySegmentDatastore;
+
+        public GetElectricNetworkInfoProtocol(ServiceProvider serviceProvider)
+        {
+            // 電力はGearのstaticと異なりDIインスタンスから取得して保持
+            // Unlike the gear static datastore, resolve and hold the energy datastore from DI
+            _energySegmentDatastore = serviceProvider.GetService<IWorldEnergySegmentDatastore<EnergySegment>>();
+        }
+
+        public ProtocolMessagePackBase GetResponse(byte[] payload, PacketResponseContext context)
+        {
+            var request = MessagePackSerializer.Deserialize<RequestGetElectricNetworkInfoMessagePack>(payload);
+
+            // 対象ブロックがどの電力セグメントにも属さないなら Info=null を返す
+            // Return Info=null when the target block belongs to no energy segment
+            if (!_energySegmentDatastore.TryGetEnergySegment(request.BlockInstanceId, out var segment))
+            {
+                return new ResponseGetElectricNetworkInfoMessagePack(null);
+            }
+
+            var statistics = segment.GetCurrentStatistics();
+            var snapshot = new ElectricNetworkInfoSnapshot(statistics.TotalGeneratePower, statistics.TotalRequiredPower, statistics.PowerRate, statistics.ConsumerCount);
+            return new ResponseGetElectricNetworkInfoMessagePack(snapshot);
+        }
+
+        #region MessagePack
+
+        [MessagePackObject]
+        public class RequestGetElectricNetworkInfoMessagePack : ProtocolMessagePackBase
+        {
+            [Key(2)] public BlockInstanceId BlockInstanceId { get; set; }
+
+            [Obsolete("デシリアライズ用のコンストラクタです。基本的に使用しないでください。")]
+            public RequestGetElectricNetworkInfoMessagePack() { }
+
+            public RequestGetElectricNetworkInfoMessagePack(BlockInstanceId blockInstanceId)
+            {
+                Tag = ProtocolTag;
+                BlockInstanceId = blockInstanceId;
+            }
+        }
+
+        [MessagePackObject]
+        public class ResponseGetElectricNetworkInfoMessagePack : ProtocolMessagePackBase
+        {
+            // Info が null なら対象ブロックはどの電力セグメントにも未所属。見つかった場合のみ下位フィールドが有効
+            // Info == null means the block is not a member of any energy segment; inner fields are meaningful only when Info is non-null
+            [Key(2)] public ElectricNetworkInfoSnapshot Info { get; set; }
+
+            [Obsolete("デシリアライズ用のコンストラクタです。基本的に使用しないでください。")]
+            public ResponseGetElectricNetworkInfoMessagePack() { }
+
+            public ResponseGetElectricNetworkInfoMessagePack(ElectricNetworkInfoSnapshot info)
+            {
+                Tag = ProtocolTag;
+                Info = info;
+            }
+        }
+
+        [MessagePackObject]
+        public class ElectricNetworkInfoSnapshot
+        {
+            [Key(0)] public float TotalGeneratePower { get; set; }
+            [Key(1)] public float TotalRequiredPower { get; set; }
+            [Key(2)] public float PowerRate { get; set; }
+            // 消費者数。0なら「需要なし」を供給率0%(不足)と区別して表示するために使う
+            // Consumer count; when 0 it is used to display "no demand" instead of a misleading 0% supply rate
+            [Key(3)] public int ConsumerCount { get; set; }
+
+            [Obsolete("デシリアライズ用のコンストラクタです。基本的に使用しないでください。")]
+            public ElectricNetworkInfoSnapshot() { }
+
+            public ElectricNetworkInfoSnapshot(float totalGeneratePower, float totalRequiredPower, float powerRate, int consumerCount)
+            {
+                TotalGeneratePower = totalGeneratePower;
+                TotalRequiredPower = totalRequiredPower;
+                PowerRate = powerRate;
+                ConsumerCount = consumerCount;
+            }
+        }
+
+        #endregion
+    }
+}

--- a/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/GetElectricNetworkInfoProtocol.cs.meta
+++ b/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/GetElectricNetworkInfoProtocol.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4c21de6494307465f92ad1e177f80ab0

--- a/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponseCreator.cs
+++ b/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponseCreator.cs
@@ -50,6 +50,7 @@ namespace Server.Protocol
             _packetResponseDictionary.Add(InvokeBlockStateEventProtocol.ProtocolTag, new InvokeBlockStateEventProtocol(serviceProvider));
             _packetResponseDictionary.Add(DebugBlockInfoRequestProtocol.ProtocolTag, new DebugBlockInfoRequestProtocol(serviceProvider));
             _packetResponseDictionary.Add(GetGearNetworkInfoProtocol.ProtocolTag, new GetGearNetworkInfoProtocol(serviceProvider));
+            _packetResponseDictionary.Add(GetElectricNetworkInfoProtocol.ProtocolTag, new GetElectricNetworkInfoProtocol(serviceProvider));
 
             _packetResponseDictionary.Add(ApplyCraftTreeProtocol.ProtocolTag, new ApplyCraftTreeProtocol(serviceProvider));
             _packetResponseDictionary.Add(GetCraftTreeProtocol.ProtocolTag, new GetCraftTreeProtocol(serviceProvider));

--- a/moorestech_server/Assets/Scripts/Tests/CombinedTest/Game/Energy/RemoveGeneratorFromMultiSegmentTest.cs
+++ b/moorestech_server/Assets/Scripts/Tests/CombinedTest/Game/Energy/RemoveGeneratorFromMultiSegmentTest.cs
@@ -1,0 +1,57 @@
+using System;
+using Core.Update;
+using Game.Block.Interface;
+using Game.Block.Interface.Extension;
+using Game.Context;
+using Game.EnergySystem;
+using Game.World.Interface.DataStore;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Server.Boot;
+using Tests.Module.TestMod;
+using UnityEngine;
+using static Tests.Module.TestMod.ForUnitTestModBlockId;
+
+namespace Tests.CombinedTest.Game.Energy
+{
+    /// <summary>
+    ///     複数セグメントに所属する発電機を破壊したときに、残存参照でtickがクラッシュしないことを検証する
+    ///     Verify that destroying a generator belonging to multiple segments does not crash the tick via a dangling reference
+    /// </summary>
+    public class RemoveGeneratorFromMultiSegmentTest
+    {
+        [Test]
+        public void RemovingGeneratorSharedByMultipleSegmentsDoesNotCrashOnNextTick()
+        {
+            var (_, serviceProvider) =
+                new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
+            var worldBlockDatastore = ServerContext.WorldBlockDatastore;
+
+            // 電柱を置かずに発電機のみ設置し、自動セグメント接続を発生させない
+            // Place only the generator (no pole) so no automatic segment connection happens
+            var generatorPos = new Vector3Int(0, 0, 0);
+            worldBlockDatastore.TryAddBlock(InfinityGeneratorId, generatorPos, BlockDirection.North, Array.Empty<BlockCreateParam>(), out var generatorBlock);
+            var generator = generatorBlock.GetComponent<IElectricGenerator>();
+
+            var segmentDatastore = serviceProvider.GetService<IWorldEnergySegmentDatastore<EnergySegment>>();
+
+            // 範囲が重なる電柱構成を模し、1台の発電機を2つのセグメントへ登録する
+            // Register one generator into two segments, emulating overlapping pole ranges
+            var segmentA = segmentDatastore.CreateEnergySegment();
+            segmentA.AddGenerator(generator);
+            var segmentB = segmentDatastore.CreateEnergySegment();
+            segmentB.AddGenerator(generator);
+
+            // 発電機を破壊。全セグメントから外れないと破壊済み参照が残る
+            // Destroy the generator; if it is not removed from every segment a dangling reference remains
+            worldBlockDatastore.RemoveBlock(generatorPos, BlockRemoveReason.ManualRemove);
+
+            // 破壊後にtickしても OutputEnergy が破壊済みコンポーネントを叩いて落ちないこと
+            // Ticking after destruction must not crash by calling OutputEnergy on the destroyed component
+            Assert.DoesNotThrow(() =>
+            {
+                for (var i = 0; i < 2; i++) GameUpdater.UpdateOneTick();
+            });
+        }
+    }
+}

--- a/moorestech_server/Assets/Scripts/Tests/CombinedTest/Game/Energy/RemoveGeneratorFromMultiSegmentTest.cs.meta
+++ b/moorestech_server/Assets/Scripts/Tests/CombinedTest/Game/Energy/RemoveGeneratorFromMultiSegmentTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a86d45a166742496f8bf80d81e3456fd

--- a/moorestech_server/Assets/Scripts/Tests/CombinedTest/Server/PacketTest/GetElectricNetworkInfoProtocolTest.cs
+++ b/moorestech_server/Assets/Scripts/Tests/CombinedTest/Server/PacketTest/GetElectricNetworkInfoProtocolTest.cs
@@ -1,0 +1,96 @@
+using System;
+using Game.Block.Interface;
+using Game.Context;
+using Game.EnergySystem;
+using Game.World.Interface.DataStore;
+using MessagePack;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Server.Boot;
+using Server.Protocol;
+using Server.Protocol.PacketResponse;
+using Tests.Module.TestMod;
+using UnityEngine;
+
+namespace Tests.CombinedTest.Server.PacketTest
+{
+    public class GetElectricNetworkInfoProtocolTest
+    {
+        [Test]
+        public void GetElectricNetworkInfo_ReturnsSameAggregateForEveryMemberBlock()
+        {
+            // 電柱・発電機・機械を1セグメントに構築し、いずれのブロックIDからも同一の集約値が返るか確認
+            // Build one segment from a pole, generator, and machine, then assert every member block reports the same aggregate
+            var (packet, serviceProvider) = new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
+            var worldBlockDatastore = ServerContext.WorldBlockDatastore;
+
+            worldBlockDatastore.TryAddBlock(ForUnitTestModBlockId.ElectricPoleId, Pos(0, 0), BlockDirection.North, Array.Empty<BlockCreateParam>(), out var pole);
+            worldBlockDatastore.TryAddBlock(ForUnitTestModBlockId.InfinityGeneratorId, Pos(0, 2), BlockDirection.North, Array.Empty<BlockCreateParam>(), out var generator);
+            worldBlockDatastore.TryAddBlock(ForUnitTestModBlockId.MachineId, Pos(2, 0), BlockDirection.North, Array.Empty<BlockCreateParam>(), out var machine);
+
+            var segmentDatastore = serviceProvider.GetService<IWorldEnergySegmentDatastore<EnergySegment>>();
+            Assert.IsTrue(segmentDatastore.TryGetEnergySegment(pole.BlockInstanceId, out var segment));
+
+            var expected = segment.GetCurrentStatistics();
+            // 無限発電機を使うため発電量は正、機械が消費者として1台登録される
+            // The infinity generator yields positive generation and the machine registers as one consumer
+            Assert.Greater(expected.TotalGeneratePower, 0f);
+            Assert.AreEqual(1, expected.ConsumerCount);
+
+            // 電柱・発電機・機械のいずれのIDでも同じ集約値が返ることを確認
+            // Confirm the pole, generator, and machine IDs all report the same aggregate
+            foreach (var id in new[] { pole.BlockInstanceId, generator.BlockInstanceId, machine.BlockInstanceId })
+            {
+                var info = InvokeGetElectricNetworkInfo(packet, id).Info;
+                Assert.IsNotNull(info);
+                Assert.AreEqual(expected.TotalGeneratePower, info.TotalGeneratePower);
+                Assert.AreEqual(expected.TotalRequiredPower, info.TotalRequiredPower);
+                Assert.AreEqual(expected.PowerRate, info.PowerRate);
+                Assert.AreEqual(expected.ConsumerCount, info.ConsumerCount);
+            }
+        }
+
+        [Test]
+        public void GetElectricNetworkInfo_NoConsumer_ReportsNoDemandWithoutDivisionError()
+        {
+            // 消費者ゼロのセグメントで、ゼロ除算なく需要なし(供給率1.0/要求0/消費者0)が返るか確認
+            // With a consumer-less segment, assert no-demand (rate 1.0 / required 0 / consumer 0) without a division error
+            var (packet, serviceProvider) = new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
+            var worldBlockDatastore = ServerContext.WorldBlockDatastore;
+
+            worldBlockDatastore.TryAddBlock(ForUnitTestModBlockId.ElectricPoleId, Pos(0, 0), BlockDirection.North, Array.Empty<BlockCreateParam>(), out var pole);
+            worldBlockDatastore.TryAddBlock(ForUnitTestModBlockId.InfinityGeneratorId, Pos(0, 2), BlockDirection.North, Array.Empty<BlockCreateParam>(), out _);
+
+            var info = InvokeGetElectricNetworkInfo(packet, pole.BlockInstanceId).Info;
+
+            Assert.IsNotNull(info);
+            Assert.AreEqual(0, info.ConsumerCount);
+            Assert.AreEqual(0f, info.TotalRequiredPower);
+            Assert.AreEqual(1f, info.PowerRate);
+        }
+
+        [Test]
+        public void GetElectricNetworkInfo_UnknownBlockInstanceId_ReturnsNull()
+        {
+            // どの電力セグメントにも属さないブロックIDで Info=null が返ることを確認
+            // Confirm Info=null is returned for a block that belongs to no energy segment
+            var (packet, _) = new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
+
+            var response = InvokeGetElectricNetworkInfo(packet, new BlockInstanceId(int.MinValue + 1));
+
+            Assert.IsNull(response.Info);
+        }
+
+        private static GetElectricNetworkInfoProtocol.ResponseGetElectricNetworkInfoMessagePack InvokeGetElectricNetworkInfo(PacketResponseCreator packet, BlockInstanceId id)
+        {
+            var request = new GetElectricNetworkInfoProtocol.RequestGetElectricNetworkInfoMessagePack(id);
+            var responseBytes = packet.GetPacketResponse(MessagePackSerializer.Serialize(request), new PacketResponseContext());
+            return MessagePackSerializer.Deserialize<GetElectricNetworkInfoProtocol.ResponseGetElectricNetworkInfoMessagePack>(responseBytes[0]);
+        }
+
+        private static Vector3Int Pos(int x, int z)
+        {
+            return new Vector3Int(x, 0, z);
+        }
+    }
+}

--- a/moorestech_server/Assets/Scripts/Tests/CombinedTest/Server/PacketTest/GetElectricNetworkInfoProtocolTest.cs.meta
+++ b/moorestech_server/Assets/Scripts/Tests/CombinedTest/Server/PacketTest/GetElectricNetworkInfoProtocolTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e1d73f5eb42b04987be6f375493e9054


### PR DESCRIPTION
## Summary
- 電気機械・発電機・電柱の各UIに所属電力ネットワークの現在発電量・現在要求量・供給率を表示する機能を追加（歯車ネットワーク情報UIを電力側にミラー）
- サーバー: `GetElectricNetworkInfoProtocol` (va:getElectricNetInfo) を追加し、`EnergySegment` の算出ロジックを `CalculateStatistics()` に一本化（要求0時のゼロ除算を回避）
- バグ修正: 複数セグメントに所属する発電機/消費機を破壊すると、`DisconnectMachineFromElectricSegment` が先頭1セグメントしか削除せず破壊済み参照が残り、次tickで `InvalidOperationException` によりサーバー更新スレッドが停止する既存バグを修正

## 変更内容
- クライアント: 再利用コンポーネント `ElectricNetworkInfoView` を新設し約1秒間隔で再fetch、`MachineBlockInventoryView` / `GeneratorBlockInventoryView` に配線、電柱専用 `ElectricPoleNetworkInfoUIView` とprefabを追加
- サーバー: `ElectricNetworkStatistics` struct、`WorldEnergySegmentDatastore` への BlockInstanceId 逆引きを追加
- all-code-review (v3 reviewer + Codex外部監査) の確定指摘を反映（%色判定の整合、デッドコード削除、多重所属制約の明記等）

## Test plan
- [ ] `GetElectricNetworkInfoProtocolTest`（3件）が通過
- [ ] `RemoveGeneratorFromMultiSegmentTest`（回帰テスト）が通過
- [ ] 既存の電力セグメント・機械処理・歯車プロトコルテストが全通過
- [ ] 電気機械/発電機/電柱UIで発電量・要求量・供給率が正しく表示される
- [ ] 範囲が重なる電柱構成で発電機を破壊してもサーバーがクラッシュしない

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added electric network information UI displaying real-time power generation, consumption, and supply rate
  * Electric poles now show aggregated network statistics
  * Integrated network status display in generators and machines
  * Implemented API endpoint to query electric network data

* **Bug Fixes**
  * Fixed crash when generators belong to multiple energy segments

* **Tests**
  * Added tests for electric network query functionality and multi-segment scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->