### PR TITLE
docs(skill): playtest masterピンを固定パス廃止→作業中ブランチの互換コミットから自動解決

### DIFF
--- a/.claude/skills/unity-playmode-recorded-playtest/SKILL.md
+++ b/.claude/skills/unity-playmode-recorded-playtest/SKILL.md
@@ -43,9 +43,10 @@ uloop control-play-mode --project-path ./moorestech_client --action stop   # 前
 
 ## 絶対規則（全ユースケース共通・違反すると必ず死ぬ）
 
-1. **masterデータはピン留めworktree**（`/Users/katsumi/moorestech-worktrees/playtest-master/server_v8`）。
-   共有moorestech_masterのHEADは別ブランチ用スキーマに進んでいることがあり、使うと`MooresmasterLoaderException`で初期化が**無言死**する。互換コミットは`.moorestech-external-revisions.json`の`commitHash`で特定。worktree作成:
-   `git -C /Users/katsumi/moorestech_master worktree add <path> <互換コミット>`
+1. **masterデータは作業中ブランチの互換コミットにピン留めしたworktreeを使う**（スキル固定のパスは持たない）。
+   共有moorestech_masterのHEADや他ブランチ用の既存worktreeは別スキーマに進んでいることがあり、使うと`MooresmasterLoaderException`で初期化が**無言死**する。互換コミットは作業中プロジェクトの`.moorestech-external-revisions.json`の`moorestech_master.commitHash`で、Unityが作業ツリー版を実チェックアウト値へ常時書き戻すため**コミット済み(`git show HEAD:`)の値が正**。
+   `run-scenario.sh`/`preflight.sh`はこのコミット済みcommitHashにHEADが一致するmoorestech_master worktreeを**自動解決**する（第3/第2引数省略時）。未作成なら自動解決が失敗しエラーになるので、作業中ブランチ用に1つ作る:
+   `git -C ../moorestech_master worktree add <path> <互換コミット>`（作成後は第3引数で明示してもよい）
 2. **OSレベル入力シミュレート禁止**（simulate-keyboard/simulate-mouse-input）。Editorを前面化させ実OSマウスが毎フレーム注入を上書きし、PlayMode再起動まで回復しない。注入は`SemanticInput`（QueueStateEvent）一択。**スニペットから`InputSystem.Update()`も呼ばない**
 3. **固定sleepで待たない**。`p.Until(条件, timeout, ラベル)`かファイル出現ポーリング（result.json / ready.marker）で待つ
 4. **サーバーポート11564は固定・全worktree共通**。プレイテストは同時に1つ。他worktreeのPlayModeが占有していると起動不能（PlayMode停止後のソケットリークも起きる→troubleshooting.md）

--- a/.claude/skills/unity-playmode-recorded-playtest/references/run-scenario.md
+++ b/.claude/skills/unity-playmode-recorded-playtest/references/run-scenario.md
@@ -18,7 +18,7 @@ SKILL=.claude/skills/unity-playmode-recorded-playtest
 "$SKILL/scripts/run-scenario.sh" ./moorestech_client "$SKILL/scenarios/<シナリオ名>.cs"
 ```
 
-- 第3引数でmasterデータを差し替え可能。省略時 `/Users/katsumi/moorestech-worktrees/playtest-master/server_v8`（通常は省略）
+- 第3引数でmasterデータを差し替え可能。省略時は作業中プロジェクトの`.moorestech-external-revisions.json`の互換コミットにHEADが一致するmoorestech_master worktreeを自動解決する（スキル固定パスは無い）。該当worktree未作成なら自動解決が失敗しエラーになるので、`git -C ../moorestech_master worktree add <path> <互換コミット>`で作るか第3引数で明示する
 - 所要: preflight ~30秒 + ready ~15〜30秒 + シナリオ本体。**バックグラウンド実行してresult.json出現を待つ**（固定sleepの多段待ちをしない）
 
 ## ランナー内部の流れ（すべて自動・リトライ内蔵）

--- a/.claude/skills/unity-playmode-recorded-playtest/references/troubleshooting.md
+++ b/.claude/skills/unity-playmode-recorded-playtest/references/troubleshooting.md
@@ -33,8 +33,8 @@ uloop execute-dynamic-code --project-path <保持側client> --code 'UnityEditor.
 ※他セッションのEditorを止める前にユーザーへ確認する。preflight [5/5]が事前検出する。
 
 **(b) `MooresmasterLoaderException`（例: PropertyPath: data[0].priority）** — masterスキーマ不整合。
-ピン留めmaster（`/Users/katsumi/moorestech-worktrees/playtest-master/server_v8`）を使っているか確認。
-互換コミットは`.moorestech-external-revisions.json`の`moorestech_master.commitHash`が正。preflight [4/5]が検出する。
+作業中ブランチの互換コミットにピン留めしたmaster worktreeを使っているか確認（スキル固定パスは無い。既存の別ブランチ用worktreeがドリフトしていることがある）。
+互換コミットは作業中プロジェクトの`.moorestech-external-revisions.json`の`moorestech_master.commitHash`が正で、`run-scenario.sh`はこれにHEADが一致するworktreeを自動解決する。該当worktree未作成なら自動解決失敗のエラーになるので`git -C ../moorestech_master worktree add <path> <互換コミット>`で作る。preflight [4/5]が不整合を検出する。
 なお本番マスタは`IMasterValidator.Validate`が走るため、ロジックテストで出なかったmaster不整合を
 このスキルが最初に検出することが多い（それ自体がバグ検出の成果になる）。
 

--- a/.claude/skills/unity-playmode-recorded-playtest/scripts/preflight.sh
+++ b/.claude/skills/unity-playmode-recorded-playtest/scripts/preflight.sh
@@ -9,7 +9,33 @@
 set -u
 
 PROJECT_PATH="${1:?usage: preflight.sh <unity-project-path> [master-server-dir]}"
-MASTER_DIR="${2:-/Users/katsumi/moorestech-worktrees/playtest-master/server_v8}"
+
+# masterピンworktreeを作業中プロジェクトの互換コミットから自動解決する（固定パスを持たない）
+# Resolve the pinned master worktree from the working project's own compat commit (no hardcoded path)
+resolve_master_dir() {
+    local repo_root commit master_repo wt json
+    repo_root="$(cd "$PROJECT_PATH/.." 2>/dev/null && pwd)" || return 1
+    # Unityが作業ツリーのピンファイルを実チェックアウト値へ常時書き戻すため、コミット済みの値を正とする
+    # Unity keeps rewriting the working-tree pin file to the resolved checkout, so trust the committed value
+    json=$(git -C "$repo_root" show HEAD:.moorestech-external-revisions.json 2>/dev/null)
+    [[ -n "$json" ]] || json=$(cat "$repo_root/.moorestech-external-revisions.json" 2>/dev/null)
+    [[ -n "$json" ]] || return 1
+    commit=$(printf '%s' "$json" | python3 -c "import json,sys; d=json.load(sys.stdin); print(next((r['commitHash'] for r in d.get('repositories',[]) if r.get('key')=='moorestech_master'),''))" 2>/dev/null)
+    [[ -n "$commit" ]] || return 1
+    master_repo="$(cd "$repo_root/../moorestech_master" 2>/dev/null && pwd)" || return 1
+    wt=$(git -C "$master_repo" worktree list --porcelain 2>/dev/null | awk -v c="$commit" '/^worktree /{p=substr($0,10)} /^HEAD /{if($2==c){print p; exit}}')
+    [[ -n "$wt" && -d "$wt/server_v8" ]] || return 1
+    echo "$wt/server_v8"
+}
+
+MASTER_DIR="${2:-}"
+if [[ -z "$MASTER_DIR" ]]; then
+    MASTER_DIR=$(resolve_master_dir) || {
+        echo "ERROR: masterピンworktreeを自動解決できません。作業中ブランチの互換コミット(.moorestech-external-revisions.jsonのmoorestech_master.commitHash)にHEADを合わせたmoorestech_master worktreeを用意し、第2引数で明示してください:" >&2
+        echo "  git -C ../moorestech_master worktree add <path> <互換コミット>" >&2
+        exit 1
+    }
+fi
 FAIL=0
 
 # uloop出力から先頭の警告行を除いてJSON部分だけを取り出す

--- a/.claude/skills/unity-playmode-recorded-playtest/scripts/run-scenario.sh
+++ b/.claude/skills/unity-playmode-recorded-playtest/scripts/run-scenario.sh
@@ -11,7 +11,33 @@ set -u
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_PATH="${1:?usage: run-scenario.sh <unity-project-path> <scenario.cs> [master-server-dir]}"
 SCENARIO_FILE="${2:?scenario .cs file required}"
-MASTER_DIR="${3:-/Users/katsumi/moorestech-worktrees/playtest-master/server_v8}"
+
+# masterピンworktreeを作業中プロジェクトの互換コミットから自動解決する（固定パスを持たない）
+# Resolve the pinned master worktree from the working project's own compat commit (no hardcoded path)
+resolve_master_dir() {
+    local repo_root commit master_repo wt json
+    repo_root="$(cd "$PROJECT_PATH/.." 2>/dev/null && pwd)" || return 1
+    # Unityが作業ツリーのピンファイルを実チェックアウト値へ常時書き戻すため、コミット済みの値を正とする
+    # Unity keeps rewriting the working-tree pin file to the resolved checkout, so trust the committed value
+    json=$(git -C "$repo_root" show HEAD:.moorestech-external-revisions.json 2>/dev/null)
+    [[ -n "$json" ]] || json=$(cat "$repo_root/.moorestech-external-revisions.json" 2>/dev/null)
+    [[ -n "$json" ]] || return 1
+    commit=$(printf '%s' "$json" | python3 -c "import json,sys; d=json.load(sys.stdin); print(next((r['commitHash'] for r in d.get('repositories',[]) if r.get('key')=='moorestech_master'),''))" 2>/dev/null)
+    [[ -n "$commit" ]] || return 1
+    master_repo="$(cd "$repo_root/../moorestech_master" 2>/dev/null && pwd)" || return 1
+    wt=$(git -C "$master_repo" worktree list --porcelain 2>/dev/null | awk -v c="$commit" '/^worktree /{p=substr($0,10)} /^HEAD /{if($2==c){print p; exit}}')
+    [[ -n "$wt" && -d "$wt/server_v8" ]] || return 1
+    echo "$wt/server_v8"
+}
+
+MASTER_DIR="${3:-}"
+if [[ -z "$MASTER_DIR" ]]; then
+    MASTER_DIR=$(resolve_master_dir) || {
+        echo "ERROR: masterピンworktreeを自動解決できません。作業中ブランチの互換コミット(.moorestech-external-revisions.jsonのmoorestech_master.commitHash)にHEADを合わせたmoorestech_master worktreeを用意し、第3引数で明示してください:" >&2
+        echo "  git -C ../moorestech_master worktree add <path> <互換コミット>" >&2
+        exit 1
+    }
+fi
 READY_TIMEOUT=300
 RESULT_TIMEOUT=420
 


### PR DESCRIPTION
- run-scenario.sh/preflight.shの固定default（moorestech-worktrees/playtest-master）を撤廃
- コミット済み.moorestech-external-revisions.jsonのcommitHashにHEADが一致するmoorestech_master worktreeを自動解決（Unityが作業ツリー版をdirtyにするためgit show HEAD:を正とする）
- 未解決時は明示エラーで作成手順を案内。SKILL.md/references/troubleshootingの記述も更新