### PR TITLE
実行時MeshCollider追加を廃止しPhysics負荷を軽減

### DIFF
--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/Context/BlockGameObjectPrefabContainer.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/Context/BlockGameObjectPrefabContainer.cs
@@ -118,12 +118,14 @@ namespace Client.Game.InGame.Context
                     blockObj = block.AddComponent<BlockGameObject>();
                 }
 
-                // 子要素のコンポーネントの設定
-                // Set up child element components
-                foreach (var mesh in blockObj.GetComponentsInChildren<MeshRenderer>())
+                // 実行時のMeshCollider追加をやめ、既にColliderがある子にのみBlockGameObjectChildを付ける
+                // Stop adding MeshColliders at runtime; add BlockGameObjectChild only to children that already have a Collider
+                foreach (var childCollider in blockObj.GetComponentsInChildren<Collider>())
                 {
-                    mesh.gameObject.AddComponent<BlockGameObjectChild>();
-                    mesh.gameObject.AddComponent<MeshCollider>();
+                    // 同一オブジェクトに複数Colliderがあっても二重付与しない
+                    // Avoid double-attaching when one object has multiple Colliders
+                    if (childCollider.TryGetComponent<BlockGameObjectChild>(out _)) continue;
+                    childCollider.gameObject.AddComponent<BlockGameObjectChild>();
                 }
 
                 blockObj.gameObject.SetActive(true);


### PR DESCRIPTION
## Summary
- ブロック生成時にメッシュごとの `MeshCollider` を実行時追加する処理を廃止し、Physics負荷を軽減
- `MeshRenderer` 単位ではなく、既に `Collider` を持つ子要素にのみ `BlockGameObjectChild` を付与するよう変更
- 同一オブジェクトに複数 `Collider` がある場合の `BlockGameObjectChild` 二重付与を防止

## Test plan
- [ ] ブロック配置・破壊が正常に動作すること
- [ ] ブロックのクリック（Collider経由の選択・操作）が引き続き機能すること
- [ ] 大量ブロック設置時のPhysics負荷が改善していること

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved block child setup so existing collider-based child objects are handled more reliably.
  * Prevented duplicate child component attachment during block creation.
  * Removed automatic runtime collider creation on block children.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->