### PR TITLE
feat: ブロックスポイト機能（ミドルクリックで設置ブロックをピック）

### DIFF
--- a/.claude/skills/unity-playmode-recorded-playtest/scenarios/block-eyedropper-via-ui.cs
+++ b/.claude/skills/unity-playmode-recorded-playtest/scenarios/block-eyedropper-via-ui.cs
@@ -7,12 +7,13 @@ using Client.Playtest.Input;
 using Client.Playtest.Operations;
 using Client.Game.InGame.BlockSystem.PlaceSystem;
 using Client.Game.InGame.Block;
+using Client.Game.InGame.Context;
 using Client.Game.InGame.UI.UIState;
-using Client.Starter;
 using Game.UnlockState;
 using Core.Master;
 using Cysharp.Threading.Tasks;
 using Game.Block.Interface;
+using System.Linq;
 using UnityEngine;
 using VContainer;
 
@@ -23,11 +24,15 @@ return PlaytestRunner.Run("block-eyedropper-via-ui", options, async p =>
     p.WarpPlayer(new Vector3(0f, 33.5f, 0f));
     await p.WaitSeconds(0.5f);
 
-    // クライアント側DIシングルトンをMainGameStarterのLifetimeScopeから取得する
-    // Resolve client-side DI singletons from MainGameStarter's LifetimeScope
-    var container = UnityEngine.Object.FindFirstObjectByType<MainGameStarter>().Container;
-    var placementSelection = container.Resolve<PlacementSelection>();
-    var gameUnlockStateData = container.Resolve<IGameUnlockStateData>();
+    // クライアント側DIシングルトンはClientDIContext経由で取得する（MainGameStarter.Containerは
+    // ルートスコープでゲームプレイ系登録を持たないため不可。StartGame()内で別ビルドされた
+    // resolverがClientDIContext.DIContainer.DIContainerResolverへ保持される）
+    // Resolve client-side DI singletons via ClientDIContext (MainGameStarter.Container is the root
+    // scope and lacks gameplay registrations; the resolver built inside StartGame() is what's
+    // exposed through ClientDIContext.DIContainer.DIContainerResolver)
+    var resolver = ClientDIContext.DIContainer.DIContainerResolver;
+    var placementSelection = resolver.Resolve<PlacementSelection>();
+    var gameUnlockStateData = resolver.Resolve<IGameUnlockStateData>();
     var chestBlockId = PlaytestBlockOps.ResolveBlockId("木のチェスト");
     var beltBlockId = PlaytestBlockOps.ResolveBlockId("ベルトコンベア");
 
@@ -41,12 +46,18 @@ return PlaytestRunner.Run("block-eyedropper-via-ui", options, async p =>
         await UniTask.DelayFrame(2);
     }
 
-    // 指定座標のBlockGameObject中心を照準し、BlockレイヤーへのRaycastに当てる
-    // Aim at the BlockGameObject center at the given coordinate so the Block-layer raycast hits it
+    // 指定座標のBlockGameObjectの"ClickCollider"を照準し、BlockレイヤーへのRaycastに当てる
+    // GetComponentInChildren<Collider>()は子階層先頭のコライダーを返すため、ベルト等では
+    // 装飾用サブメッシュ（例: Cube_2）を拾ってしまい実際の判定面から外れる。
+    // "ClickCollider"という名前のコライダーが全ブロック共通の本来の判定対象。
+    // Aim at the block's "ClickCollider" so the Block-layer raycast hits it.
+    // GetComponentInChildren<Collider>() returns the first child in hierarchy order, which for
+    // belts picks up a decorative sub-mesh (e.g. Cube_2) offset from the real hit surface.
+    // The collider named "ClickCollider" is the actual intended hit target across all blocks.
     async UniTask PickBlockAtAsync(Vector3Int blockPos)
     {
         var blockGo = await p.WaitBlockGameObject(blockPos);
-        var collider = blockGo.GetComponentInChildren<Collider>();
+        var collider = blockGo.GetComponentsInChildren<Collider>().First(c => c.name == "ClickCollider");
         await p.AimAt(collider.bounds.center);
         await MiddleClickAsync();
         await UniTask.DelayFrame(3);

--- a/.claude/skills/unity-playmode-recorded-playtest/scenarios/block-eyedropper-via-ui.cs
+++ b/.claude/skills/unity-playmode-recorded-playtest/scenarios/block-eyedropper-via-ui.cs
@@ -1,0 +1,132 @@
+// ブロックスポイトE2E検証: 通常プレイ中と配置モード中のミドルクリックで設置済みブロックをピックする
+// 検証項目: GameScreenからPlaceBlock遷移と選択反映、PlaceBlock中の選択切替、West向き保持、地形ミス時の不変、3連ベルトの代表解決
+// Block eyedropper E2E: pick placed blocks with middle-click during normal play and placement mode.
+// Verifies: GameScreen->PlaceBlock transition with selection, selection swap in PlaceBlock, West direction retention, no-op on bare terrain, and length-3 belt resolution.
+using Client.Playtest;
+using Client.Playtest.Input;
+using Client.Playtest.Operations;
+using Client.Game.InGame.BlockSystem.PlaceSystem;
+using Client.Game.InGame.Block;
+using Client.Game.InGame.UI.UIState;
+using Client.Starter;
+using Game.UnlockState;
+using Core.Master;
+using Cysharp.Threading.Tasks;
+using Game.Block.Interface;
+using UnityEngine;
+using VContainer;
+
+var options = new PlaytestRunOptions { Record = true };
+return PlaytestRunner.Run("block-eyedropper-via-ui", options, async p =>
+{
+    await p.SetupFlatGround();
+    p.WarpPlayer(new Vector3(0f, 33.5f, 0f));
+    await p.WaitSeconds(0.5f);
+
+    // クライアント側DIシングルトンをMainGameStarterのLifetimeScopeから取得する
+    // Resolve client-side DI singletons from MainGameStarter's LifetimeScope
+    var container = UnityEngine.Object.FindFirstObjectByType<MainGameStarter>().Container;
+    var placementSelection = container.Resolve<PlacementSelection>();
+    var gameUnlockStateData = container.Resolve<IGameUnlockStateData>();
+    var chestBlockId = PlaytestBlockOps.ResolveBlockId("木のチェスト");
+    var beltBlockId = PlaytestBlockOps.ResolveBlockId("ベルトコンベア");
+
+    // 通常プレイ・配置モード共通のミドルクリック入力をSemanticInputで注入する
+    // Inject shared middle-click input for both normal play and placement mode via SemanticInput
+    async UniTask MiddleClickAsync()
+    {
+        SemanticInput.MouseButtonDown(2);
+        await UniTask.DelayFrame(2);
+        SemanticInput.MouseButtonUp(2);
+        await UniTask.DelayFrame(2);
+    }
+
+    // 指定座標のBlockGameObject中心を照準し、BlockレイヤーへのRaycastに当てる
+    // Aim at the BlockGameObject center at the given coordinate so the Block-layer raycast hits it
+    async UniTask PickBlockAtAsync(Vector3Int blockPos)
+    {
+        var blockGo = await p.WaitBlockGameObject(blockPos);
+        var collider = blockGo.GetComponentInChildren<Collider>();
+        await p.AimAt(collider.bounds.center);
+        await MiddleClickAsync();
+        await UniTask.DelayFrame(3);
+    }
+
+    // カメラの現在向きからXZ平面上の配置座標を決め、シーン依存の初期向きを吸収する
+    // Derive XZ placement coordinates from the current camera facing to absorb scene-dependent startup orientation
+    var cam = Camera.main;
+    var forward = cam.transform.forward;
+    forward.y = 0f;
+    forward = forward.normalized;
+    var right = cam.transform.right;
+    right.y = 0f;
+    right = right.normalized;
+    Vector3Int GroundPoint(float fwd, float rgt) =>
+        new Vector3Int(
+            Mathf.RoundToInt(cam.transform.position.x + forward.x * fwd + right.x * rgt),
+            32,
+            Mathf.RoundToInt(cam.transform.position.z + forward.z * fwd + right.z * rgt));
+
+    // 各確認項目の設置点を分離し、地形のみの検証点にはブロックを置かない
+    // Keep each check's placement point separated, and leave the bare-terrain point empty
+    var posA = GroundPoint(4f, -6f);
+    var posC = GroundPoint(4f, -2f);
+    var posB = GroundPoint(4f, 2f);
+    var posD = GroundPoint(7f, -6f);
+    var posE = GroundPoint(4f, 6f);
+
+    // サーバー側アンロック後、クライアント側ミラーへ反映されるまで条件待機する
+    // After server-side unlock, wait until the client-side mirror reflects it
+    p.UnlockBlock("木のチェスト");
+    p.UnlockBlock("ベルトコンベア");
+    var chestGuid = MasterHolder.BlockMaster.GetBlockMaster(chestBlockId).BlockGuid;
+    var beltGuid = MasterHolder.BlockMaster.GetBlockMaster(beltBlockId).BlockGuid;
+    await p.Until(() => gameUnlockStateData.BlockUnlockStateInfos.TryGetValue(chestGuid, out var ci) && ci.IsUnlocked, 10f, "チェストのアンロック同期");
+    await p.Until(() => gameUnlockStateData.BlockUnlockStateInfos.TryGetValue(beltGuid, out var bi) && bi.IsUnlocked, 10f, "ベルトのアンロック同期");
+
+    // 確認項目1: GameScreen中にNorth向きチェストをピックし、PlaceBlock遷移と選択反映を検証する
+    // Check item 1: pick a North-facing chest during GameScreen, then verify PlaceBlock transition and selection
+    p.Assert(p.CurrentUiState == UIStateEnum.GameScreen, "初期状態はGameScreen");
+    p.PlaceBlockDirect("木のチェスト", posA, BlockDirection.North);
+    await PickBlockAtAsync(posA);
+    p.Assert(p.CurrentUiState == UIStateEnum.PlaceBlock, "項目1: ピック成功でPlaceBlockへ遷移");
+    p.Assert(placementSelection.SelectionType == PlacementSelectionType.Block, "項目1: 選択種別がBlockになる");
+    p.Assert(placementSelection.SelectedBlockId == chestBlockId, "項目1: 選択ブロックがチェストになる");
+    await p.Screenshot("01-pick-in-gamescreen");
+
+    // 確認項目3: West向きチェストをピックし、選択向きが元ブロックと一致することを検証する
+    // Check item 3: pick a West-facing chest and verify the selected direction matches the source block
+    p.PlaceBlockDirect("木のチェスト", posC, BlockDirection.West);
+    await PickBlockAtAsync(posC);
+    p.Assert(placementSelection.SelectedBlockId == chestBlockId, "項目3: 選択ブロックはチェストのまま");
+    p.Assert(placementSelection.SelectedBlockDirection == BlockDirection.West, "項目3: 向きがWestで一致");
+    await p.Screenshot("02-pick-west-direction");
+
+    // 確認項目2: PlaceBlock中にベルトをピックし、画面遷移せず選択だけ切り替わることを検証する
+    // Check item 2: pick a belt while in PlaceBlock and verify only the selection swaps without a state transition
+    p.PlaceBlockDirect("ベルトコンベア", posB, BlockDirection.North);
+    await PickBlockAtAsync(posB);
+    p.Assert(p.CurrentUiState == UIStateEnum.PlaceBlock, "項目2: PlaceBlockのまま");
+    p.Assert(placementSelection.SelectedBlockId == beltBlockId, "項目2: 選択がベルトへ切り替わる");
+    await p.Screenshot("03-pick-switch-selection");
+
+    // 確認項目4: 地形のみをミドルクリックし、直前の選択とUI状態が不変であることを検証する
+    // Check item 4: middle-click bare terrain and verify the prior selection and UI state remain unchanged
+    var beforeBlockId = placementSelection.SelectedBlockId;
+    var beforeDirection = placementSelection.SelectedBlockDirection;
+    var beforeUiState = p.CurrentUiState;
+    await p.AimAt(new Vector3(posD.x + 0.5f, 32f, posD.z + 0.5f));
+    await MiddleClickAsync();
+    await UniTask.DelayFrame(3);
+    p.Assert(placementSelection.SelectedBlockId == beforeBlockId, "項目4: 選択ブロックIDが変化しない");
+    p.Assert(placementSelection.SelectedBlockDirection == beforeDirection, "項目4: 選択向きが変化しない");
+    p.Assert(p.CurrentUiState == beforeUiState, "項目4: UI状態が変化しない");
+    await p.Screenshot("04-pick-empty-terrain-noop");
+
+    // 確認項目5: 3連ベルトの隠しバリアントをピックし、代表ベルトIDへ解決されることを検証する
+    // Check item 5: pick the hidden length-3 belt variant and verify it resolves to the representative belt ID
+    p.PlaceBlockDirect("ベルトコンベア(3連)", posE, BlockDirection.North);
+    await PickBlockAtAsync(posE);
+    p.Assert(placementSelection.SelectedBlockId == beltBlockId, "項目5: 隠しバリアントが代表ブロックへ解決される");
+    await p.Screenshot("05-pick-hidden-belt-variant");
+});

--- a/.moorestech-external-revisions.json
+++ b/.moorestech-external-revisions.json
@@ -3,7 +3,7 @@
         {
             "key": "moorestech_master",
             "relativePath": "../moorestech_master",
-            "commitHash": "c940ca48b41aca7788d013fa141a75333d52dab5"
+            "commitHash": "f8d25b0725600fbb47814179211d0035f383eba6"
         },
         {
             "key": "moorestech_client_private",

--- a/docs/cmux-usage.md
+++ b/docs/cmux-usage.md
@@ -1,0 +1,195 @@
+# cmux 使い方メモ
+
+cmux は `tmux` 風に、`window` / `workspace` / `pane` / `surface` を CLI から操作できる環境です。cmux の terminal では `CMUX_WORKSPACE_ID` や `CMUX_SURFACE_ID` が自動設定されるため、多くのコマンドは対象を省略すると現在の workspace / surface に対して実行されます。
+
+## 基本構造
+- `window`: cmux のトップレベルウィンドウ
+- `workspace`: 作業単位。タブやプロジェクトに近い
+- `pane`: 分割された表示領域
+- `surface`: pane の中身。`terminal` / `browser` / `agent-session` など
+
+対象指定には短い ref を使えます。UUID も使えますが、通常の確認や操作では短い ref で十分です。
+```bash
+window:1
+workspace:8
+pane:55
+surface:129
+```
+
+## 状況確認
+現在フォーカスされている `window` / `workspace` / `pane` / `surface` を確認します。
+```bash
+cmux identify --no-caller
+```
+
+現在の workspace を表示します。
+```bash
+cmux current-workspace
+```
+
+window / workspace / pane / surface の階層を一覧します。ペイン位置や tty を確認する時に一番便利です。
+
+```bash
+cmux tree
+cmux tree --all
+```
+
+pane や surface を個別に確認します。
+
+```bash
+cmux list-panes
+cmux list-panels
+cmux list-pane-surfaces --pane pane:55
+```
+
+cmux 内のプロセス、CPU、メモリ、surface 対応を確認します。
+
+```bash
+cmux top --workspace workspace:8 --processes --flat --format tsv
+```
+
+## 画面を読む
+指定 surface の現在画面を読みます。対象ペインに入力しないため、安全に状態確認できます。
+```bash
+cmux read-screen --surface surface:129 --lines 80
+cmux read-screen --surface surface:129 --scrollback --lines 200
+```
+
+tmux 互換名でも読めます。
+
+```bash
+cmux capture-pane --surface surface:129 --lines 80
+```
+
+## 入力を送る
+通常テキストや Enter などのキーを送ります。誤操作を避けるため、入力前に `read-screen` で対象が入力待ちか確認してください。
+```bash
+cmux send --surface surface:129 "echo hello"
+cmux send-key --surface surface:129 Enter
+```
+
+panel 指定で送る場合は `send-panel` / `send-key-panel` を使います。
+
+```bash
+cmux send-panel --panel pane:55 "pwd"
+cmux send-key-panel --panel pane:55 Enter
+```
+
+## フォーカス操作
+
+指定 pane / panel / window にフォーカスします。
+
+```bash
+cmux focus-pane --pane pane:55
+cmux focus-panel --panel pane:55
+cmux focus-window --window window:1
+```
+
+## 分割と作成
+
+現在 workspace に右分割の terminal pane を作ります。
+
+```bash
+cmux new-pane --type terminal --direction right
+```
+
+tmux 風に右分割します。
+
+```bash
+cmux new-split right
+```
+
+指定 pane に terminal surface や browser surface を追加します。
+
+```bash
+cmux new-surface --type terminal --pane pane:55
+cmux new-surface --type browser --pane pane:55 --url https://example.com
+```
+
+## ワークスペース操作
+
+workspace 一覧と現在 workspace を確認します。
+
+```bash
+cmux list-workspaces
+cmux current-workspace
+```
+
+workspace を作成、選択、リネームします。
+
+```bash
+cmux new-workspace --name "作業名" --cwd /Users/katsumi/moorestech
+cmux select-workspace --workspace workspace:8
+cmux rename-workspace --workspace workspace:8 "新しい名前"
+```
+
+## ブラウザ操作
+
+ブラウザ split を開き、状態確認やスクリーンショット取得を行います。
+
+```bash
+cmux browser open https://example.com
+cmux browser snapshot
+cmux browser get url
+cmux browser get title
+cmux browser screenshot --out /tmp/cmux-shot.png
+```
+
+## diff / Markdown 表示
+
+未ステージ差分、patch、Markdown を cmux 上で表示します。
+
+```bash
+cmux diff --source unstaged --cwd /Users/katsumi/moorestech
+cmux diff patch.diff
+cmux markdown open README.md
+```
+
+## 設定とドキュメント
+
+公式ドキュメントや raw resource の場所を表示します。
+
+```bash
+cmux docs api
+cmux docs agents
+cmux docs shortcuts
+cmux docs settings
+```
+
+設定ファイルの場所を確認します。
+
+```bash
+cmux settings path
+cmux config paths
+```
+
+Ghostty config と cmux config を再読み込みします。アプリ再起動は不要です。
+
+```bash
+cmux reload-config
+```
+
+## 右隣ペインを確認する手順
+
+右隣ペインのような「周辺 pane を読むだけ」の用途では、次の流れが安全です。
+
+1. `pwd` で現在の worktree を確認する。
+2. `cmux identify --no-caller` で自分の `pane` / `surface` を確認する。
+3. `cmux tree` で同じ workspace 内の隣接 pane と surface を特定する。
+4. `cmux read-screen --surface surface:<id> --lines 80` で対象画面を読む。
+5. 入力が必要な場合だけ、対象を再確認してから `cmux send` / `cmux send-key` を使う。
+
+実際に使った確認コマンド例です。
+
+```bash
+pwd
+cmux identify --no-caller
+cmux current-workspace
+cmux list-panes
+cmux list-panels
+cmux tree
+cmux read-screen --surface surface:129 --lines 80
+cmux read-screen --surface surface:135 --lines 80
+cmux read-screen --surface surface:139 --lines 80
+cmux top --workspace workspace:8 --processes --flat --format tsv
+```

--- a/docs/superpowers/plans/2026-07-08-block-eyedropper.md
+++ b/docs/superpowers/plans/2026-07-08-block-eyedropper.md
@@ -1,0 +1,486 @@
+# ブロックスポイト（ミドルクリック） Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** ミドルクリックで設置済みブロックをピックし、そのブロック種類と向きを設置選択状態にするスポイト機能を実装する。
+
+**Architecture:** 既存の `PlacementSelection` → `PlaceSystemStateController`（毎フレーム選択変化検知）→ `PlaceSystemSelector` の選択フローにそのまま乗る。新規は「ミドルクリック入力＋レイキャスト＋選択セット」を担う `BlockPickService` と、「隠しバリアント変換＋解放ゲート」の純粋ロジック `BlockPickResolver` の2クラスのみ。向きは `PlacementSelection` に `BlockDirection?` を追加して既存コンテキスト経由で `CommonBlockPlaceSystem` へ届ける。
+
+**Tech Stack:** Unity / C#, VContainer (DI), uloop (コンパイル・テスト), NUnit (Client.Tests)
+
+**Spec:** `docs/superpowers/specs/2026-07-08-block-eyedropper-design.md`
+
+## Global Constraints
+
+- 1ファイル200行以下。partial 禁止。デフォルト引数禁止（引数追加時は全呼び出し側を明示変更）
+- 主要処理に日本語→英語の2行セットコメント（各1行厳守）。自明なコメントは書かない
+- try-catch 禁止。null チェックは外部データ・非同期ロード結果のみ
+- .cs 変更後は必ず `uloop compile --project-path ./moorestech_client` を実行
+- .meta ファイルは手動作成禁止（Unity 自動生成に任せ、生成されたらコミットに含める）
+- テストは `uloop run-tests --project-path ./moorestech_client --filter-type regex --filter-value "<正規表現>"` で対象限定実行
+- ドメインリロードエラー（Unity is reloading）が出たら45秒待ってリトライ
+- git worktree 頻用のため作業開始時に `pwd` 確認。タスク終了前に必ずコミット
+
+## 配置と前例
+
+| 項目 | 配置先 | 前例 |
+|---|---|---|
+| `BlockPickService`（ステート駆動の入力サービス） | `Client.Game/InGame/UI/UIState/State/BlockPick/` | `State/SubInventory/GameScreenSubInventoryInteractService.cs`（GameScreenState から駆動される入力サービス）、`State/DragDelete/DeleteObjectService.cs` |
+| `BlockPickResolver`（選択可否の純粋ロジック） | 同上ディレクトリ | `UI/BuildMenu/BuildMenuEntryCatalog.cs`（解放フィルタ＋隠しバリアント除外を UI 層で実施している同役割の前例） |
+| DI 登録 | `Client.Starter/MainGameStarter.cs` | `builder.Register<GameScreenSubInventoryInteractService>(Lifetime.Singleton);`（229行付近） |
+| 向きの伝搬 | `PlacementSelection` → `PlaceSystemUpdateContext` | 既存の選択値（BlockId 等）と同じ通り道。新経路は作らない |
+| ブロック検出 | `BlockClickDetectUtil.TryGetCursorOnBlock` | `GameScreenSubInventoryInteractService` が GameScreen で同ユーティリティを使用 |
+| ミドルクリック入力 | `HybridInput.GetMouseButtonDown(2)` | `BuildViewModeController.ManualUpdate` が `GetMouseButtonDown(1)` を同形式で使用。ゲーム内でボタン2の既存使用なし（衝突なし） |
+
+**機能パリティ:** 本計画は新規入力（未使用のミドルクリック）の追加のみで、既存機構の抑止・置換・凍結は無い。既存操作は全て無傷。
+
+---
+
+### Task 0: 前提確認（マージ解決ゲート）
+
+**Files:** なし（確認のみ）
+
+- [ ] **Step 1: 作業ディレクトリとマージ状態を確認**
+
+Run:
+```bash
+pwd
+git rev-parse -q --verify MERGE_HEAD && echo "MERGE IN PROGRESS - STOP" || echo "OK: no merge in progress"
+```
+Expected: `OK: no merge in progress`
+
+**`MERGE IN PROGRESS` が出た場合は実装を開始せず、ユーザーにマージ解決を依頼して停止すること。** 本プランは HEAD 側（`BuildViewModeController` 経由）のステート構造を前提としている（プラン作成時点で `PlaceBlockState.cs` / `BuildMenuState.cs` に競合マーカーが残っていた）。
+
+- [ ] **Step 2: ベースラインコンパイル確認**
+
+Run: `uloop compile --project-path ./moorestech_client`
+Expected: エラー0件。ここでエラーが出るなら着手前に報告する
+
+- [ ] **Step 3: スペックとプランをコミット（未コミットの場合）**
+
+```bash
+git add docs/superpowers/specs/2026-07-08-block-eyedropper-design.md docs/superpowers/plans/2026-07-08-block-eyedropper.md
+git commit -m "docs: ブロックスポイト機能のspecと実装プランを追加"
+```
+
+---
+
+### Task 1: 向きプラミング（選択→コンテキスト→CommonBlockPlaceSystem）
+
+**Files:**
+- Modify: `moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/PlacementSelection.cs`
+- Modify: `moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/IPlaceSystem.cs`
+- Modify: `moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/PlaceSystemStateController.cs`
+- Modify: `moorestech_client/Assets/Scripts/Client.Game/InGame/UI/UIState/State/BuildMenuState.cs`
+- Modify: `moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/Common/CommonBlockPlaceSystem.cs`
+
+**Interfaces:**
+- Produces: `PlacementSelection.SetSelectedBlock(BlockId blockId, BlockDirection? direction)`（Task 3 の `BlockPickService` が呼ぶ）、`PlacementSelection.SelectedBlockDirection`（`BlockDirection?`）、`PlaceSystemUpdateContext.SelectedBlockDirection`（`BlockDirection?`）
+- `BlockDirection` は `Game.Block.Interface` 名前空間（Client.Game は参照済み）
+
+- [ ] **Step 1: PlacementSelection に向きを追加**
+
+`PlacementSelection.cs` — using に `Game.Block.Interface` を追加し、以下を変更:
+
+```csharp
+public BlockId? SelectedBlockId { get; private set; }
+// スポイトでピックした向き（メニュー選択時はnull）
+// The direction picked by the eyedropper (null when selected from the menu)
+public BlockDirection? SelectedBlockDirection { get; private set; }
+```
+
+```csharp
+public void SetSelectedBlock(BlockId blockId, BlockDirection? direction)
+{
+    ClearSelection();
+    SelectionType = PlacementSelectionType.Block;
+    SelectedBlockId = blockId;
+    SelectedBlockDirection = direction;
+}
+```
+
+`ClearSelection()` に `SelectedBlockDirection = null;` を追加。
+
+- [ ] **Step 2: 呼び出し側 BuildMenuState を追従**
+
+`BuildMenuState.cs` の `case PlacementSelectionType.Block:` を変更（デフォルト引数は禁止のため null 明示）:
+
+```csharp
+case PlacementSelectionType.Block:
+    _placementSelection.SetSelectedBlock(entry.BlockId, null);
+    break;
+```
+
+- [ ] **Step 3: PlaceSystemUpdateContext に向きを追加**
+
+`IPlaceSystem.cs` — using に `Game.Block.Interface` を追加し、struct にフィールドとコンストラクタ引数を追加:
+
+```csharp
+public readonly BlockId? SelectedBlockId;
+// スポイトでピックした向き（未指定はnull）
+// The eyedropped block direction (null when not specified)
+public readonly BlockDirection? SelectedBlockDirection;
+```
+
+コンストラクタは `BlockId? selectedBlockId` の直後に `BlockDirection? selectedBlockDirection` を追加し、代入を1行足す。
+
+- [ ] **Step 4: PlaceSystemStateController の変化検知に向きを追加**
+
+`PlaceSystemStateController.cs` — using に `Game.Block.Interface` を追加:
+
+既存の `private BlockId? _lastSelectedBlockId;` の直下にフィールドを1つ追加:
+```csharp
+private BlockDirection? _lastSelectedBlockDirection;
+```
+
+`Disable()` のリセット群に `_lastSelectedBlockDirection = null;` を追加。
+
+`CreateContext()` 内の `isSelectionChanged` 比較に1行追加:
+```csharp
+var isSelectionChanged = _lastSelectionType != _placementSelection.SelectionType
+                         || _lastSelectedBlockId != _placementSelection.SelectedBlockId
+                         || _lastSelectedBlockDirection != _placementSelection.SelectedBlockDirection
+                         || _lastSelectedTrainCarGuid != _placementSelection.SelectedTrainCarGuid
+                         || _lastSelectedConnectPlaceMode != _placementSelection.SelectedConnectPlaceMode
+                         || _lastSelectedBlueprintName != _placementSelection.SelectedBlueprintName;
+```
+
+`new PlaceSystemUpdateContext(...)` の `_placementSelection.SelectedBlockId` の直後に `_placementSelection.SelectedBlockDirection` を渡し、`_lastSelectedBlockDirection = _placementSelection.SelectedBlockDirection;` の保存も追加。
+
+- [ ] **Step 5: CommonBlockPlaceSystem で向きを適用**
+
+`CommonBlockPlaceSystem.cs` の `ManualUpdate` 先頭に `ApplyPickedDirection();` を追加し、既存の `#region Internal` 内にローカル関数を追加:
+
+```csharp
+public void ManualUpdate(PlaceSystemUpdateContext context)
+{
+    ApplyPickedDirection();
+    UpdateHeightOffset();
+    BlockDirectionControl();
+    GroundClickControl(context);
+
+    #region Internal
+
+    void ApplyPickedDirection()
+    {
+        // スポイトでピックした向きを選択変化時に反映する
+        // Apply the eyedropped block direction when the selection changes
+        if (context.IsSelectionChanged && context.SelectedBlockDirection.HasValue) _currentBlockDirection = context.SelectedBlockDirection.Value;
+    }
+    // （以下既存のUpdateHeightOffset / BlockDirectionControl）
+```
+
+- [ ] **Step 6: コンパイル**
+
+Run: `uloop compile --project-path ./moorestech_client`
+Expected: エラー0件（`SetSelectedBlock` の呼び出し漏れがあればここでコンパイルエラーとして検出される）
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/PlacementSelection.cs moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/IPlaceSystem.cs moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/PlaceSystemStateController.cs moorestech_client/Assets/Scripts/Client.Game/InGame/UI/UIState/State/BuildMenuState.cs moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/Common/CommonBlockPlaceSystem.cs
+git commit -m "feat: 設置選択にスポイト用のブロック向きを伝搬"
+```
+
+---
+
+### Task 2: BlockPickResolver（純粋ロジック）＋ユニットテスト
+
+**Files:**
+- Create: `moorestech_client/Assets/Scripts/Client.Game/InGame/UI/UIState/State/BlockPick/BlockPickResolver.cs`
+- Test: `moorestech_client/Assets/Scripts/Client.Tests/PlaceSystem/BlockPickResolverTest.cs`
+
+**Interfaces:**
+- Produces: `static bool BlockPickResolver.TryResolvePickTarget(BlockId rawBlockId, IGameUnlockStateData unlockState, out BlockId resolvedBlockId)`（Task 3 の `BlockPickService` が呼ぶ）
+- Consumes: `BeltConveyorPlaceFamilyUtil.TryGetFamily(BlockId, out BeltConveyorPlaceParam)` / `GetRepresentativeBlockId(BeltConveyorPlaceParam)`（Game.Block.Interface.Extension）、`IGameUnlockStateData.BlockUnlockStateInfos`（`IReadOnlyDictionary<Guid, BlockUnlockStateInfo>`、`info.IsUnlocked`）
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`moorestech_client/Assets/Scripts/Client.Tests/PlaceSystem/BlockPickResolverTest.cs` を作成:
+
+```csharp
+using Client.Game.InGame.UI.UIState.State.BlockPick;
+using Core.Master;
+using Game.UnlockState;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Server.Boot;
+using Tests.CombinedTest.Server.PacketTest;
+using Tests.Module.TestMod;
+
+namespace Client.Tests.PlaceSystem
+{
+    public class BlockPickResolverTest
+    {
+        [Test]
+        public void 解放済み通常ブロックはそのまま解決される()
+        {
+            var serviceProvider = CreateServer();
+            PlaceBlockProtocolTestSupport.UnlockBlock(serviceProvider, ForUnitTestModBlockId.MachineId);
+            var unlockState = serviceProvider.GetService<IGameUnlockStateDataController>();
+
+            Assert.IsTrue(BlockPickResolver.TryResolvePickTarget(ForUnitTestModBlockId.MachineId, unlockState, out var resolved));
+            Assert.AreEqual(ForUnitTestModBlockId.MachineId, resolved);
+        }
+
+        [Test]
+        public void ベルト隠しバリアントは代表ブロックへ解決される()
+        {
+            var serviceProvider = CreateServer();
+            PlaceBlockProtocolTestSupport.UnlockBlock(serviceProvider, ForUnitTestModBlockId.GearBeltConveyor);
+            var unlockState = serviceProvider.GetService<IGameUnlockStateDataController>();
+
+            // 長さ3の隠しバリアントをピックしても代表（長さ1）に解決される
+            // Picking the hidden length-3 variant resolves to the representative length-1 block
+            Assert.IsTrue(BlockPickResolver.TryResolvePickTarget(ForUnitTestModBlockId.GearBeltConveyor3, unlockState, out var resolved));
+            Assert.AreEqual(ForUnitTestModBlockId.GearBeltConveyor, resolved);
+        }
+
+        [Test]
+        public void 未解放ブロックはピックできない()
+        {
+            var serviceProvider = CreateServer();
+            PlaceBlockProtocolTestSupport.LockBlock(serviceProvider, ForUnitTestModBlockId.MachineId);
+            var unlockState = serviceProvider.GetService<IGameUnlockStateDataController>();
+
+            Assert.IsFalse(BlockPickResolver.TryResolvePickTarget(ForUnitTestModBlockId.MachineId, unlockState, out _));
+        }
+
+        private static ServiceProvider CreateServer()
+        {
+            var (_, serviceProvider) = new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
+            return serviceProvider;
+        }
+    }
+}
+```
+
+注意: `PlaceBlockProtocolTestSupport.UnlockBlock/LockBlock`（`moorestech_server/Assets/Scripts/Tests/CombinedTest/Server/PacketTest/PlaceBlockProtocolTestSupport.cs`）は既存ヘルパー。Client.Tests は `Server.Tests` を asmdef 参照済み。ヘルパーのアクセシビリティや名前空間が異なっていた場合は同等処理（`IGameUnlockStateDataController.UnlockBlock(guid)` / `LoadUnlockState` によるロック上書き）をテスト内に直接書くこと。
+
+- [ ] **Step 2: コンパイルして失敗を確認**
+
+Run: `uloop compile --project-path ./moorestech_client`
+Expected: FAIL — `BlockPickResolver` が存在しない旨のコンパイルエラー（CS0246）
+
+- [ ] **Step 3: BlockPickResolver を実装**
+
+`moorestech_client/Assets/Scripts/Client.Game/InGame/UI/UIState/State/BlockPick/BlockPickResolver.cs` を作成:
+
+```csharp
+using Core.Master;
+using Game.Block.Interface.Extension;
+using Game.UnlockState;
+
+namespace Client.Game.InGame.UI.UIState.State.BlockPick
+{
+    /// <summary>
+    /// スポイトでピックしたブロックの選択可否と最終ブロックIDを解決する
+    /// Resolves whether an eyedropped block is pickable and its final block id
+    /// </summary>
+    public static class BlockPickResolver
+    {
+        public static bool TryResolvePickTarget(BlockId rawBlockId, IGameUnlockStateData unlockState, out BlockId resolvedBlockId)
+        {
+            resolvedBlockId = rawBlockId;
+
+            // ベルトファミリーは代表ブロックへ変換（ビルドメニューの隠しバリアント除外と整合）
+            // Belt family members resolve to the representative block, matching the menu's hidden-variant exclusion
+            if (BeltConveyorPlaceFamilyUtil.TryGetFamily(rawBlockId, out var beltParam))
+            {
+                resolvedBlockId = BeltConveyorPlaceFamilyUtil.GetRepresentativeBlockId(beltParam);
+            }
+
+            // 未解放ブロックはピック不可（スポイトで解放システムを迂回させない）
+            // Locked blocks are not pickable; the eyedropper must not bypass the unlock system
+            var blockGuid = MasterHolder.BlockMaster.GetBlockMaster(resolvedBlockId).BlockGuid;
+            return unlockState.BlockUnlockStateInfos.TryGetValue(blockGuid, out var info) && info.IsUnlocked;
+        }
+    }
+}
+```
+
+- [ ] **Step 4: コンパイルしてテスト実行**
+
+Run:
+```bash
+uloop compile --project-path ./moorestech_client
+uloop run-tests --project-path ./moorestech_client --filter-type regex --filter-value "BlockPickResolverTest"
+```
+Expected: 3件 PASS
+
+- [ ] **Step 5: コミット（Unity生成の.metaも含める）**
+
+```bash
+git add moorestech_client/Assets/Scripts/Client.Game/InGame/UI/UIState/State/BlockPick moorestech_client/Assets/Scripts/Client.Tests/PlaceSystem/BlockPickResolverTest.cs*
+git commit -m "feat: スポイトのピック解決ロジックBlockPickResolverを追加"
+```
+
+---
+
+### Task 3: BlockPickService ＋ DI 登録
+
+**Files:**
+- Create: `moorestech_client/Assets/Scripts/Client.Game/InGame/UI/UIState/State/BlockPick/BlockPickService.cs`
+- Modify: `moorestech_client/Assets/Scripts/Client.Starter/MainGameStarter.cs`（229行付近、`GameScreenSubInventoryInteractService` 登録の隣）
+
+**Interfaces:**
+- Produces: `bool BlockPickService.TryPickBlockUnderCursor()`（Task 4 の両ステートが呼ぶ。ピック成立時に選択状態を書き換えて true）
+- Consumes: `BlockClickDetectUtil.TryGetCursorOnBlock(out BlockGameObject)`（Client.Game.InGame.Control）、`BlockGameObject.BlockId` / `BlockGameObject.BlockPosInfo.BlockDirection`、Task 1 の `PlacementSelection.SetSelectedBlock(BlockId, BlockDirection?)`、Task 2 の `BlockPickResolver`
+
+- [ ] **Step 1: BlockPickService を実装**
+
+`moorestech_client/Assets/Scripts/Client.Game/InGame/UI/UIState/State/BlockPick/BlockPickService.cs` を作成:
+
+```csharp
+using Client.Game.InGame.BlockSystem.PlaceSystem;
+using Client.Game.InGame.Control;
+using Client.Input;
+using Game.UnlockState;
+
+namespace Client.Game.InGame.UI.UIState.State.BlockPick
+{
+    /// <summary>
+    /// ミドルクリックでカーソル下のブロックをピックし設置選択状態へ反映する
+    /// Middle-click eyedropper: picks the block under the cursor into the placement selection
+    /// </summary>
+    public class BlockPickService
+    {
+        private readonly PlacementSelection _placementSelection;
+        private readonly IGameUnlockStateData _gameUnlockStateData;
+
+        public BlockPickService(PlacementSelection placementSelection, IGameUnlockStateData gameUnlockStateData)
+        {
+            _placementSelection = placementSelection;
+            _gameUnlockStateData = gameUnlockStateData;
+        }
+
+        public bool TryPickBlockUnderCursor()
+        {
+            //TODO InputSystem対応
+            if (!HybridInput.GetMouseButtonDown(2)) return false;
+            if (!BlockClickDetectUtil.TryGetCursorOnBlock(out var blockObject)) return false;
+            if (!BlockPickResolver.TryResolvePickTarget(blockObject.BlockId, _gameUnlockStateData, out var resolvedBlockId)) return false;
+
+            // ブロック種類と設置向きをまとめて選択状態へ反映する
+            // Apply both the block type and its placed direction to the selection
+            _placementSelection.SetSelectedBlock(resolvedBlockId, blockObject.BlockPosInfo.BlockDirection);
+            return true;
+        }
+    }
+}
+```
+
+- [ ] **Step 2: DI 登録**
+
+`MainGameStarter.cs` の `builder.Register<GameScreenSubInventoryInteractService>(Lifetime.Singleton);` の直下に追加（using に `Client.Game.InGame.UI.UIState.State.BlockPick` が必要）:
+
+```csharp
+builder.Register<BlockPickService>(Lifetime.Singleton);
+```
+
+- [ ] **Step 3: コンパイル**
+
+Run: `uloop compile --project-path ./moorestech_client`
+Expected: エラー0件
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add moorestech_client/Assets/Scripts/Client.Game/InGame/UI/UIState/State/BlockPick moorestech_client/Assets/Scripts/Client.Starter/MainGameStarter.cs
+git commit -m "feat: BlockPickServiceを追加しDIへ登録"
+```
+
+---
+
+### Task 4: ステート統合（GameScreen / PlaceBlock）＋キー説明文
+
+**Files:**
+- Modify: `moorestech_client/Assets/Scripts/Client.Game/InGame/UI/UIState/State/GameScreenState.cs`
+- Modify: `moorestech_client/Assets/Scripts/Client.Game/InGame/UI/UIState/State/PlaceBlockState.cs`
+
+**Interfaces:**
+- Consumes: Task 3 の `BlockPickService.TryPickBlockUnderCursor()`
+
+- [ ] **Step 1: GameScreenState にスポイト遷移を追加**
+
+コンストラクタに `BlockPickService blockPickService` を追加しフィールド `_blockPickService` へ保持（using `Client.Game.InGame.UI.UIState.State.BlockPick` 追加）。VContainer がコンストラクタインジェクションするため登録以外の配線は不要。
+
+`GetNextUpdate()` の `_subInventoryInteractService.TryGetSubInventoryInteractObject` 判定の直後に追加:
+
+```csharp
+// ミドルクリックでブロックをスポイトし配置モードへ入る
+// Middle-click eyedrops a block and enters placement mode
+if (_blockPickService.TryPickBlockUnderCursor()) return new UITransitContext(UIStateEnum.PlaceBlock);
+```
+
+`OnEnter` のキー説明文の `G:ブロック削除\n` の直後に `ミドルクリック: ブロックをスポイト\n` を挿入:
+
+```csharp
+KeyControlDescription.Instance.SetText("Tab: インベントリ\n1~9: アイテム持ち替え\nB: ブロック配置\nG:ブロック削除\nミドルクリック: ブロックをスポイト\nT: チャレンジ一覧\nR: リサーチツリー\nF3: デバッグモード\n");
+```
+
+- [ ] **Step 2: PlaceBlockState にスポイト切替を追加**
+
+コンストラクタに `BlockPickService blockPickService` を追加しフィールドへ保持。
+
+`GetNextUpdate()` のテキスト入力ガード `if (!isTextInputFocused)` ブロック内、`_buildViewModeController.ManualUpdate();` の直後に追加（遷移はしない。選択が変われば `PlaceSystemStateController` が次の `ManualUpdate` で PlaceSystem を自動切替する）:
+
+```csharp
+// ミドルクリックで選択ブロックをスポイトで切り替える
+// Middle-click switches the selected block via the eyedropper
+_blockPickService.TryPickBlockUnderCursor();
+```
+
+注意: マージ解決後の `PlaceBlockState` に `isTextInputFocused` ガードが無い形になっていた場合は、`_placeSystemStateController.ManualUpdate();` の直前に置くこと（BP名入力の誤爆リスクはガードが存在する場合のみ）。
+
+`OnEnter` のキー説明文の末尾 `G:ブロック削除` の後に `\nミドルクリック: ブロックをスポイト` を追加:
+
+```csharp
+KeyControlDescription.Instance.SetText("Tab: ブロック選択\nV: 視点切替\nQ: 設置高さ上げる\nE: ブロック高さ下げる\nB: 配置モード終了\n左クリック: ブロック配置\nG:ブロック削除\nミドルクリック: ブロックをスポイト");
+```
+
+- [ ] **Step 3: コンパイル**
+
+Run: `uloop compile --project-path ./moorestech_client`
+Expected: エラー0件
+
+- [ ] **Step 4: 関連テストの回帰確認**
+
+Run: `uloop run-tests --project-path ./moorestech_client --filter-type regex --filter-value "BlockPickResolverTest|BeltConveyorPlaceFamilyUtilTest"`
+Expected: 全件 PASS
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add moorestech_client/Assets/Scripts/Client.Game/InGame/UI/UIState/State/GameScreenState.cs moorestech_client/Assets/Scripts/Client.Game/InGame/UI/UIState/State/PlaceBlockState.cs
+git commit -m "feat: GameScreen/PlaceBlockステートにミドルクリックスポイトを統合"
+```
+
+---
+
+### Task 5: 実プレイ検証（プレイモード）
+
+**Files:** なし（検証のみ。unity-playmode-recorded-playtest スキルの DSL シナリオを使う場合は同スキルの手順に従う）
+
+- [ ] **Step 1: プレイモードで以下を確認**
+
+unity-playmode-recorded-playtest スキル（プレイテストDSL）で検証する。確認項目:
+
+1. 通常プレイ中に設置済みブロックへ照準しミドルクリック → 配置モードへ入り、そのブロックがプレビュー選択されている
+2. 配置モード中に別のブロックをミドルクリック → 選択が切り替わる（PlaceSystem の自動切替を含む。例: 機械→ベルト）
+3. 向きが North 以外のブロックをピック → プレビューの向きがピック元と一致する
+4. 地形のみ（ブロック無し）でミドルクリック → 何も起きず現在の選択が維持される
+5. ベルトの隠しバリアント（長尺・斜面）をピック → 代表ベルトが選択される
+
+- [ ] **Step 2: エラーログ確認**
+
+Run: `uloop get-logs --project-path ./moorestech_client --log-type Error`
+Expected: スポイト操作起因のエラーなし
+
+- [ ] **Step 3: 未コミットの作業があれば全てコミット**
+
+```bash
+git status --short
+git add -A && git commit -m "test: スポイト機能のプレイ検証結果を反映"
+```
+（差分が無ければコミット不要）

--- a/docs/superpowers/specs/2026-07-08-block-eyedropper-design.md
+++ b/docs/superpowers/specs/2026-07-08-block-eyedropper-design.md
@@ -1,0 +1,70 @@
+# ブロックスポイト機能（ミドルクリック）設計
+
+日付: 2026-07-08
+ブランチ: feature/replace-palce-system-with-electric
+
+## 概要
+
+ワールドに設置済みのブロックをミドルクリックでピックし、そのブロック（と向き）を設置選択状態にする「スポイト」機能。FactorioのパイプットやMinecraftのピックブロックに相当する。完全クライアントサイドで、サーバー通信・スキーマ変更は不要。
+
+## 発動条件と挙動
+
+### GameScreenState（通常プレイ）
+- ミドルクリックでカーソル下のブロックをピックし、`PlacementSelection` にセットして `UIStateEnum.PlaceBlock` へ遷移する
+- `PlaceBlockState.OnEnter` → `BuildViewModeController.OnEnterBuildState` がセッション未開始時に自動でカメラ保存・セッション開始するため、追加のセッション処理は不要（調査で確認済み）
+
+### PlaceBlockState（配置モード）
+- ミドルクリックで選択ブロックがピック対象へ切り替わる。ステート遷移は起きない
+- `PlacementSelection` を書き換えるだけで、`PlaceSystemStateController` が毎フレーム選択変化を検知し PlaceSystem（Common/ベルト/レール/歯車ポール）を自動で切り替える
+- テキスト入力中ガード（`!isTextInputFocused`）の内側に置き、BP名入力中の誤爆を防ぐ
+
+### 照準
+既存の `BlockClickDetectUtil.TryGetCursorOnBlock`（`AimPointProvider` 経由、`BlockOnlyLayerMask`）を使用。GameScreenでのブロックインタラクト（`GameScreenSubInventoryInteractService`）と同じ照準セマンティクスになる。
+
+## コンポーネント構成
+
+### BlockPickService（新規）
+両ステートに注入する1クラス。`bool TryPickBlockUnderCursor()` が以下を行い、ピック成立時 true を返す:
+1. `HybridInput.GetMouseButtonDown(2)` でミドルクリック検知（既存のゲーム内ミドルクリック使用は無く衝突しない）
+2. `BlockClickDetectUtil.TryGetCursorOnBlock` でカーソル下の `BlockGameObject` を取得
+3. `BlockPickResolver` でピック可否と最終BlockIdを解決
+4. `BlockGameObject.BlockPosInfo.BlockDirection` を取得
+5. `PlacementSelection.SetSelectedBlock(blockId, direction)` を呼ぶ
+
+### BlockPickResolver（新規・純粋ロジック）
+`BlockId + IGameUnlockStateData → 最終BlockId or 失敗` の解決のみを担う静的クラス:
+1. ベルト隠しバリアントなら `BeltConveyorPlaceFamilyUtil.GetRepresentativeBlockId` で代表ブロックへ変換（ビルドメニューが隠しバリアントを除外するのと整合）
+2. 未解放ブロックなら失敗（スポイトで解放システムを迂回できてはならない）
+
+## 向きのコピー
+
+- `PlacementSelection.SetSelectedBlock(BlockId blockId, BlockDirection? direction)` に引数を追加する。デフォルト引数は禁止のため、既存呼び出し元（`BuildMenuState`）は `null` を明示する
+- `PlaceSystemUpdateContext` に `SelectedBlockDirection` を追加し、選択変化検知（IsSelectionChanged）の比較対象に含める。同一ブロックを別向きでピックし直したケースを変化として拾うため
+- `CommonBlockPlaceSystem` は `IsSelectionChanged` かつ direction 有りのとき `_currentBlockDirection` へ適用する
+- ベルト・レール等、ドラッグ操作で向きが決まる PlaceSystem は direction を単に無視する（壊れない）
+
+## エッジケース
+
+| ケース | 挙動 |
+|---|---|
+| 空振り（ブロック無し・地形のみ） | 何もしない。現在の選択を維持（クリアしない） |
+| 未解放ブロック | 無反応 |
+| 多セルブロックの端をクリック | 子コライダー → `BlockGameObjectChild.BlockGameObject` で親解決（既存ユーティリティの挙動） |
+| 列車・電線 | `BlockOnlyLayerMask` のためヒットせず対象外 |
+| 縦向き設置ブロック（UpNorth等） | `BlockDirection` をそのままコピー |
+| ベルト隠しバリアント | 代表ブロックへ変換して選択 |
+| テキスト入力中（PlaceBlockState） | 既存ガードにより無効 |
+
+## UI
+
+キー操作説明文（`KeyControlDescription`）を更新し、GameScreen と PlaceBlock の両方へ「ミドルクリック: ブロックをスポイト」を追記する。
+
+## テスト
+
+- `BlockPickResolver` をユニットテスト（隠しバリアント→代表ブロック変換、未解放ブロックの拒否）
+- 入力・レイキャスト・ステート遷移はプレイモード/実機で確認（`BlockPickService` は Unity の入力とカメラに依存するためユニットテスト対象外）
+- 注: `PlaceSystemStateController` の選択変化検知フローは既存機能として動作しているものに乗る形であり、本機能で新規テストは追加しない
+
+## 実装上の注意
+
+作業ツリーが `origin/master-fable-tmp` とのマージ途中（本スペック作成時点）。本設計は HEAD 側の `BuildViewModeController` 経路を前提とするため、実装はマージ解決後に着手すること。

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/Common/CommonBlockPlaceSystem.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/Common/CommonBlockPlaceSystem.cs
@@ -71,12 +71,20 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem.Common
         
         public void ManualUpdate(PlaceSystemUpdateContext context)
         {
+            ApplyPickedDirection();
             UpdateHeightOffset();
             BlockDirectionControl();
             GroundClickControl(context);
-            
+
             #region Internal
-            
+
+            void ApplyPickedDirection()
+            {
+                // スポイトでピックした向きを選択変化時に反映する
+                // Apply the eyedropped block direction when the selection changes
+                if (context.IsSelectionChanged && context.SelectedBlockDirection.HasValue) _currentBlockDirection = context.SelectedBlockDirection.Value;
+            }
+
             void UpdateHeightOffset()
             {
                 if (HybridInput.GetKeyDown(KeyCode.Q)) //TODO InputManagerに移す

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/IPlaceSystem.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/IPlaceSystem.cs
@@ -1,5 +1,6 @@
 using System;
 using Core.Master;
+using Game.Block.Interface;
 
 namespace Client.Game.InGame.BlockSystem.PlaceSystem
 {
@@ -18,6 +19,10 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem
         // The block selected in the build menu (null when nothing is selected)
         public readonly BlockId? SelectedBlockId;
 
+        // スポイトでピックした向き（未指定はnull）
+        // The eyedropped block direction (null when not specified)
+        public readonly BlockDirection? SelectedBlockDirection;
+
         // ・選択種別
         // ・車両/接続具/BPの選択値
         // ・選択変化フラグ
@@ -28,10 +33,11 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem
         public readonly string SelectedBlueprintName;
         public readonly bool IsSelectionChanged;
 
-        public PlaceSystemUpdateContext(PlacementSelectionType selectionType, BlockId? selectedBlockId, Guid selectedTrainCarGuid, string selectedConnectPlaceMode, string selectedBlueprintName, bool isSelectionChanged)
+        public PlaceSystemUpdateContext(PlacementSelectionType selectionType, BlockId? selectedBlockId, BlockDirection? selectedBlockDirection, Guid selectedTrainCarGuid, string selectedConnectPlaceMode, string selectedBlueprintName, bool isSelectionChanged)
         {
             SelectionType = selectionType;
             SelectedBlockId = selectedBlockId;
+            SelectedBlockDirection = selectedBlockDirection;
             SelectedTrainCarGuid = selectedTrainCarGuid;
             SelectedConnectPlaceMode = selectedConnectPlaceMode;
             SelectedBlueprintName = selectedBlueprintName;

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/PlaceSystemStateController.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/PlaceSystemStateController.cs
@@ -1,5 +1,6 @@
 using System;
 using Core.Master;
+using Game.Block.Interface;
 
 namespace Client.Game.InGame.BlockSystem.PlaceSystem
 {
@@ -14,6 +15,7 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem
         // Previous frame's selection (used to detect selection changes)
         private PlacementSelectionType _lastSelectionType;
         private BlockId? _lastSelectedBlockId;
+        private BlockDirection? _lastSelectedBlockDirection;
         private Guid _lastSelectedTrainCarGuid;
         private string _lastSelectedConnectPlaceMode;
         private string _lastSelectedBlueprintName;
@@ -36,6 +38,7 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem
             // Reset previous selection values so the first frame after re-enable reports IsSelectionChanged=true
             _lastSelectionType = PlacementSelectionType.None;
             _lastSelectedBlockId = null;
+            _lastSelectedBlockDirection = null;
             _lastSelectedTrainCarGuid = Guid.Empty;
             _lastSelectedConnectPlaceMode = null;
             _lastSelectedBlueprintName = null;
@@ -64,6 +67,7 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem
                 // Detect selection changes (used to reset previews such as the train car preview)
                 var isSelectionChanged = _lastSelectionType != _placementSelection.SelectionType
                                          || _lastSelectedBlockId != _placementSelection.SelectedBlockId
+                                         || _lastSelectedBlockDirection != _placementSelection.SelectedBlockDirection
                                          || _lastSelectedTrainCarGuid != _placementSelection.SelectedTrainCarGuid
                                          || _lastSelectedConnectPlaceMode != _placementSelection.SelectedConnectPlaceMode
                                          || _lastSelectedBlueprintName != _placementSelection.SelectedBlueprintName;
@@ -71,6 +75,7 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem
                 var context = new PlaceSystemUpdateContext(
                     _placementSelection.SelectionType,
                     _placementSelection.SelectedBlockId,
+                    _placementSelection.SelectedBlockDirection,
                     _placementSelection.SelectedTrainCarGuid,
                     _placementSelection.SelectedConnectPlaceMode,
                     _placementSelection.SelectedBlueprintName,
@@ -79,6 +84,7 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem
 
                 _lastSelectionType = _placementSelection.SelectionType;
                 _lastSelectedBlockId = _placementSelection.SelectedBlockId;
+                _lastSelectedBlockDirection = _placementSelection.SelectedBlockDirection;
                 _lastSelectedTrainCarGuid = _placementSelection.SelectedTrainCarGuid;
                 _lastSelectedConnectPlaceMode = _placementSelection.SelectedConnectPlaceMode;
                 _lastSelectedBlueprintName = _placementSelection.SelectedBlueprintName;

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/PlacementSelection.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/BlockSystem/PlaceSystem/PlacementSelection.cs
@@ -1,5 +1,6 @@
 using System;
 using Core.Master;
+using Game.Block.Interface;
 
 namespace Client.Game.InGame.BlockSystem.PlaceSystem
 {
@@ -21,15 +22,19 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem
     {
         public PlacementSelectionType SelectionType { get; private set; } = PlacementSelectionType.None;
         public BlockId? SelectedBlockId { get; private set; }
+        // スポイトでピックした向き（メニュー選択時はnull）
+        // The direction picked by the eyedropper (null when selected from the menu)
+        public BlockDirection? SelectedBlockDirection { get; private set; }
         public Guid SelectedTrainCarGuid { get; private set; }
         public string SelectedConnectPlaceMode { get; private set; }
         public string SelectedBlueprintName { get; private set; }
 
-        public void SetSelectedBlock(BlockId blockId)
+        public void SetSelectedBlock(BlockId blockId, BlockDirection? direction)
         {
             ClearSelection();
             SelectionType = PlacementSelectionType.Block;
             SelectedBlockId = blockId;
+            SelectedBlockDirection = direction;
         }
 
         public void SetSelectedTrainCar(Guid trainCarGuid)
@@ -63,6 +68,7 @@ namespace Client.Game.InGame.BlockSystem.PlaceSystem
         {
             SelectionType = PlacementSelectionType.None;
             SelectedBlockId = null;
+            SelectedBlockDirection = null;
             SelectedTrainCarGuid = Guid.Empty;
             SelectedConnectPlaceMode = null;
             SelectedBlueprintName = null;

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/Control/BlockClickDetectUtil.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/Control/BlockClickDetectUtil.cs
@@ -1,5 +1,6 @@
 using Client.Common;
 using Client.Game.InGame.Block;
+using Client.Game.InGame.BlockSystem.PlaceSystem.Common.PreviewController;
 using Client.Game.InGame.Control.BuildView;
 using UnityEngine;
 
@@ -49,14 +50,18 @@ namespace Client.Game.InGame.Control
             var hits = Physics.RaycastAll(ray, 100, LayerConst.BlockOnlyLayerMask);
             if (hits.Length == 0) return false;
             
-            // プレビューゴーストを自然に飛ばすため、手前から順に対象コンポーネントを探す
-            // Search target components from nearest hits so preview ghosts are skipped naturally
+            // 手前のプレビューゴーストだけを貫通対象にする
+            // Only nearby preview ghosts are allowed to be penetrated
             System.Array.Sort(hits, (left, right) => left.distance.CompareTo(right.distance));
             
             foreach (var hit in hits)
             {
+                if (hit.collider.GetComponentInParent<BlockPreviewObject>() != null) continue;
+                
                 component = hit.collider.gameObject.GetComponentInChildren<T>();
                 if (component is not null) return true;
+                
+                return false;
             }
             
             return false;

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/Control/BlockClickDetectUtil.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/Control/BlockClickDetectUtil.cs
@@ -46,10 +46,20 @@ namespace Client.Game.InGame.Control
             // The aim point is resolved centrally by AimPointProvider per view mode
             var ray = camera.ScreenPointToRay(AimPointProvider.GetAimScreenPoint());
             
-            if (!Physics.Raycast(ray, out var hit, 100, LayerConst.BlockOnlyLayerMask)) return false;
-            component = hit.collider.gameObject.GetComponentInChildren<T>();
+            var hits = Physics.RaycastAll(ray, 100, LayerConst.BlockOnlyLayerMask);
+            if (hits.Length == 0) return false;
             
-            return component is not null;
+            // プレビューゴーストを自然に飛ばすため、手前から順に対象コンポーネントを探す
+            // Search target components from nearest hits so preview ghosts are skipped naturally
+            System.Array.Sort(hits, (left, right) => left.distance.CompareTo(right.distance));
+            
+            foreach (var hit in hits)
+            {
+                component = hit.collider.gameObject.GetComponentInChildren<T>();
+                if (component is not null) return true;
+            }
+            
+            return false;
         }
     }
 }

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/UIState/State/BlockPick.meta
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/UIState/State/BlockPick.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9d2e0e9691b4342d19678ef85852e3aa
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/UIState/State/BlockPick/BlockPickResolver.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/UIState/State/BlockPick/BlockPickResolver.cs
@@ -1,0 +1,30 @@
+using Core.Master;
+using Game.Block.Interface.Extension;
+using Game.UnlockState;
+
+namespace Client.Game.InGame.UI.UIState.State.BlockPick
+{
+    /// <summary>
+    /// スポイトでピックしたブロックの選択可否と最終ブロックIDを解決する
+    /// Resolves whether an eyedropped block is pickable and its final block id
+    /// </summary>
+    public static class BlockPickResolver
+    {
+        public static bool TryResolvePickTarget(BlockId rawBlockId, IGameUnlockStateData unlockState, out BlockId resolvedBlockId)
+        {
+            resolvedBlockId = rawBlockId;
+
+            // ベルトファミリーは代表ブロックへ変換（ビルドメニューの隠しバリアント除外と整合）
+            // Belt family members resolve to the representative block, matching the menu's hidden-variant exclusion
+            if (BeltConveyorPlaceFamilyUtil.TryGetFamily(rawBlockId, out var beltParam))
+            {
+                resolvedBlockId = BeltConveyorPlaceFamilyUtil.GetRepresentativeBlockId(beltParam);
+            }
+
+            // 未解放ブロックはピック不可（スポイトで解放システムを迂回させない）
+            // Locked blocks are not pickable; the eyedropper must not bypass the unlock system
+            var blockGuid = MasterHolder.BlockMaster.GetBlockMaster(resolvedBlockId).BlockGuid;
+            return unlockState.BlockUnlockStateInfos.TryGetValue(blockGuid, out var info) && info.IsUnlocked;
+        }
+    }
+}

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/UIState/State/BlockPick/BlockPickResolver.cs.meta
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/UIState/State/BlockPick/BlockPickResolver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 42ac2b4d91ec544a7a0fa7730658b4a5

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/UIState/State/BlockPick/BlockPickService.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/UIState/State/BlockPick/BlockPickService.cs
@@ -1,0 +1,36 @@
+using Client.Game.InGame.BlockSystem.PlaceSystem;
+using Client.Game.InGame.Control;
+using Client.Input;
+using Game.UnlockState;
+
+namespace Client.Game.InGame.UI.UIState.State.BlockPick
+{
+    /// <summary>
+    /// ミドルクリックでカーソル下のブロックをピックし設置選択状態へ反映する
+    /// Middle-click eyedropper: picks the block under the cursor into the placement selection
+    /// </summary>
+    public class BlockPickService
+    {
+        private readonly PlacementSelection _placementSelection;
+        private readonly IGameUnlockStateData _gameUnlockStateData;
+
+        public BlockPickService(PlacementSelection placementSelection, IGameUnlockStateData gameUnlockStateData)
+        {
+            _placementSelection = placementSelection;
+            _gameUnlockStateData = gameUnlockStateData;
+        }
+
+        public bool TryPickBlockUnderCursor()
+        {
+            //TODO InputSystem対応
+            if (!HybridInput.GetMouseButtonDown(2)) return false;
+            if (!BlockClickDetectUtil.TryGetCursorOnBlock(out var blockObject)) return false;
+            if (!BlockPickResolver.TryResolvePickTarget(blockObject.BlockId, _gameUnlockStateData, out var resolvedBlockId)) return false;
+
+            // ブロック種類と設置向きをまとめて選択状態へ反映する
+            // Apply both the block type and its placed direction to the selection
+            _placementSelection.SetSelectedBlock(resolvedBlockId, blockObject.BlockPosInfo.BlockDirection);
+            return true;
+        }
+    }
+}

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/UIState/State/BlockPick/BlockPickService.cs.meta
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/UIState/State/BlockPick/BlockPickService.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f0df8827724f445ea9213c7f0351efbb

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/UIState/State/BuildMenuState.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/UIState/State/BuildMenuState.cs
@@ -38,7 +38,7 @@ namespace Client.Game.InGame.UI.UIState.State
                 switch (entry.EntryType)
                 {
                     case PlacementSelectionType.Block:
-                        _placementSelection.SetSelectedBlock(entry.BlockId);
+                        _placementSelection.SetSelectedBlock(entry.BlockId, null);
                         break;
                     case PlacementSelectionType.TrainCar:
                         _placementSelection.SetSelectedTrainCar(entry.TrainCarGuid);

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/UIState/State/GameScreenState.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/UIState/State/GameScreenState.cs
@@ -2,6 +2,7 @@
 using Client.Game.InGame.Control;
 using Client.Game.InGame.Train.Unit;
 using Client.Game.InGame.UI.KeyControl;
+using Client.Game.InGame.UI.UIState.State.BlockPick;
 using Client.Game.InGame.UI.UIState.State.SubInventory;
 using Client.Game.Skit;
 using Client.Input;
@@ -15,17 +16,20 @@ namespace Client.Game.InGame.UI.UIState.State
         private readonly SkitManager _skitManager;
         private readonly GameScreenSubInventoryInteractService _subInventoryInteractService;
         private readonly RideVehicleInputService _rideVehicleInputService;
+        private readonly BlockPickService _blockPickService;
 
         public GameScreenState(
             SkitManager skitManager,
             InGameCameraController inGameCameraController,
             GameScreenSubInventoryInteractService subInventoryInteractService,
-            RideVehicleInputService rideVehicleInputService)
+            RideVehicleInputService rideVehicleInputService,
+            BlockPickService blockPickService)
         {
             _skitManager = skitManager;
             _inGameCameraController = inGameCameraController;
             _subInventoryInteractService = subInventoryInteractService;
             _rideVehicleInputService = rideVehicleInputService;
+            _blockPickService = blockPickService;
         }
 
         public UITransitContext GetNextUpdate()
@@ -39,6 +43,10 @@ namespace Client.Game.InGame.UI.UIState.State
 
             // ブロックや列車とインタラクトしたか
             if (_subInventoryInteractService.TryGetSubInventoryInteractObject(out var context)) return context;
+
+            // ミドルクリックでブロックをスポイトし配置モードへ入る
+            // Middle-click eyedrops a block and enters placement mode
+            if (_blockPickService.TryPickBlockUnderCursor()) return new UITransitContext(UIStateEnum.PlaceBlock);
 
             if (InputManager.UI.BlockDelete.GetKeyDown) return new UITransitContext(UIStateEnum.DeleteBar);
             if (_skitManager.IsPlayingSkit) return new UITransitContext(UIStateEnum.Story);
@@ -61,7 +69,7 @@ namespace Client.Game.InGame.UI.UIState.State
             InputManager.MouseCursorVisible(false);
             _inGameCameraController.SetControllable(true);
 
-            KeyControlDescription.Instance.SetText("Tab: インベントリ\n1~9: アイテム持ち替え\nB: ブロック配置\nG:ブロック削除\nT: チャレンジ一覧\nR: リサーチツリー\nF3: デバッグモード\n");
+            KeyControlDescription.Instance.SetText("Tab: インベントリ\n1~9: アイテム持ち替え\nB: ブロック配置\nG:ブロック削除\nミドルクリック: ブロックをスポイト\nT: チャレンジ一覧\nR: リサーチツリー\nF3: デバッグモード\n");
         }
         
         public void OnExit()

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/UIState/State/PlaceBlockState.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/UIState/State/PlaceBlockState.cs
@@ -4,6 +4,7 @@ using Client.Game.InGame.Block;
 using Client.Game.InGame.BlockSystem.PlaceSystem;
 using Client.Game.InGame.Control.BuildView;
 using Client.Game.InGame.UI.KeyControl;
+using Client.Game.InGame.UI.UIState.State.BlockPick;
 using Client.Game.Skit;
 using Client.Input;
 using UniRx;
@@ -18,14 +19,16 @@ namespace Client.Game.InGame.UI.UIState.State
         private readonly BuildViewModeController _buildViewModeController;
         private readonly List<IDisposable> _blockPlacedDisposable = new();
         private readonly PlaceSystemStateController _placeSystemStateController;
+        private readonly BlockPickService _blockPickService;
         private bool _wasTextInputFocused;
 
-        public PlaceBlockState(SkitManager skitManager, BuildViewModeController buildViewModeController, BlockGameObjectDataStore blockGameObjectDataStore, PlaceSystemStateController placeSystemStateController)
+        public PlaceBlockState(SkitManager skitManager, BuildViewModeController buildViewModeController, BlockGameObjectDataStore blockGameObjectDataStore, PlaceSystemStateController placeSystemStateController, BlockPickService blockPickService)
         {
             _skitManager = skitManager;
             _buildViewModeController = buildViewModeController;
             _blockGameObjectDataStore = blockGameObjectDataStore;
             _placeSystemStateController = placeSystemStateController;
+            _blockPickService = blockPickService;
         }
 
         public void OnEnter(UITransitContext context)
@@ -42,7 +45,7 @@ namespace Client.Game.InGame.UI.UIState.State
             }
             _blockPlacedDisposable.Add(_blockGameObjectDataStore.OnBlockPlaced.Subscribe(OnPlaceBlock));
 
-            KeyControlDescription.Instance.SetText("Tab: ブロック選択\nV: 視点切替\nQ: 設置高さ上げる\nE: ブロック高さ下げる\nB: 配置モード終了\n左クリック: ブロック配置\nG:ブロック削除");
+            KeyControlDescription.Instance.SetText("Tab: ブロック選択\nV: 視点切替\nQ: 設置高さ上げる\nE: ブロック高さ下げる\nB: 配置モード終了\n左クリック: ブロック配置\nG:ブロック削除\nミドルクリック: ブロックをスポイト");
         }
 
         public UITransitContext GetNextUpdate()
@@ -70,6 +73,10 @@ namespace Client.Game.InGame.UI.UIState.State
                 if (InputManager.UI.CloseUI.GetKeyDown || HybridInput.GetKeyDown(KeyCode.B)) return Leave(UIStateEnum.GameScreen);
 
                 _buildViewModeController.ManualUpdate();
+
+                // ミドルクリックで選択ブロックをスポイトで切り替える
+                // Middle-click switches the selected block via the eyedropper
+                _blockPickService.TryPickBlockUnderCursor();
             }
 
             _placeSystemStateController.ManualUpdate();

--- a/moorestech_client/Assets/Scripts/Client.Starter/MainGameStarter.cs
+++ b/moorestech_client/Assets/Scripts/Client.Starter/MainGameStarter.cs
@@ -53,6 +53,7 @@ using Client.Game.InGame.Train.View;
 using Client.Game.InGame.Train.View.Object.Core;
 using Client.Game.InGame.UI.Inventory.Craft;
 using Client.Game.InGame.UI.UIState.State;
+using Client.Game.InGame.UI.UIState.State.BlockPick;
 using Client.Game.InGame.UI.UIState.State.PauseMenu;
 using Client.Game.InGame.UI.UIState.State.SubInventory;
 using Client.Game.Skit;
@@ -227,6 +228,7 @@ namespace Client.Starter
             builder.Register<BuildMenuState>(Lifetime.Singleton);
             builder.Register<ItemRecipeViewerDataContainer>(Lifetime.Singleton);
             builder.Register<GameScreenSubInventoryInteractService>(Lifetime.Singleton);
+            builder.Register<BlockPickService>(Lifetime.Singleton);
             builder.Register<RideVehicleInputService>(Lifetime.Singleton);
             builder.Register<PauseMenuStateService>(Lifetime.Singleton);
 

--- a/moorestech_client/Assets/Scripts/Client.Tests/PlaceSystem/BlockPickResolverTest.cs
+++ b/moorestech_client/Assets/Scripts/Client.Tests/PlaceSystem/BlockPickResolverTest.cs
@@ -1,0 +1,54 @@
+using Client.Game.InGame.UI.UIState.State.BlockPick;
+using Core.Master;
+using Game.UnlockState;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Server.Boot;
+using Tests.CombinedTest.Server.PacketTest;
+using Tests.Module.TestMod;
+
+namespace Client.Tests.PlaceSystem
+{
+    public class BlockPickResolverTest
+    {
+        [Test]
+        public void 解放済み通常ブロックはそのまま解決される()
+        {
+            var serviceProvider = CreateServer();
+            PlaceBlockProtocolTestSupport.UnlockBlock(serviceProvider, ForUnitTestModBlockId.MachineId);
+            var unlockState = serviceProvider.GetService<IGameUnlockStateDataController>();
+
+            Assert.IsTrue(BlockPickResolver.TryResolvePickTarget(ForUnitTestModBlockId.MachineId, unlockState, out var resolved));
+            Assert.AreEqual(ForUnitTestModBlockId.MachineId, resolved);
+        }
+
+        [Test]
+        public void ベルト隠しバリアントは代表ブロックへ解決される()
+        {
+            var serviceProvider = CreateServer();
+            PlaceBlockProtocolTestSupport.UnlockBlock(serviceProvider, ForUnitTestModBlockId.GearBeltConveyor);
+            var unlockState = serviceProvider.GetService<IGameUnlockStateDataController>();
+
+            // 長さ3の隠しバリアントをピックしても代表（長さ1）に解決される
+            // Picking the hidden length-3 variant resolves to the representative length-1 block
+            Assert.IsTrue(BlockPickResolver.TryResolvePickTarget(ForUnitTestModBlockId.GearBeltConveyor3, unlockState, out var resolved));
+            Assert.AreEqual(ForUnitTestModBlockId.GearBeltConveyor, resolved);
+        }
+
+        [Test]
+        public void 未解放ブロックはピックできない()
+        {
+            var serviceProvider = CreateServer();
+            PlaceBlockProtocolTestSupport.LockBlock(serviceProvider, ForUnitTestModBlockId.MachineId);
+            var unlockState = serviceProvider.GetService<IGameUnlockStateDataController>();
+
+            Assert.IsFalse(BlockPickResolver.TryResolvePickTarget(ForUnitTestModBlockId.MachineId, unlockState, out _));
+        }
+
+        private static ServiceProvider CreateServer()
+        {
+            var (_, serviceProvider) = new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
+            return serviceProvider;
+        }
+    }
+}

--- a/moorestech_client/Assets/Scripts/Client.Tests/PlaceSystem/BlockPickResolverTest.cs.meta
+++ b/moorestech_client/Assets/Scripts/Client.Tests/PlaceSystem/BlockPickResolverTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9972a51e6a7ef477b9b0e3aceaf33272

--- a/moorestech_client/Assets/Scripts/Client.Tests/Tests.asmdef
+++ b/moorestech_client/Assets/Scripts/Client.Tests/Tests.asmdef
@@ -28,7 +28,8 @@
         "Server.Util",
         "Game.Train",
         "Core.Update",
-        "Core.Inventory"
+        "Core.Inventory",
+        "Game.UnlockState"
     ],
     "includePlatforms": [
         "Editor"


### PR DESCRIPTION
## Summary
- ミドルクリックで照準先のブロックをピックし、そのブロック・向きをそのまま設置状態にするスポイト機能を追加
- ピック解決ロジックを`BlockPickResolver`（純粋ロジック）と`BlockPickService`（DI登録・状態遷移連携）に分離し、GameScreen/PlaceBlockの両ステートから利用
- `PlacementSelection`にブロック向き（`BlockDirection`）を伝搬し、ピック元と同じ向きで設置プレビューを開始
- 配置プレビューゴーストがピック用raycastを遮る問題を修正（貫通対象をプレビューゴーストのみに限定）
- プレイテストDSLシナリオ`block-eyedropper-via-ui.cs`と`BlockPickResolverTest`（EditModeユニットテスト）を追加、spec/実装プランをdocsに追加

## Base branch
FPS建設モード（#996 `feature/replace-place-system-with-electric`）の上に積んだスタックPRです。#996マージ後にこのPRをレビュー・マージしてください。

## Test plan
- [ ] `BlockPickResolverTest` がグリーンであること
- [ ] プレイテストDSLシナリオ `block-eyedropper-via-ui.cs` が通ること（masterピン: playtest-pin/block-eyedropper f8d25b07）
- [ ] 実プレイでミドルクリックにより照準先ブロックがホットバー選択なしで設置対象になり、向きが引き継がれること
- [ ] 設置プレビュー表示中でもゴースト越しにピックできること

🤖 Generated with [Claude Code](https://claude.com/claude-code)