### PR TITLE
fix: マージ後のコンパイルエラー修正と外部マスタ参照更新

### DIFF
--- a/.moorestech-external-revisions.json
+++ b/.moorestech-external-revisions.json
@@ -3,7 +3,7 @@
         {
             "key": "moorestech_master",
             "relativePath": "../moorestech_master",
-            "commitHash": "9c0993f254b20adfd776fe650f632b3d7e5a3140"
+            "commitHash": "120712b8a37b1a6e945dc242c4105b6f0c4abbda"
         },
         {
             "key": "moorestech_client_private",

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/CraftTree/Target/CraftTreeTargetView.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/CraftTree/Target/CraftTreeTargetView.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using Game.CraftTree.Models;
-using Game.CraftTree.Models;
 using UnityEngine;
 
 namespace Client.Game.InGame.CraftTree.Target

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/CraftTree/Target/CraftTreeTargetViewItems.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/CraftTree/Target/CraftTreeTargetViewItems.cs
@@ -1,7 +1,6 @@
 using Client.Game.InGame.Context;
 using Client.Game.InGame.UI.Inventory.Common;
 using Game.CraftTree.Models;
-using Game.CraftTree.Models;
 using TMPro;
 using UnityEngine;
 

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/CraftTree/Target/CraftTreeTargetViewManager.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/CraftTree/Target/CraftTreeTargetViewManager.cs
@@ -1,6 +1,5 @@
 using Client.Game.InGame.CraftTree.TreeView;
 using Game.CraftTree.Models;
-using Game.CraftTree.Models;
 using UniRx;
 using UnityEngine;
 

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Block/MachineRecipeSelectionPanel.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Block/MachineRecipeSelectionPanel.cs
@@ -94,7 +94,7 @@ namespace Client.Game.InGame.UI.Inventory.Block
                 }
                 var fluidId = MasterHolder.FluidMaster.GetFluidId(recipe.OutputFluids[0].FluidGuid);
                 var fluidView = ClientContext.FluidImageContainer.GetItemView(fluidId);
-                slotView.SetItem(fluidView, 0, BuildToolTip(recipe));
+                slotView.SetFluid(fluidView, BuildToolTip(recipe));
             }
 
             string BuildToolTip(MachineRecipeMasterElement recipe)

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Common/ItemSlotView.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Common/ItemSlotView.cs
@@ -41,6 +41,15 @@ namespace Client.Game.InGame.UI.Inventory.Common
             }
         }
 
+        // 液体出力のみのレシピ表示用に液体アイコンを表示
+        // Display a fluid icon for recipes whose output is fluid only
+        public void SetFluid(FluidViewData fluidView, string toolTipText)
+        {
+            ItemViewData = null;
+            Count = 0;
+            commonSlotView.SetView(fluidView.FluidImage, string.Empty, toolTipText);
+        }
+
         // アイコン無しエントリはテキストのみ表示（BP等）
         // Display an icon-less entry as text only (e.g. blueprint entries)
         public void SetTextOnly(string text, string toolTipText)

--- a/moorestech_server/Assets/Scripts/Core.Master/_CompileRequester.cs
+++ b/moorestech_server/Assets/Scripts/Core.Master/_CompileRequester.cs
@@ -5,5 +5,5 @@ public class CompileRequester
 {
 // スキーマを更新したら、こちらの更新もコミットしてください。
 // If you update the schema, please also commit this update.
-    private const string dummyText = "2026/07/10 16:14:17";
+    private const string dummyText = "2026/07/13 09:34:40";
 }


### PR DESCRIPTION
## Summary
- マージ後のコンパイルエラーを修正（液体レシピ表示をSetFluid経由に統一・using重複除去）
- 外部マスタ参照（moorestech_master）とコンパイル要求用ダミーテキストを更新

## Test plan
- [ ] `uloop compile --project-path ./moorestech_client` でコンパイルが通ることを確認

Generated with [Claude Code](https://claude.com/claude-code)