### PR TITLE
fix: 電気設置レビュー指摘を反映

### DIFF
--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/BeltConveyor/Parts/BeltConveyorCostPreviewMarker.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/BeltConveyor/Parts/BeltConveyorCostPreviewMarker.cs
@@ -15,10 +15,13 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.BeltConveyor.Parts
     {
         public static void MarkInsufficientEntitiesAsNotPlaceable(List<PlaceInfo> currentPlaceInfos, IEnumerable<IItemStack> inventoryItems)
         {
-            var entityCosts = new ConstructionRequiredItemElement[currentPlaceInfos.Count][];
+            // 地面埋没等の設置不可エンティティはコストを消費しないため予算計算から除外する
+            // Exclude already-unplaceable entities (e.g. buried in ground) since they consume no cost
+            var entityCosts = new List<ConstructionRequiredItemElement[]>(currentPlaceInfos.Count);
             for (var i = 0; i < currentPlaceInfos.Count; i++)
             {
-                entityCosts[i] = MasterHolder.BlockMaster.GetBlockMaster(currentPlaceInfos[i].BlockId).RequiredItems;
+                if (!currentPlaceInfos[i].Placeable) continue;
+                entityCosts.Add(MasterHolder.BlockMaster.GetBlockMaster(currentPlaceInfos[i].BlockId).RequiredItems);
             }
 
             // 建設コストで賄えるエンティティ数まで設置可にする

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/Common/CommonBlockPlacePointCalculator.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/Common/CommonBlockPlacePointCalculator.cs
@@ -19,12 +19,12 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.Common
             _blockGameObjectDataStore = blockGameObjectDataStore;
         }
         
-        public List<PlaceInfo> CalculatePoint(Vector3Int startPoint, Vector3Int endPoint, bool isStartDirectionZ, BlockDirection blockDirection, BlockMasterElement holdingBlockMasterElement)
+        public List<PlaceInfo> CalculatePoint(Vector3Int startPoint, Vector3Int endPoint, BlockDirection blockDirection, BlockMasterElement holdingBlockMasterElement)
         {
-            return CalculatePoint(startPoint, endPoint, isStartDirectionZ, blockDirection, holdingBlockMasterElement, IsNotExistBlock, IsOccupied);
+            return CalculatePoint(startPoint, endPoint, blockDirection, holdingBlockMasterElement, IsNotExistBlock);
         }
-        
-        public static List<PlaceInfo> CalculatePoint(Vector3Int startPoint, Vector3Int endPoint, bool isStartDirectionZ, BlockDirection blockDirection, BlockMasterElement holdingBlockMasterElement, Func<PlaceInfo, BlockMasterElement, bool> isNotExistBlock, Func<Vector3Int, bool> isOccupied)
+
+        public static List<PlaceInfo> CalculatePoint(Vector3Int startPoint, Vector3Int endPoint, BlockDirection blockDirection, BlockMasterElement holdingBlockMasterElement, Func<PlaceInfo, BlockMasterElement, bool> isNotExistBlock)
         {
             // ひとまず、XとZ方向に目的地に向かって1ずつ進む
             var blockSize = holdingBlockMasterElement.BlockSize;
@@ -136,14 +136,6 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.Common
             var previewPositionInfo = new BlockPositionInfo(placeInfo.Position, placeInfo.Direction, size);
 
             return !_blockGameObjectDataStore.IsOverlapPositionInfo(previewPositionInfo);
-        }
-
-        // 1×1×1セルに既存ブロックが存在するか（障害物スキャン用）
-        // Whether a 1x1x1 cell is occupied by an existing block (used by obstacle scanning).
-        private bool IsOccupied(Vector3Int cell)
-        {
-            var positionInfo = new BlockPositionInfo(cell, BlockDirection.North, Vector3Int.one);
-            return _blockGameObjectDataStore.IsOverlapPositionInfo(positionInfo);
         }
     }
 }

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/Common/CommonBlockPlaceSystem.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/Common/CommonBlockPlaceSystem.cs
@@ -34,7 +34,6 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.Common
         private BlockDirection _currentBlockDirection = BlockDirection.North;
         private Vector3Int? _clickStartPosition;
         private int _clickStartHeightOffset;
-        private bool? _isStartZDirection;
         private List<PlaceInfo> _currentPlaceInfos = new();
         private BlockId? _previousSelectedBlockId;
 
@@ -65,7 +64,6 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.Common
 
             // 連続設置状態をリセット
             _clickStartPosition = null;
-            _isStartZDirection = null;
             _currentPlaceInfos.Clear();
         }
         
@@ -175,24 +173,8 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.Common
             
             void SetCurrentPlaceInfo()
             {
-                if (_clickStartPosition.HasValue)
-                {
-                    if (_clickStartPosition.Value == placePoint)
-                    {
-                        _isStartZDirection = null;
-                    }
-                    else if (!_isStartZDirection.HasValue)
-                    {
-                        _isStartZDirection = Mathf.Abs(placePoint.z - _clickStartPosition.Value.z) > Mathf.Abs(placePoint.x - _clickStartPosition.Value.x);
-                    }
-                    
-                    _currentPlaceInfos = _blockPlacePointCalculator.CalculatePoint(_clickStartPosition.Value, placePoint, _isStartZDirection ?? true, _currentBlockDirection, holdingBlockMaster);
-                }
-                else
-                {
-                    _isStartZDirection = null;
-                    _currentPlaceInfos = _blockPlacePointCalculator.CalculatePoint(placePoint, placePoint, true, _currentBlockDirection, holdingBlockMaster);
-                }
+                var startPoint = _clickStartPosition ?? placePoint;
+                _currentPlaceInfos = _blockPlacePointCalculator.CalculatePoint(startPoint, placePoint, _currentBlockDirection, holdingBlockMaster);
             }
             
             void PlaceBlock()

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/Common/ElectricWireAutoConnect/ElectricWireAutoConnectPreview.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/Common/ElectricWireAutoConnect/ElectricWireAutoConnectPreview.cs
@@ -64,19 +64,19 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.Common.ElectricWireAutoConn
             // Evaluate cells in order while decrementing a virtual inventory, predicting the server's sequential consumption
             // 注意: ドラッグ中の未設置電柱同士の接続は評価に現れない近似（サーバーが設置順に個別再検証するため安全側）
             // Note: connections between not-yet-placed poles in a drag are approximated away (the server re-validates each in placement order, so this stays safe)
-            var virtualCounts = BuildVirtualCounts();
+            var virtualInventory = new ElectricWireAutoConnectVirtualInventory(inventory, blockMaster.RequiredItems);
             var totalCost = 0;
             var anyPlaceable = false;
             PlaceInfo cursorInfo = null;
             foreach (var placeInfo in placeInfos)
             {
                 var targets = GetOrCollectCellGeometry(placeInfo.Position);
-                var wirePlaceable = TrySelectWire(targets, virtualCounts, out var wireItemId, out var cellCost);
+                var wirePlaceable = TrySelectWire(targets, virtualInventory, out var wireItemId, out var cellCost);
                 if (!wirePlaceable) placeInfo.Placeable = false;
 
                 if (placeInfo.Placeable)
                 {
-                    ConsumeVirtual(virtualCounts, wireItemId, cellCost);
+                    virtualInventory.ConsumePlacedCell(wireItemId, cellCost);
                     totalCost += cellCost;
                     anyPlaceable = true;
                 }
@@ -102,20 +102,6 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.Common.ElectricWireAutoConn
                 _cachedDirection = direction;
                 _cachedBlockId = blockId;
                 _hasCacheKey = true;
-            }
-
-            Dictionary<ItemId, int> BuildVirtualCounts()
-            {
-                // 所持アイテムをID別に合算する
-                // Sum held items per item id
-                var counts = new Dictionary<ItemId, int>();
-                foreach (var itemStack in inventory)
-                {
-                    if (itemStack.Count <= 0) continue;
-                    counts[itemStack.Id] = counts.GetValueOrDefault(itemStack.Id) + itemStack.Count;
-                }
-
-                return counts;
             }
 
             List<(Vector3Int TargetPos, float Distance)> GetOrCollectCellGeometry(Vector3Int position)
@@ -147,7 +133,7 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.Common.ElectricWireAutoConn
 
         // 全ターゲットを賄える電線アイテムをマスタ設定順に仮想在庫から選ぶ（サーバーと同じ選定規則）
         // Pick the wire item covering all targets in master order against the virtual inventory (same rule as the server)
-        private static bool TrySelectWire(List<(Vector3Int TargetPos, float Distance)> targets, Dictionary<ItemId, int> virtualCounts, out ItemId wireItemId, out int totalCost)
+        private static bool TrySelectWire(List<(Vector3Int TargetPos, float Distance)> targets, ElectricWireAutoConnectVirtualInventory virtualInventory, out ItemId wireItemId, out int totalCost)
         {
             wireItemId = ItemMaster.EmptyItemId;
             totalCost = 0;
@@ -163,7 +149,7 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.Common.ElectricWireAutoConn
                 var candidateItemId = MasterHolder.ItemMaster.GetItemId(wireItem.ItemGuid);
                 if (!TrySumCost(candidateItemId, out var cost)) continue;
 
-                if (virtualCounts.GetValueOrDefault(candidateItemId) < cost) continue;
+                if (!virtualInventory.CanAffordWire(candidateItemId, cost)) continue;
 
                 wireItemId = candidateItemId;
                 totalCost = cost;
@@ -187,14 +173,6 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.Common.ElectricWireAutoConn
             }
 
             #endregion
-        }
-
-        // 選択電線の消費を仮想在庫へ反映する（ブロック本体は建設コスト方式のためここでは扱わない）
-        // Apply the selected wire consumption to the virtual inventory (block bodies are handled by construction cost)
-        private static void ConsumeVirtual(Dictionary<ItemId, int> virtualCounts, ItemId wireItemId, int wireCost)
-        {
-            if (wireItemId == ItemMaster.EmptyItemId || wireCost <= 0) return;
-            virtualCounts[wireItemId] = virtualCounts.GetValueOrDefault(wireItemId) - wireCost;
         }
     }
 }

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/Common/ElectricWireAutoConnect/ElectricWireAutoConnectVirtualInventory.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/Common/ElectricWireAutoConnect/ElectricWireAutoConnectVirtualInventory.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using Client.Game.InGame.UI.Inventory.Main;
+using Core.Master;
+using Mooresmaster.Model.BlocksModule;
+
+namespace Client.Game.InGame.BlockSystem.PlaceSystem.Common.ElectricWireAutoConnect
+{
+    /// <summary>
+    /// ドラッグ設置プレビュー用の仮想在庫。サーバーの逐次消費（建設コスト予約＋電線消費）を再現する
+    /// Virtual inventory for drag placement preview, replaying the server's sequential consumption (construction reservation + wire cost)
+    /// </summary>
+    public class ElectricWireAutoConnectVirtualInventory
+    {
+        private readonly Dictionary<ItemId, int> _counts = new();
+        private readonly Dictionary<ItemId, int> _constructionCostPerCell = new();
+
+        public ElectricWireAutoConnectVirtualInventory(ILocalPlayerInventory inventory, ConstructionRequiredItemElement[] requiredItems)
+        {
+            // 所持アイテムをID別に合算する
+            // Sum held items per item id
+            foreach (var itemStack in inventory)
+            {
+                if (itemStack.Count <= 0) continue;
+                _counts[itemStack.Id] = _counts.GetValueOrDefault(itemStack.Id) + itemStack.Count;
+            }
+
+            // セル1つ分の建設コストをID別に合算する
+            // Sum one cell's construction cost per item id
+            foreach (var requiredItem in requiredItems)
+            {
+                var itemId = MasterHolder.ItemMaster.GetItemId(requiredItem.ItemGuid);
+                _constructionCostPerCell[itemId] = _constructionCostPerCell.GetValueOrDefault(itemId) + requiredItem.Count;
+            }
+        }
+
+        // サーバー同様、当該セルの建設コスト予約分を上乗せして電線所持数を判定する
+        // Like the server, judge the wire count with this cell's construction reservation added on top
+        public bool CanAffordWire(ItemId wireItemId, int wireCost)
+        {
+            var requiredCount = wireCost + _constructionCostPerCell.GetValueOrDefault(wireItemId);
+            return requiredCount <= _counts.GetValueOrDefault(wireItemId);
+        }
+
+        // 設置確定セル分の電線と建設コストを仮想在庫から消費する
+        // Consume the placed cell's wire cost and construction cost from the virtual inventory
+        public void ConsumePlacedCell(ItemId wireItemId, int wireCost)
+        {
+            if (wireItemId != ItemMaster.EmptyItemId && 0 < wireCost)
+            {
+                _counts[wireItemId] = _counts.GetValueOrDefault(wireItemId) - wireCost;
+            }
+
+            foreach (var (itemId, count) in _constructionCostPerCell)
+            {
+                _counts[itemId] = _counts.GetValueOrDefault(itemId) - count;
+            }
+        }
+    }
+}

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/Common/ElectricWireAutoConnect/ElectricWireAutoConnectVirtualInventory.cs.meta
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/Common/ElectricWireAutoConnect/ElectricWireAutoConnectVirtualInventory.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a483284773bcf469ba7f304f8333474b

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/ElectricWireConnect/Modes/ElectricWireExtendMode.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/ElectricWireConnect/Modes/ElectricWireExtendMode.cs
@@ -110,7 +110,7 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.ElectricWireConnect.Modes
 
                 // 通常設置と同じ計算でPlaceInfo生成
                 // Build the pole PlaceInfo using the same calculation as normal placement
-                var placeInfos = _pointCalculator.CalculatePoint(placePoint, placePoint, true, BlockDirection.North, poleMaster);
+                var placeInfos = _pointCalculator.CalculatePoint(placePoint, placePoint, BlockDirection.North, poleMaster);
                 var placeInfo = placeInfos[0];
 
                 // 設置可否を確定しワイヤー可否と合算

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/GearChainPoleConnect/GearChainPoleConnectSystem.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/GearChainPoleConnect/GearChainPoleConnectSystem.cs
@@ -53,12 +53,12 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.GearChainPoleConnect
             if (context.SelectionType == PlacementSelectionType.Block)
             {
                 var poleBlockMaster = MasterHolder.BlockMaster.GetBlockMaster(context.SelectedBlockId.Value);
-                var input = _inputCollector.CollectPlaceExtend(context, _sourcePole, poleBlockMaster, _requestSender.IsAwaitingResponse);
+                var input = _inputCollector.CollectPlaceExtend(_sourcePole, poleBlockMaster, _requestSender.IsAwaitingResponse);
                 result = GearChainPolePlaceExtendMode.Decide(input);
             }
             else
             {
-                var input = _inputCollector.CollectChainConnect(context, _sourcePole);
+                var input = _inputCollector.CollectChainConnect(_sourcePole);
                 result = GearChainPoleChainConnectMode.Decide(input);
             }
 

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/GearChainPoleConnect/Modes/GearChainPoleFrameInputCollector.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/GearChainPoleConnect/Modes/GearChainPoleFrameInputCollector.cs
@@ -39,7 +39,7 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.GearChainPoleConnect.Modes
             _previewObject = previewObject;
         }
 
-        public GearChainPolePlaceExtendInput CollectPlaceExtend(PlaceSystemUpdateContext context, IGearChainPoleConnectAreaCollider sourcePole, BlockMasterElement poleBlockMaster, bool isAwaitingResponse)
+        public GearChainPolePlaceExtendInput CollectPlaceExtend(IGearChainPoleConnectAreaCollider sourcePole, BlockMasterElement poleBlockMaster, bool isAwaitingResponse)
         {
             var poleParam = (GearChainPoleBlockParam)poleBlockMaster.BlockParam;
 
@@ -85,7 +85,7 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.GearChainPoleConnect.Modes
             return input;
         }
 
-        public GearChainPoleChainConnectInput CollectChainConnect(PlaceSystemUpdateContext context, IGearChainPoleConnectAreaCollider sourcePole)
+        public GearChainPoleChainConnectInput CollectChainConnect(IGearChainPoleConnectAreaCollider sourcePole)
         {
             // 接続に使うチェーンアイテムをインベントリから自動選択する（手持ち非依存）
             // Auto-select the chain item from inventory, independent of the held item

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/StateProcessor/ConnectionLine.meta
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/StateProcessor/ConnectionLine.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f85c3dd95e0de491a9b832c59f8eafba
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/StateProcessor/ConnectionLine/ConnectionLineViewBase.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/StateProcessor/ConnectionLine/ConnectionLineViewBase.cs
@@ -1,0 +1,111 @@
+using System.Collections.Generic;
+using System.Linq;
+using Client.Common.Asset;
+using Client.Game.InGame.Block;
+using Game.Block.Interface;
+using UnityEngine;
+
+namespace Client.Game.InGame.BlockSystem.StateProcessor.ConnectionLine
+{
+    /// <summary>
+    /// ブロック間の接続ライン群を管理・表示するビューの共通基底
+    /// Common base for views that manage and display connection lines between blocks
+    /// </summary>
+    public abstract class ConnectionLineViewBase<TElement> : MonoBehaviour where TElement : MonoBehaviour, IConnectionLineViewElement
+    {
+        private BlockInstanceId _myBlockInstanceId;
+        private TElement _linePrefab;
+
+        // 接続先InstanceId -> 生成したラインElement
+        // Target InstanceId -> Generated line element
+        private readonly Dictionary<BlockInstanceId, TElement> _activeLines = new();
+
+        // ラインElementプレハブのAddressableアドレス
+        // Addressable address of the line element prefab
+        protected abstract string GetLinePrefabAddress();
+
+        public void Initialize(BlockGameObject blockGameObject)
+        {
+            var prefab = AddressableLoader.LoadDefault<GameObject>(GetLinePrefabAddress());
+            _linePrefab = prefab.GetComponent<TElement>();
+
+            _myBlockInstanceId = blockGameObject.BlockInstanceId;
+        }
+
+        /// <summary>
+        /// 接続ラインの表示を更新する
+        /// Update the connection line display
+        /// </summary>
+        public void UpdateConnectionLines(BlockInstanceId[] partnerInstanceIds)
+        {
+            var newInstanceIds = new HashSet<BlockInstanceId>(partnerInstanceIds);
+
+            // 不要になったラインを削除する
+            // Remove lines that are no longer needed
+            RemoveOldLines(newInstanceIds);
+
+            // 新規接続のラインを作成する
+            // Create lines for new connections
+            AddNewLines(partnerInstanceIds);
+
+            #region Internal
+
+            void RemoveOldLines(HashSet<BlockInstanceId> currentInstanceIds)
+            {
+                var idsToRemove = _activeLines.Keys
+                    .Where(id => !currentInstanceIds.Contains(id))
+                    .ToList();
+
+                foreach (var id in idsToRemove)
+                {
+                    if (_activeLines.TryGetValue(id, out var element))
+                    {
+                        Destroy(element.gameObject);
+                    }
+                    _activeLines.Remove(id);
+                }
+            }
+
+            void AddNewLines(BlockInstanceId[] instanceIds)
+            {
+                foreach (var targetId in instanceIds)
+                {
+                    if (_activeLines.ContainsKey(targetId)) continue;
+                    if (!ShouldDrawLine(_myBlockInstanceId, targetId)) continue;
+
+                    var element = CreateLineElement(targetId);
+                    _activeLines[targetId] = element;
+                }
+            }
+
+            // 重複回避：InstanceId比較で小さい方のみ描画担当
+            // Duplicate avoidance: Only the one with smaller InstanceId draws
+            bool ShouldDrawLine(BlockInstanceId myId, BlockInstanceId targetId)
+            {
+                return myId.AsPrimitive() < targetId.AsPrimitive();
+            }
+
+            // ラインElementを生成する
+            // Create the line element
+            TElement CreateLineElement(BlockInstanceId targetId)
+            {
+                var element = Instantiate(_linePrefab, transform);
+                element.SetLine(_myBlockInstanceId, targetId);
+                return element;
+            }
+
+            #endregion
+        }
+
+        private void OnDestroy()
+        {
+            // すべてのラインを削除する
+            // Destroy all lines
+            foreach (var element in _activeLines.Values)
+            {
+                if (element != null) Destroy(element.gameObject);
+            }
+            _activeLines.Clear();
+        }
+    }
+}

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/StateProcessor/ConnectionLine/ConnectionLineViewBase.cs.meta
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/StateProcessor/ConnectionLine/ConnectionLineViewBase.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f657c74c281304e79b67ded5d0a61450

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/StateProcessor/ConnectionLine/IConnectionLineViewElement.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/StateProcessor/ConnectionLine/IConnectionLineViewElement.cs
@@ -1,0 +1,15 @@
+using Game.Block.Interface;
+
+namespace Client.Game.InGame.BlockSystem.StateProcessor.ConnectionLine
+{
+    /// <summary>
+    /// ブロック間接続ラインの1本分の表示要素
+    /// A single connection line element between two blocks
+    /// </summary>
+    public interface IConnectionLineViewElement
+    {
+        // ラインの両端ブロックを設定する
+        // Set both endpoint blocks of the line
+        void SetLine(BlockInstanceId fromId, BlockInstanceId toId);
+    }
+}

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/StateProcessor/ConnectionLine/IConnectionLineViewElement.cs.meta
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/StateProcessor/ConnectionLine/IConnectionLineViewElement.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 04260e6f163614e448c0b2858b4de3f4

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/StateProcessor/ElectricWire/ElectricWireLineView.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/StateProcessor/ElectricWire/ElectricWireLineView.cs
@@ -1,9 +1,4 @@
-using System.Collections.Generic;
-using System.Linq;
-using Client.Common.Asset;
-using Client.Game.InGame.Block;
-using Game.Block.Interface;
-using UnityEngine;
+using Client.Game.InGame.BlockSystem.StateProcessor.ConnectionLine;
 
 namespace Client.Game.InGame.BlockSystem.StateProcessor.ElectricWire
 {
@@ -11,99 +6,13 @@ namespace Client.Game.InGame.BlockSystem.StateProcessor.ElectricWire
     /// 電力ワイヤーの接続を視覚的に表示するコンポーネント
     /// Component for visually displaying electric wire connections
     /// </summary>
-    public class ElectricWireLineView : MonoBehaviour
+    public class ElectricWireLineView : ConnectionLineViewBase<ElectricWireLineViewElement>
     {
         private const string WireLinePrefabAddress = "Vanilla/Block/Util/ElectricWireLine";
 
-        private BlockInstanceId _myBlockInstanceId;
-        private ElectricWireLineViewElement _wireLinePrefab;
-
-        // 接続先InstanceId -> 生成したワイヤーElement
-        // Target InstanceId -> Generated wire element
-        private readonly Dictionary<BlockInstanceId, ElectricWireLineViewElement> _activeLines = new();
-
-        public void Initialize(BlockGameObject blockGameObject)
+        protected override string GetLinePrefabAddress()
         {
-            var prefab = AddressableLoader.LoadDefault<GameObject>(WireLinePrefabAddress);
-            _wireLinePrefab = prefab.GetComponent<ElectricWireLineViewElement>();
-
-            _myBlockInstanceId = blockGameObject.BlockInstanceId;
-        }
-
-        /// <summary>
-        /// ワイヤー接続の表示を更新する
-        /// Update the wire connection display
-        /// </summary>
-        public void UpdateWireLines(BlockInstanceId[] partnerInstanceIds)
-        {
-            var newInstanceIds = new HashSet<BlockInstanceId>(partnerInstanceIds);
-
-            // 不要になったラインを削除する
-            // Remove lines that are no longer needed
-            RemoveOldLines(newInstanceIds);
-
-            // 新規接続のラインを作成する
-            // Create lines for new connections
-            AddNewLines(partnerInstanceIds);
-
-            #region Internal
-
-            void RemoveOldLines(HashSet<BlockInstanceId> currentInstanceIds)
-            {
-                var idsToRemove = _activeLines.Keys
-                    .Where(id => !currentInstanceIds.Contains(id))
-                    .ToList();
-
-                foreach (var id in idsToRemove)
-                {
-                    if (_activeLines.TryGetValue(id, out var element))
-                    {
-                        Destroy(element.gameObject);
-                    }
-                    _activeLines.Remove(id);
-                }
-            }
-
-            void AddNewLines(BlockInstanceId[] instanceIds)
-            {
-                foreach (var targetId in instanceIds)
-                {
-                    if (_activeLines.ContainsKey(targetId)) continue;
-                    if (!ShouldDrawLine(_myBlockInstanceId, targetId)) continue;
-
-                    var element = CreateWireLineElement(targetId);
-                    _activeLines[targetId] = element;
-                }
-            }
-
-            // 重複回避：InstanceId比較で小さい方のみ描画担当
-            // Duplicate avoidance: Only the one with smaller InstanceId draws
-            bool ShouldDrawLine(BlockInstanceId myId, BlockInstanceId targetId)
-            {
-                return myId.AsPrimitive() < targetId.AsPrimitive();
-            }
-
-            // ワイヤーラインElementを生成する
-            // Create wire line element
-            ElectricWireLineViewElement CreateWireLineElement(BlockInstanceId targetId)
-            {
-                var element = Instantiate(_wireLinePrefab, transform);
-                element.SetLine(_myBlockInstanceId, targetId);
-                return element;
-            }
-
-            #endregion
-        }
-
-        private void OnDestroy()
-        {
-            // すべてのラインを削除する
-            // Destroy all lines
-            foreach (var element in _activeLines.Values)
-            {
-                if (element != null) Destroy(element.gameObject);
-            }
-            _activeLines.Clear();
+            return WireLinePrefabAddress;
         }
     }
 }

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/StateProcessor/ElectricWire/ElectricWireLineViewElement.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/StateProcessor/ElectricWire/ElectricWireLineViewElement.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Client.Common;
 using Client.Game.InGame.Block;
+using Client.Game.InGame.BlockSystem.StateProcessor.ConnectionLine;
 using Client.Game.InGame.Context;
 using Game.Block.Interface;
 using UnityEngine;
@@ -11,7 +12,7 @@ namespace Client.Game.InGame.BlockSystem.StateProcessor.ElectricWire
     /// 単一の電力ワイヤー接続をカテナリー曲線で表示するコンポーネント
     /// Component that renders a single electric wire connection as a catenary curve
     /// </summary>
-    public class ElectricWireLineViewElement : MonoBehaviour
+    public class ElectricWireLineViewElement : MonoBehaviour, IConnectionLineViewElement
     {
         // ワイヤーの垂れ量は両端距離に比例させる
         // Wire sag is proportional to the distance between endpoints
@@ -19,6 +20,9 @@ namespace Client.Game.InGame.BlockSystem.StateProcessor.ElectricWire
         // 未解決時の再解決を試みる間隔
         // Interval between resolution retries while unresolved
         private const float RetryIntervalSeconds = 0.5f;
+        // CapsuleColliderのdirectionはローカルY軸を表す1
+        // CapsuleCollider direction value 1 means the local Y axis
+        private const int CapsuleDirectionYAxis = 1;
         [SerializeField] private MeshFilter meshFilter;
 
         private Mesh _generatedMesh;
@@ -122,7 +126,7 @@ namespace Client.Game.InGame.BlockSystem.StateProcessor.ElectricWire
                     // Make it a trigger to avoid physical collision with the player (still hit by raycasts)
                     var capsule = colliderObject.AddComponent<CapsuleCollider>();
                     capsule.isTrigger = true;
-                    capsule.direction = 1;
+                    capsule.direction = CapsuleDirectionYAxis;
                     capsule.radius = CatenaryWireMeshBuilder.WireRadius;
                     capsule.height = segment.length;
                 }

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/StateProcessor/ElectricWire/ElectricWireStateChangeProcessor.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/StateProcessor/ElectricWire/ElectricWireStateChangeProcessor.cs
@@ -51,7 +51,7 @@ namespace Client.Game.InGame.BlockSystem.StateProcessor.ElectricWire
 
             // ワイヤー表示を更新する
             // Update the wire display
-            _wireLineView.UpdateWireLines(partnerInstanceIds);
+            _wireLineView.UpdateConnectionLines(partnerInstanceIds);
         }
     }
 }

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/StateProcessor/GearChainPoleStateChangeProcessor.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/StateProcessor/GearChainPoleStateChangeProcessor.cs
@@ -37,7 +37,7 @@ namespace Client.Game.InGame.BlockSystem.StateProcessor
 
             // ライン表示を更新
             // Update line display
-            chainLineView.UpdateChainLines(partnerInstanceIds);
+            chainLineView.UpdateConnectionLines(partnerInstanceIds);
         }
     }
 }

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/StateProcessor/GearPole/GearChainPoleChainLineView.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/StateProcessor/GearPole/GearChainPoleChainLineView.cs
@@ -1,9 +1,4 @@
-using System.Collections.Generic;
-using System.Linq;
-using Client.Common.Asset;
-using Client.Game.InGame.Block;
-using Game.Block.Interface;
-using UnityEngine;
+using Client.Game.InGame.BlockSystem.StateProcessor.ConnectionLine;
 
 namespace Client.Game.InGame.BlockSystem.StateProcessor.GearPole
 {
@@ -11,100 +6,13 @@ namespace Client.Game.InGame.BlockSystem.StateProcessor.GearPole
     /// GearChainPoleのチェーン接続を視覚的に表示するコンポーネント
     /// Component for visually displaying chain connections of GearChainPole
     /// </summary>
-    public class GearChainPoleChainLineView : MonoBehaviour
+    public class GearChainPoleChainLineView : ConnectionLineViewBase<GearChainPoleChainLineViewElement>
     {
         private const string ChainLinePrefabAddress = "Vanilla/Block/Util/GearChainLine";
 
-        private BlockInstanceId _myBlockInstanceId;
-        private GearChainPoleChainLineViewElement _chainLinePrefab;
-
-        // 接続先InstanceId -> 生成したラインElement
-        // Target InstanceId -> Generated line element
-        private readonly Dictionary<BlockInstanceId, GearChainPoleChainLineViewElement> _activeLines = new();
-
-        public void Initialize(BlockGameObject blockGameObject)
+        protected override string GetLinePrefabAddress()
         {
-            var prefab = AddressableLoader.LoadDefault<GameObject>(ChainLinePrefabAddress);
-            _chainLinePrefab = prefab.GetComponent<GearChainPoleChainLineViewElement>();
-
-            _myBlockInstanceId = blockGameObject.BlockInstanceId;
-        }
-
-        /// <summary>
-        /// チェーン接続の表示を更新する
-        /// Update the chain connection display
-        /// </summary>
-        public void UpdateChainLines(BlockInstanceId[] partnerInstanceIds)
-        {
-            var newInstanceIds = new HashSet<BlockInstanceId>(partnerInstanceIds);
-
-            // 削除対象を特定して削除
-            // Identify and remove lines that are no longer needed
-            RemoveOldLines(newInstanceIds);
-
-            // 新規接続のラインを作成
-            // Create lines for new connections
-            AddNewLines(partnerInstanceIds);
-
-            #region Internal
-
-            void RemoveOldLines(HashSet<BlockInstanceId> currentInstanceIds)
-            {
-                var idsToRemove = _activeLines.Keys
-                    .Where(id => !currentInstanceIds.Contains(id))
-                    .ToList();
-
-                foreach (var id in idsToRemove)
-                {
-                    if (_activeLines.TryGetValue(id, out var element))
-                    {
-                        Destroy(element.gameObject);
-                    }
-                    _activeLines.Remove(id);
-                }
-            }
-
-            void AddNewLines(BlockInstanceId[] instanceIds)
-            {
-                foreach (var targetId in instanceIds)
-                {
-                    if (_activeLines.ContainsKey(targetId)) continue;
-                    if (!ShouldDrawLine(_myBlockInstanceId, targetId)) continue;
-
-                    var element = CreateChainLineElement(targetId);
-                    _activeLines[targetId] = element;
-                }
-            }
-            
-            // 重複回避：InstanceId比較で小さい方のみ描画担当
-            // Duplicate avoidance: Only the one with smaller InstanceId draws
-            bool ShouldDrawLine(BlockInstanceId myId, BlockInstanceId targetId)
-            {
-                return myId.AsPrimitive() < targetId.AsPrimitive();
-            }
-            
-            // チェーンラインElementを生成する
-            // Create chain line element
-            GearChainPoleChainLineViewElement CreateChainLineElement(BlockInstanceId targetId)
-            {
-                var element = Instantiate(_chainLinePrefab, transform);
-                element.SetLine(_myBlockInstanceId, targetId);
-                return element;
-            }
-            
-
-            #endregion
-        }
-
-        private void OnDestroy()
-        {
-            // すべてのラインを削除
-            // Destroy all lines
-            foreach (var element in _activeLines.Values)
-            {
-                if (element != null) Destroy(element.gameObject);
-            }
-            _activeLines.Clear();
+            return ChainLinePrefabAddress;
         }
     }
 }

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/StateProcessor/GearPole/GearChainPoleChainLineViewElement.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/StateProcessor/GearPole/GearChainPoleChainLineViewElement.cs
@@ -1,3 +1,4 @@
+using Client.Game.InGame.BlockSystem.StateProcessor.ConnectionLine;
 using Client.Game.InGame.Context;
 using Game.Block.Interface;
 using UnityEngine;
@@ -8,7 +9,7 @@ namespace Client.Game.InGame.BlockSystem.StateProcessor.GearPole
     /// 単一のチェーン接続を表示するコンポーネント
     /// Component for displaying a single chain connection
     /// </summary>
-    public class GearChainPoleChainLineViewElement : MonoBehaviour
+    public class GearChainPoleChainLineViewElement : MonoBehaviour, IConnectionLineViewElement
     {
         private const float LineSpacing = 0.1f;
 

--- a/moorestech_client/Assets/Scripts/Client.Tests/PlaceSystem/CommonBlockPlacePointCalculatorTest.cs
+++ b/moorestech_client/Assets/Scripts/Client.Tests/PlaceSystem/CommonBlockPlacePointCalculatorTest.cs
@@ -19,8 +19,8 @@ namespace Client.Tests.PlaceSystem
             var blockMasterElement = MakeBlock(Vector3Int.one);
 
             var actual = CommonBlockPlacePointCalculator.CalculatePoint(
-                new Vector3Int(0, 0, 0), new Vector3Int(2, 0, 0), false, BlockDirection.East,
-                blockMasterElement, (_, _) => true, _ => false);
+                new Vector3Int(0, 0, 0), new Vector3Int(2, 0, 0), BlockDirection.East,
+                blockMasterElement, (_, _) => true);
 
             Assert.AreEqual(3, actual.Count);
             foreach (var info in actual)
@@ -39,8 +39,8 @@ namespace Client.Tests.PlaceSystem
             var blockMasterElement = MakeBlock(new Vector3Int(2, 1, 1));
 
             var actual = CommonBlockPlacePointCalculator.CalculatePoint(
-                new Vector3Int(0, 0, 0), new Vector3Int(4, 0, 0), false, BlockDirection.North,
-                blockMasterElement, (_, _) => true, _ => false);
+                new Vector3Int(0, 0, 0), new Vector3Int(4, 0, 0), BlockDirection.North,
+                blockMasterElement, (_, _) => true);
 
             Assert.AreEqual(3, actual.Count);
             Assert.AreEqual(new Vector3Int(0, 0, 0), actual[0].Position);
@@ -57,8 +57,8 @@ namespace Client.Tests.PlaceSystem
             var occupied = new Vector3Int(1, 0, 0);
 
             var actual = CommonBlockPlacePointCalculator.CalculatePoint(
-                new Vector3Int(0, 0, 0), new Vector3Int(2, 0, 0), false, BlockDirection.East,
-                blockMasterElement, (info, _) => info.Position != occupied, _ => false);
+                new Vector3Int(0, 0, 0), new Vector3Int(2, 0, 0), BlockDirection.East,
+                blockMasterElement, (info, _) => info.Position != occupied);
 
             Assert.IsTrue(actual[0].Placeable);
             Assert.IsFalse(actual[1].Placeable);

--- a/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/ElectricWireConnectionEditProtocol.cs
+++ b/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/ElectricWireConnectionEditProtocol.cs
@@ -105,8 +105,6 @@ namespace Server.Protocol.PacketResponse
             [Key(2)] public bool IsSuccess { get; set; }
             [Key(3)] public ElectricWirePlacementFailureReason FailureReason { get; set; }
 
-            [IgnoreMember] public bool HasError => FailureReason != ElectricWirePlacementFailureReason.None;
-
             [Obsolete("デシリアライズ用のコンストラクタです。基本的に使用しないでください。")]
             public ElectricWireConnectionEditResponse() { }
 

--- a/moorestech_server/Assets/Scripts/Tests/CombinedTest/Server/PacketTest/AttachTrainCarToUnitProtocolTest.cs
+++ b/moorestech_server/Assets/Scripts/Tests/CombinedTest/Server/PacketTest/AttachTrainCarToUnitProtocolTest.cs
@@ -92,7 +92,7 @@ namespace Tests.CombinedTest.Server.PacketTest
             AssertRejected(setup, response, AttachTrainCarFailureType.ItemNotFound);
         }
 
-        #region Internal
+        #region TestUtil
 
         private readonly struct AttachTestSetup
         {

--- a/moorestech_server/Assets/Scripts/Tests/CombinedTest/Server/PacketTest/GearChain.meta
+++ b/moorestech_server/Assets/Scripts/Tests/CombinedTest/Server/PacketTest/GearChain.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3fe5dddaf43a6466a83ca2d3407ce52a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/moorestech_server/Assets/Scripts/Tests/CombinedTest/Server/PacketTest/GearChain/GearChainPoleExtendTestHelper.cs
+++ b/moorestech_server/Assets/Scripts/Tests/CombinedTest/Server/PacketTest/GearChain/GearChainPoleExtendTestHelper.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Linq;
+using Core.Inventory;
+using Core.Master;
+using Game.Block.Interface;
+using Game.Context;
+using Game.PlayerInventory.Interface;
+using Game.World.Interface.DataStore;
+using MessagePack;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Server.Boot;
+using Server.Protocol;
+using Server.Protocol.PacketResponse;
+using Server.Protocol.PacketResponse.Util.GearChain;
+using Tests.Module;
+using Tests.Module.TestMod;
+using UnityEngine;
+
+namespace Tests.CombinedTest.Server.PacketTest.GearChain
+{
+    /// <summary>
+    /// GearChainPoleExtendProtocolTestのサーバー準備・送受信・不変検証ヘルパー
+    /// Server setup, send/receive and no-state-change assertion helper for GearChainPoleExtendProtocolTest
+    /// </summary>
+    public class GearChainPoleExtendTestHelper
+    {
+        public const int PlayerId = 1;
+        public static readonly Vector3Int FromPos = Vector3Int.zero;
+
+        // ポールの建設コスト(Test3 x2)。BlockId化に伴いポールアイテムではなく素材を消費する
+        // Construction cost of the pole (Test3 x2). After BlockId migration, materials are consumed instead of a pole item
+        private static readonly Guid MaterialGuid = Guid.Parse("00000000-0000-0000-1234-000000000003");
+
+        public readonly ItemId ChainItemId;
+        public readonly ItemId MaterialItemId;
+
+        private readonly PacketResponseCreator _packet;
+        private readonly IOpenableInventory _inventory;
+
+        public GearChainPoleExtendTestHelper()
+        {
+            // サーバーと起点ポールを準備する
+            // Prepare the server and the source pole
+            var (packet, serviceProvider) = new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
+            _packet = packet;
+            ChainItemId = MasterHolder.ItemMaster.GetItemId(ChainConstants.ChainItemGuid);
+            MaterialItemId = MasterHolder.ItemMaster.GetItemId(MaterialGuid);
+            _inventory = serviceProvider.GetService<IPlayerInventoryDataStore>().GetInventoryData(PlayerId).MainOpenableInventory;
+            ServerContext.WorldBlockDatastore.TryAddBlock(ForUnitTestModBlockId.GearChainPole, FromPos, BlockDirection.North, Array.Empty<BlockCreateParam>(), out _);
+        }
+
+        public void SetInventory(int chainCount, int materialCount)
+        {
+            _inventory.SetItem(0, ServerContext.ItemStackFactory.Create(ChainItemId, chainCount));
+            if (0 < materialCount) _inventory.SetItem(1, ServerContext.ItemStackFactory.Create(MaterialItemId, materialCount));
+        }
+
+        public void AssertExtendFailsWithoutStateChange(Vector3Int placePos, string expectedError, int expectedChainCount, int expectedMaterialCount)
+        {
+            // 失敗時に一切の状態変更が起きないことを検証する
+            // Verify failures leave absolutely no state changes
+            var response = SendExtend(placePos);
+            Assert.False(response.IsSuccess);
+            Assert.AreEqual(expectedError, response.Error);
+            Assert.False(ServerContext.WorldBlockDatastore.Exists(placePos));
+            Assert.AreEqual(expectedChainCount, CountItem(ChainItemId));
+            Assert.AreEqual(expectedMaterialCount, CountItem(MaterialItemId));
+        }
+
+        public GearChainPoleExtendProtocol.GearChainPoleExtendResponse SendExtend(Vector3Int placePos)
+        {
+            return SendExtendWithBlock(placePos, ForUnitTestModBlockId.GearChainPole);
+        }
+
+        public GearChainPoleExtendProtocol.GearChainPoleExtendResponse SendExtendWithBlock(Vector3Int placePos, BlockId poleBlockId)
+        {
+            var request = GearChainPoleExtendProtocol.GearChainPoleExtendRequest.CreateExtendRequest(PlayerId, FromPos, poleBlockId, CreatePlaceInfo(placePos), ChainItemId);
+            return Send(request);
+        }
+
+        public GearChainPoleExtendProtocol.GearChainPoleExtendResponse SendIsolated(Vector3Int placePos)
+        {
+            var request = GearChainPoleExtendProtocol.GearChainPoleExtendRequest.CreateIsolatedPlaceRequest(PlayerId, ForUnitTestModBlockId.GearChainPole, CreatePlaceInfo(placePos));
+            return Send(request);
+        }
+
+        public int CountItem(ItemId itemId)
+        {
+            return _inventory.InventoryItems.Where(stack => stack.Id == itemId).Sum(stack => stack.Count);
+        }
+
+        private GearChainPoleExtendProtocol.GearChainPoleExtendResponse Send(GearChainPoleExtendProtocol.GearChainPoleExtendRequest request)
+        {
+            var responseBytes = _packet.GetPacketResponse(MessagePackSerializer.Serialize(request), new PacketResponseContext()).First();
+            return MessagePackSerializer.Deserialize<GearChainPoleExtendProtocol.GearChainPoleExtendResponse>(responseBytes.ToArray());
+        }
+
+        private static PlaceInfo CreatePlaceInfo(Vector3Int placePos)
+        {
+            return new PlaceInfo
+            {
+                Position = placePos,
+                Direction = BlockDirection.North,
+                VerticalDirection = BlockVerticalDirection.Horizontal,
+            };
+        }
+    }
+}

--- a/moorestech_server/Assets/Scripts/Tests/CombinedTest/Server/PacketTest/GearChain/GearChainPoleExtendTestHelper.cs.meta
+++ b/moorestech_server/Assets/Scripts/Tests/CombinedTest/Server/PacketTest/GearChain/GearChainPoleExtendTestHelper.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 99549e321615d45a283b4371ae15c2de

--- a/moorestech_server/Assets/Scripts/Tests/CombinedTest/Server/PacketTest/GearChainPoleExtendProtocolTest.cs
+++ b/moorestech_server/Assets/Scripts/Tests/CombinedTest/Server/PacketTest/GearChainPoleExtendProtocolTest.cs
@@ -1,20 +1,11 @@
 using System;
 using System.Linq;
-using Core.Inventory;
-using Core.Master;
 using Game.Block.Interface;
 using Game.Context;
-using Game.Gear.Common;
-using Game.PlayerInventory.Interface;
 using Game.World.Interface.DataStore;
-using MessagePack;
-using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
-using Server.Boot;
-using Server.Protocol;
-using Server.Protocol.PacketResponse;
 using Server.Protocol.PacketResponse.Util.GearChain;
-using Tests.Module;
+using Tests.CombinedTest.Server.PacketTest.GearChain;
 using Tests.Module.TestMod;
 using UnityEngine;
 
@@ -22,37 +13,22 @@ namespace Tests.CombinedTest.Server.PacketTest
 {
     public class GearChainPoleExtendProtocolTest
     {
-        private const int PlayerId = 1;
-        private static readonly Vector3Int FromPos = Vector3Int.zero;
+        private static readonly Vector3Int FromPos = GearChainPoleExtendTestHelper.FromPos;
 
-        // ポールの建設コスト(Test3 x2)。BlockId化に伴いポールアイテムではなく素材を消費する
-        // Construction cost of the pole (Test3 x2). After BlockId migration, materials are consumed instead of a pole item
-        private static readonly Guid MaterialGuid = Guid.Parse("00000000-0000-0000-1234-000000000003");
-
-        private PacketResponseCreator _packet;
-        private ItemId _chainItemId;
-        private ItemId _materialItemId;
-        private IOpenableInventory _inventory;
+        private GearChainPoleExtendTestHelper _helper;
 
         [SetUp]
         public void SetUp()
         {
-            // サーバーと起点ポールを準備する
-            // Prepare the server and the source pole
-            var (packet, serviceProvider) = new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
-            _packet = packet;
-            _chainItemId = MasterHolder.ItemMaster.GetItemId(ChainConstants.ChainItemGuid);
-            _materialItemId = MasterHolder.ItemMaster.GetItemId(MaterialGuid);
-            _inventory = serviceProvider.GetService<IPlayerInventoryDataStore>().GetInventoryData(PlayerId).MainOpenableInventory;
-            ServerContext.WorldBlockDatastore.TryAddBlock(ForUnitTestModBlockId.GearChainPole, FromPos, BlockDirection.North, Array.Empty<BlockCreateParam>(), out _);
+            _helper = new GearChainPoleExtendTestHelper();
         }
 
         [Test]
         public void ExtendPlacesConnectsAndConsumesItems()
         {
-            SetInventory(5, 3);
+            _helper.SetInventory(5, 3);
             var placePos = new Vector3Int(3, 0, 0);
-            var response = SendExtend(placePos);
+            var response = _helper.SendExtend(placePos);
 
             // 設置・応答内容を検証する
             // Verify placement and response payload
@@ -72,16 +48,16 @@ namespace Tests.CombinedTest.Server.PacketTest
 
             // 距離3分のチェーンと建設コスト(Test3 x2)の消費を検証する
             // Verify consumption of 3 chains (distance) and the construction cost (Test3 x2)
-            Assert.AreEqual(2, CountItem(_chainItemId));
-            Assert.AreEqual(1, CountItem(_materialItemId));
+            Assert.AreEqual(2, _helper.CountItem(_helper.ChainItemId));
+            Assert.AreEqual(1, _helper.CountItem(_helper.MaterialItemId));
         }
 
         [Test]
         public void IsolatedPlaceDoesNotConnectOrConsumeChain()
         {
-            SetInventory(5, 3);
+            _helper.SetInventory(5, 3);
             var placePos = new Vector3Int(5, 0, 5);
-            var response = SendIsolated(placePos);
+            var response = _helper.SendIsolated(placePos);
 
             // 接続なしで設置されチェーン非消費・素材のみ消費を検証
             // Verify pole placed without connection: no chain consumed, only materials consumed
@@ -89,22 +65,22 @@ namespace Tests.CombinedTest.Server.PacketTest
             Assert.True(ServerContext.WorldBlockDatastore.Exists(placePos));
             GearChainSystemUtil.TryGetGearChainPole(placePos, out _, out var transformer);
             Assert.IsEmpty(transformer.GetGearConnects());
-            Assert.AreEqual(5, CountItem(_chainItemId));
-            Assert.AreEqual(1, CountItem(_materialItemId));
+            Assert.AreEqual(5, _helper.CountItem(_helper.ChainItemId));
+            Assert.AreEqual(1, _helper.CountItem(_helper.MaterialItemId));
         }
 
         [Test]
         public void ExtendFailsWhenTooFar()
         {
-            SetInventory(20, 3);
-            AssertExtendFailsWithoutStateChange(new Vector3Int(11, 0, 0), GearChainPlacementEvaluator.TooFarError, 20, 3);
+            _helper.SetInventory(20, 3);
+            _helper.AssertExtendFailsWithoutStateChange(new Vector3Int(11, 0, 0), GearChainPlacementEvaluator.TooFarError, 20, 3);
         }
 
         [Test]
         public void ExtendFailsWithoutChainItem()
         {
-            SetInventory(2, 3);
-            AssertExtendFailsWithoutStateChange(new Vector3Int(3, 0, 0), GearChainPlacementEvaluator.NoItemError, 2, 3);
+            _helper.SetInventory(2, 3);
+            _helper.AssertExtendFailsWithoutStateChange(new Vector3Int(3, 0, 0), GearChainPlacementEvaluator.NoItemError, 2, 3);
         }
 
         [Test]
@@ -112,8 +88,8 @@ namespace Tests.CombinedTest.Server.PacketTest
         {
             // 素材(建設コスト)を持たない場合はInsufficientItemsで失敗し状態不変
             // Without the materials (construction cost), it fails with InsufficientItems and leaves no state change
-            SetInventory(5, 0);
-            AssertExtendFailsWithoutStateChange(new Vector3Int(3, 0, 0), GearChainPlacementEvaluator.InsufficientItemsError, 5, 0);
+            _helper.SetInventory(5, 0);
+            _helper.AssertExtendFailsWithoutStateChange(new Vector3Int(3, 0, 0), GearChainPlacementEvaluator.InsufficientItemsError, 5, 0);
         }
 
         [Test]
@@ -121,15 +97,15 @@ namespace Tests.CombinedTest.Server.PacketTest
         {
             // 未解放ポールブロックIDを送るとNotUnlockedで失敗し状態不変
             // Sending a locked pole BlockId fails with NotUnlocked and leaves no state change
-            SetInventory(5, 3);
+            _helper.SetInventory(5, 3);
             var placePos = new Vector3Int(3, 0, 0);
-            var response = SendExtendWithBlock(placePos, ForUnitTestModBlockId.LockedGearChainPole);
+            var response = _helper.SendExtendWithBlock(placePos, ForUnitTestModBlockId.LockedGearChainPole);
 
             Assert.False(response.IsSuccess);
             Assert.AreEqual(GearChainPlacementEvaluator.NotUnlockedError, response.Error);
             Assert.False(ServerContext.WorldBlockDatastore.Exists(placePos));
-            Assert.AreEqual(5, CountItem(_chainItemId));
-            Assert.AreEqual(3, CountItem(_materialItemId));
+            Assert.AreEqual(5, _helper.CountItem(_helper.ChainItemId));
+            Assert.AreEqual(3, _helper.CountItem(_helper.MaterialItemId));
         }
 
         [Test]
@@ -137,85 +113,29 @@ namespace Tests.CombinedTest.Server.PacketTest
         {
             // 起点ポールを上限(2)まで接続してから延長を試みる
             // Fill the source pole to its limit (2) then attempt extension
-            SetInventory(10, 3);
+            _helper.SetInventory(10, 3);
             ServerContext.WorldBlockDatastore.TryAddBlock(ForUnitTestModBlockId.GearChainPole, new Vector3Int(2, 0, 0), BlockDirection.North, Array.Empty<BlockCreateParam>(), out _);
             ServerContext.WorldBlockDatastore.TryAddBlock(ForUnitTestModBlockId.GearChainPole, new Vector3Int(-2, 0, 0), BlockDirection.North, Array.Empty<BlockCreateParam>(), out _);
-            Assert.True(GearChainSystemUtil.TryConnect(FromPos, new Vector3Int(2, 0, 0), PlayerId, _chainItemId, out _));
-            Assert.True(GearChainSystemUtil.TryConnect(FromPos, new Vector3Int(-2, 0, 0), PlayerId, _chainItemId, out _));
+            Assert.True(GearChainSystemUtil.TryConnect(FromPos, new Vector3Int(2, 0, 0), GearChainPoleExtendTestHelper.PlayerId, _helper.ChainItemId, out _));
+            Assert.True(GearChainSystemUtil.TryConnect(FromPos, new Vector3Int(-2, 0, 0), GearChainPoleExtendTestHelper.PlayerId, _helper.ChainItemId, out _));
 
             // 手動接続でチェーン4個消費済み(6残)、素材は未消費(3)
             // 4 chains consumed by manual connects (6 left), materials untouched (3)
-            AssertExtendFailsWithoutStateChange(new Vector3Int(0, 0, 3), GearChainPlacementEvaluator.ConnectionLimitError, 6, 3);
+            _helper.AssertExtendFailsWithoutStateChange(new Vector3Int(0, 0, 3), GearChainPlacementEvaluator.ConnectionLimitError, 6, 3);
         }
 
         [Test]
         public void ExtendFailsWhenPositionOccupied()
         {
-            SetInventory(5, 3);
+            _helper.SetInventory(5, 3);
             var placePos = new Vector3Int(3, 0, 0);
             ServerContext.WorldBlockDatastore.TryAddBlock(ForUnitTestModBlockId.GearChainPole, placePos, BlockDirection.North, Array.Empty<BlockCreateParam>(), out _);
 
-            var response = SendExtend(placePos);
+            var response = _helper.SendExtend(placePos);
             Assert.False(response.IsSuccess);
             Assert.AreEqual(GearChainPlacementEvaluator.PositionOccupiedError, response.Error);
-            Assert.AreEqual(5, CountItem(_chainItemId));
-            Assert.AreEqual(3, CountItem(_materialItemId));
-        }
-
-        private void AssertExtendFailsWithoutStateChange(Vector3Int placePos, string expectedError, int expectedChainCount, int expectedMaterialCount)
-        {
-            // 失敗時に一切の状態変更が起きないことを検証する
-            // Verify failures leave absolutely no state changes
-            var response = SendExtend(placePos);
-            Assert.False(response.IsSuccess);
-            Assert.AreEqual(expectedError, response.Error);
-            Assert.False(ServerContext.WorldBlockDatastore.Exists(placePos));
-            Assert.AreEqual(expectedChainCount, CountItem(_chainItemId));
-            Assert.AreEqual(expectedMaterialCount, CountItem(_materialItemId));
-        }
-
-        private void SetInventory(int chainCount, int materialCount)
-        {
-            _inventory.SetItem(0, ServerContext.ItemStackFactory.Create(_chainItemId, chainCount));
-            if (0 < materialCount) _inventory.SetItem(1, ServerContext.ItemStackFactory.Create(_materialItemId, materialCount));
-        }
-
-        private GearChainPoleExtendProtocol.GearChainPoleExtendResponse SendExtend(Vector3Int placePos)
-        {
-            return SendExtendWithBlock(placePos, ForUnitTestModBlockId.GearChainPole);
-        }
-
-        private GearChainPoleExtendProtocol.GearChainPoleExtendResponse SendExtendWithBlock(Vector3Int placePos, BlockId poleBlockId)
-        {
-            var request = GearChainPoleExtendProtocol.GearChainPoleExtendRequest.CreateExtendRequest(PlayerId, FromPos, poleBlockId, CreatePlaceInfo(placePos), _chainItemId);
-            return Send(request);
-        }
-
-        private GearChainPoleExtendProtocol.GearChainPoleExtendResponse SendIsolated(Vector3Int placePos)
-        {
-            var request = GearChainPoleExtendProtocol.GearChainPoleExtendRequest.CreateIsolatedPlaceRequest(PlayerId, ForUnitTestModBlockId.GearChainPole, CreatePlaceInfo(placePos));
-            return Send(request);
-        }
-
-        private GearChainPoleExtendProtocol.GearChainPoleExtendResponse Send(GearChainPoleExtendProtocol.GearChainPoleExtendRequest request)
-        {
-            var responseBytes = _packet.GetPacketResponse(MessagePackSerializer.Serialize(request), new PacketResponseContext()).First();
-            return MessagePackSerializer.Deserialize<GearChainPoleExtendProtocol.GearChainPoleExtendResponse>(responseBytes.ToArray());
-        }
-
-        private static PlaceInfo CreatePlaceInfo(Vector3Int placePos)
-        {
-            return new PlaceInfo
-            {
-                Position = placePos,
-                Direction = BlockDirection.North,
-                VerticalDirection = BlockVerticalDirection.Horizontal,
-            };
-        }
-
-        private int CountItem(ItemId itemId)
-        {
-            return _inventory.InventoryItems.Where(stack => stack.Id == itemId).Sum(stack => stack.Count);
+            Assert.AreEqual(5, _helper.CountItem(_helper.ChainItemId));
+            Assert.AreEqual(3, _helper.CountItem(_helper.MaterialItemId));
         }
     }
 }

--- a/moorestech_server/Assets/Scripts/Tests/CombinedTest/Server/PacketTest/PlaceTrainCarOnRailProtocolTest.cs
+++ b/moorestech_server/Assets/Scripts/Tests/CombinedTest/Server/PacketTest/PlaceTrainCarOnRailProtocolTest.cs
@@ -123,7 +123,7 @@ namespace Tests.CombinedTest.Server.PacketTest
             Assert.AreEqual(0, environment.GetITrainLookupDatastore().GetRegisteredTrains().Count, "列車は生成されないべき / No train should be created");
         }
 
-        #region Internal
+        #region TestUtil
 
         private static (TrainTestEnvironment Environment, RailPositionSnapshotMessagePack RailPosition, Guid TrainCarGuid) SetupEnvironment()
         {


### PR DESCRIPTION
## Summary
- 自動接続プレビューの仮想在庫に建設コスト予約を反映し、サーバー側の配置判定との乖離を修正
- ベルコン設置プレビューの予算計算、LineView共通化、未使用レスポンス/引数/死にコード削除を反映
- GearChainPoleExtendProtocolTestをヘルパー分割し、テスト規約違反の200行超過を解消

## Test plan
- [x] `uloop compile --project-path ./moorestech_client`
- [x] `uloop run-tests --project-path ./moorestech_client --filter-type regex --filter-value "CommonBlockPlacePointCalculatorTest|GearChainPoleExtendProtocolTest|ElectricWire"`
- [ ] 実プレイで電気系ブロックのドラッグ設置プレビューを確認
- [ ] 実プレイでベルコン長尺設置時の一部埋まりケースを確認

Generated with [Claude Code](https://claude.com/claude-code)