### PR TITLE
外部リポジトリ同期のチェック頻度をフォーカス状態で切り替え

### DIFF
--- a/moorestech_client/Assets/Scripts/Editor/RepositorySync/ExternalRepositorySyncEditor.cs
+++ b/moorestech_client/Assets/Scripts/Editor/RepositorySync/ExternalRepositorySyncEditor.cs
@@ -1,13 +1,15 @@
 using UnityEditor;
+using UnityEditorInternal;
 
 namespace Client.Editor.RepositorySync
 {
     public static class ExternalRepositorySyncEditor
     {
         private const string AutoSyncSessionKey = "Moorestech.ExternalRepositorySync.AutoSynced";
-        private const double DetectIntervalSec = 5.0;
+        private const double FocusedDetectIntervalSec = 5.0;
+        private const double UnfocusedDetectIntervalSec = 30.0;
 
-        private static double _nextDetectTime;
+        private static double _lastDetectTime;
         private static bool _initialSyncFinished;
 
         [InitializeOnLoadMethod]
@@ -15,6 +17,11 @@ namespace Client.Editor.RepositorySync
         {
             EditorApplication.update -= OnUpdate;
             EditorApplication.update += OnUpdate;
+
+            // エディタ終了時にも外部repoのHEADをチェックして記録漏れを防ぐ
+            // Also check external repository HEADs on editor quit so no change is missed
+            EditorApplication.quitting -= OnEditorQuitting;
+            EditorApplication.quitting += OnEditorQuitting;
 
             if (!SessionState.GetBool(AutoSyncSessionKey, false))
             {
@@ -42,11 +49,20 @@ namespace Client.Editor.RepositorySync
         private static void OnUpdate()
         {
             if (!_initialSyncFinished) return;
-            if (EditorApplication.timeSinceStartup < _nextDetectTime) return;
-            _nextDetectTime = EditorApplication.timeSinceStartup + DetectIntervalSec;
+
+            // フォーカス中は従来間隔、非フォーカス時は30秒間隔に下げてrebase中の差分再生成を抑える
+            // Use the original interval while the editor is focused; drop to 30s when unfocused to avoid regenerating diffs during rebase cleanup
+            var detectInterval = InternalEditorUtility.isApplicationActive ? FocusedDetectIntervalSec : UnfocusedDetectIntervalSec;
+            if (EditorApplication.timeSinceStartup - _lastDetectTime < detectInterval) return;
+            _lastDetectTime = EditorApplication.timeSinceStartup;
 
             // 外部repoのHEAD変更を検出してroot側の記録ファイルへ反映する
             // Detect external repository HEAD changes and reflect them into the root revision file
+            ExternalRepositorySyncService.RecordCurrentCommitsIfChanged();
+        }
+
+        private static void OnEditorQuitting()
+        {
             ExternalRepositorySyncService.RecordCurrentCommitsIfChanged();
         }
 


### PR DESCRIPTION
## 概要
moorestech_master / moorestech_client_private のコミットハッシュ同期システムが無条件に5秒ごとに `.moorestech-external-revisions.json` へ HEAD を書き戻すため、rebase 中に差分を消してもすぐ再生成されて煩わしい問題への対応。

## 変更内容
`ExternalRepositorySyncEditor.cs` のみの変更:

- **エディタ起動時**: 既存の起動時同期をそのまま維持
- **エディタ終了時**: `EditorApplication.quitting` で `RecordCurrentCommitsIfChanged()` を実行(新規)
- **非フォーカス時**: `InternalEditorUtility.isApplicationActive` で判定し、HEAD 検出間隔を **30秒** に低減
- **フォーカス中**: 従来通り **5秒** 間隔。判定は毎フレーム行うため、ウィンドウに戻った瞬間から5秒周期に復帰

## 検証
- Unity 6000.3.8f1 同梱の Roslyn で RepositorySync フォルダ全ファイルを実エディタ DLL に対してコンパイルし成功(使用 API `isApplicationActive` / `quitting` の実在確認込み)
- エディタでのランタイム動作確認は未実施

🤖 Generated with [Claude Code](https://claude.com/claude-code)