### PR TITLE
refactor: gear周りの未使用メンバー削除（PR #1000 積み残し）

### DIFF
--- a/moorestech_server/Assets/Scripts/Game.Block/Blocks/Gear/FuelGearGeneratorFluidComponent.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Blocks/Gear/FuelGearGeneratorFluidComponent.cs
@@ -1,12 +1,9 @@
 using System.Collections.Generic;
 using Core.Master;
 using Game.Block.Blocks.Fluid;
-using Game.Block.Component;
 using Game.Block.Interface.Component;
 using Game.Fluid;
 using Newtonsoft.Json;
-using UnityEngine;
-using Game.Block.Interface.Component.ConnectJudge;
 
 namespace Game.Block.Blocks.Gear
 {
@@ -17,31 +14,23 @@ namespace Game.Block.Blocks.Gear
     public class FuelGearGeneratorFluidComponent : IFluidInventory, IUpdatableBlockComponent, IBlockSaveState
     {
         private readonly FluidContainer _fuelTank;
-        private readonly BlockConnectorComponent<IFluidInventory, DefaultConnectJudge> _fluidConnector;
-        private bool _wasRefilledThisUpdate;
         private int _consecutiveUpdatesWithoutRefill;
-        private bool _wasEverDisconnected;
-        
-        public FuelGearGeneratorFluidComponent(float tankCapacity, BlockConnectorComponent<IFluidInventory, DefaultConnectJudge> fluidConnector)
+
+        public FuelGearGeneratorFluidComponent(float tankCapacity)
         {
             _fuelTank = new FluidContainer(tankCapacity);
-            _fluidConnector = fluidConnector;
-            _wasRefilledThisUpdate = false;
             _consecutiveUpdatesWithoutRefill = 0;
-            _wasEverDisconnected = false;
         }
-        
-        public FuelGearGeneratorFluidComponent(Dictionary<string, string> componentStates, float tankCapacity, BlockConnectorComponent<IFluidInventory, DefaultConnectJudge> fluidConnector)
-            : this(tankCapacity, fluidConnector)
+
+        public FuelGearGeneratorFluidComponent(Dictionary<string, string> componentStates, float tankCapacity)
+            : this(tankCapacity)
         {
             if (!componentStates.TryGetValue(SaveKey, out var saveState)) return;
-            
+
             var saveData = JsonConvert.DeserializeObject<FuelGearGeneratorFluidSaveData>(saveState);
             _fuelTank = saveData.Fluid.ToFluidContainer(tankCapacity);
-            
-            _wasRefilledThisUpdate = saveData.WasRefilledThisUpdate;
+
             _consecutiveUpdatesWithoutRefill = saveData.ConsecutiveUpdatesWithoutRefill;
-            _wasEverDisconnected = saveData.WasEverDisconnected;
         }
         
         public FluidContainer SteamTank => _fuelTank;
@@ -50,22 +39,18 @@ namespace Game.Block.Blocks.Gear
         public void Update()
         {
             // この更新サイクルで補給があったかどうかをチェック
-            _wasRefilledThisUpdate = _fuelTank.HasPreviousSources;
-            
+            // Check whether the tank was refilled during this update cycle
+            var wasRefilledThisUpdate = _fuelTank.HasPreviousSources;
+
             // 補給状態を追跡
-            if (_wasRefilledThisUpdate)
+            // Track the refill state
+            if (wasRefilledThisUpdate)
             {
                 _consecutiveUpdatesWithoutRefill = 0;
             }
             else
             {
                 _consecutiveUpdatesWithoutRefill++;
-                // 一度でも切断が検知されたらフラグを立てる
-                if (_consecutiveUpdatesWithoutRefill >= 1)
-                {
-                    _wasEverDisconnected = true;
-                }
-                // Debug.Log($"[FluidComponent] No refill. Consecutive: {_consecutiveUpdatesWithoutRefill}, Disconnected: {IsPipeDisconnected}");
             }
             
             // タンクの送信元記録をクリア
@@ -110,9 +95,7 @@ namespace Game.Block.Blocks.Gear
             var saveData = new FuelGearGeneratorFluidSaveData
             {
                 Fluid = new FluidContainerSaveJsonObject(_fuelTank),
-                WasRefilledThisUpdate = _wasRefilledThisUpdate,
-                ConsecutiveUpdatesWithoutRefill = _consecutiveUpdatesWithoutRefill,
-                WasEverDisconnected = _wasEverDisconnected
+                ConsecutiveUpdatesWithoutRefill = _consecutiveUpdatesWithoutRefill
             };
             
             return JsonConvert.SerializeObject(saveData);
@@ -122,9 +105,7 @@ namespace Game.Block.Blocks.Gear
         private class FuelGearGeneratorFluidSaveData
         {
             public FluidContainerSaveJsonObject Fluid { get; set; }
-            public bool WasRefilledThisUpdate { get; set; }
             public int ConsecutiveUpdatesWithoutRefill { get; set; }
-            public bool WasEverDisconnected { get; set; }
         }
         
         #endregion

--- a/moorestech_server/Assets/Scripts/Game.Block/Blocks/Gear/FuelGearGeneratorItemComponent.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Blocks/Gear/FuelGearGeneratorItemComponent.cs
@@ -134,7 +134,7 @@ namespace Game.Block.Blocks.Gear
         // 現在のスロット内容をまとめて復元するためのユーティリティ
         // セーブデータからアイテムを復元する
         // Restore items from save data
-        internal void RestoreItems(List<ItemStackSaveJsonObject> items)
+        private void RestoreItems(List<ItemStackSaveJsonObject> items)
         {
             if (items == null) return;
             var slotSize = _inventoryService.GetSlotSize();

--- a/moorestech_server/Assets/Scripts/Game.Block/Blocks/Gear/GearEnergyTransformerComponent.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Blocks/Gear/GearEnergyTransformerComponent.cs
@@ -13,7 +13,6 @@ namespace Game.Block.Blocks.Gear
     public class GearEnergyTransformer : IGearEnergyTransformer, IBlockStateObservable
     {
         public IObservable<Unit> OnChangeBlockState => _simpleGearService.BlockStateChange;
-        public IObservable<GearUpdateType> OnGearUpdate => _simpleGearService.OnGearUpdate;
 
         public BlockInstanceId BlockInstanceId { get; }
 

--- a/moorestech_server/Assets/Scripts/Game.Block/Blocks/Gear/SimpleGearService.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Blocks/Gear/SimpleGearService.cs
@@ -15,9 +15,6 @@ namespace Game.Block.Blocks.Gear
         public IObservable<Unit> BlockStateChange => _onBlockStateChange;
         private readonly Subject<Unit> _onBlockStateChange = new();
 
-        public IObservable<GearUpdateType> OnGearUpdate => _onGearUpdate;
-        private readonly Subject<GearUpdateType> _onGearUpdate = new();
-
         // 現在値導出に必要なIDと要求トルク計算をownerへ委譲する
         // Delegate the id and required-torque calculation needed for derivation to the owner
         private readonly IGearEnergyTransformer _owner;
@@ -98,7 +95,6 @@ namespace Game.Block.Blocks.Gear
             _lastTorque = torque;
 
             _onBlockStateChange.OnNext(Unit.Default);
-            _onGearUpdate.OnNext(GearUpdateType.SupplyPower);
         }
 
         // 導出した現在値をクライアント送信用のステート詳細へシリアライズする
@@ -123,11 +119,5 @@ namespace Game.Block.Blocks.Gear
             if (!GearNetworkDatastore.TryGetGearNetwork(_owner.BlockInstanceId, out var network)) return false;
             return network.TryResolveRotation(_owner.BlockInstanceId, out rpm, out isClockwise);
         }
-    }
-
-    public enum GearUpdateType
-    {
-        SupplyPower,
-        Rocked,
     }
 }

--- a/moorestech_server/Assets/Scripts/Game.Block/Blocks/GearChainPole/GearChainPoleComponent.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Blocks/GearChainPole/GearChainPoleComponent.cs
@@ -46,7 +46,7 @@ namespace Game.Block.Blocks.GearChainPole
             _param = param;
             BlockInstanceId = blockInstanceId;
             _gearService = new SimpleGearService(this, connectorComponent);
-            _gearService.OnGearUpdate.Subscribe(_ => _onChangeBlockState.OnNext(Unit.Default));
+            _gearService.BlockStateChange.Subscribe(_ => _onChangeBlockState.OnNext(Unit.Default));
             
             _componentStates = componentStates;
             GearNetworkDatastore.AddGear(this);
@@ -184,6 +184,7 @@ namespace Game.Block.Blocks.GearChainPole
             // コネクタはBlockComponentManagerが別コンポーネントとして破棄するため、ここでは破棄しない
             // The connector is destroyed separately by BlockComponentManager, so it must not be destroyed here
             _chainTargets.Clear();
+            _gearService.Destroy();
             _onChangeBlockState.Dispose();
             IsDestroy = true;
         }

--- a/moorestech_server/Assets/Scripts/Game.Block/Factory/BlockTemplate/VanillaFuelGearGeneratorTemplate.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Factory/BlockTemplate/VanillaFuelGearGeneratorTemplate.cs
@@ -47,17 +47,11 @@ namespace Game.Block.Factory.BlockTemplate
             // 流体接続の設定
             var fluidConnector = IFluidInventory.CreateFluidInventoryConnector(configParam.FluidInventoryConnectors, blockPositionInfo);
             
-            // FuelGearGeneratorFluidComponentの作成（fluidConnectorを渡す）
+            // FuelGearGeneratorFluidComponentの作成
+            // Create the FuelGearGeneratorFluidComponent
             var fluidComponent = componentStates == null
-                ? new FuelGearGeneratorFluidComponent(
-                    configParam.FluidCapacity,
-                    fluidConnector
-                )
-                : new FuelGearGeneratorFluidComponent(
-                    componentStates,
-                    configParam.FluidCapacity,
-                    fluidConnector
-                );
+                ? new FuelGearGeneratorFluidComponent(configParam.FluidCapacity)
+                : new FuelGearGeneratorFluidComponent(componentStates, configParam.FluidCapacity);
             
             // 燃料ギアジェネレータコンポーネント
             // Configure the fuel gear generator aggregate component

--- a/moorestech_server/Assets/Scripts/Game.Gear/Common/GearPower.cs
+++ b/moorestech_server/Assets/Scripts/Game.Gear/Common/GearPower.cs
@@ -1,9 +1,0 @@
-using UnitGenerator;
-
-namespace Game.Gear.Common
-{
-    [UnitOf(typeof(float), UnitGenerateOptions.ArithmeticOperator | UnitGenerateOptions.ValueArithmeticOperator | UnitGenerateOptions.Comparable)]
-    public partial struct GearPower
-    {
-    }
-}

--- a/moorestech_server/Assets/Scripts/Game.Gear/Common/GearPower.cs.meta
+++ b/moorestech_server/Assets/Scripts/Game.Gear/Common/GearPower.cs.meta
@@ -1,3 +1,0 @@
-fileFormatVersion: 2
-guid: ac749dafc048467699c19305e006ee92
-timeCreated: 1718763619

--- a/moorestech_server/Assets/Scripts/Game.Gear/Common/IGearEnergyTransformer.cs
+++ b/moorestech_server/Assets/Scripts/Game.Gear/Common/IGearEnergyTransformer.cs
@@ -9,12 +9,8 @@ namespace Game.Gear.Common
 {
     public interface IGearEnergyTransformer : IBlockComponent
     {
-        public const string WorkingStateName = "Working";
-        public const string RockedStateName = "Rocked";
-        
         public BlockInstanceId BlockInstanceId { get; }
-        
-        public GearPower CurrentPower => new(CurrentRpm.AsPrimitive() * CurrentTorque.AsPrimitive());
+
         public RPM CurrentRpm { get; }
         public Torque CurrentTorque { get; }
         public bool IsCurrentClockwise { get; }

--- a/moorestech_server/Assets/Scripts/Tests/CombinedTest/Game/GearNetworkTest.cs
+++ b/moorestech_server/Assets/Scripts/Tests/CombinedTest/Game/GearNetworkTest.cs
@@ -291,9 +291,9 @@ namespace Tests.CombinedTest.Game
             // 新formula: rpm=10 > baseRpm=5 なのでexpOverを使用
             // New formula: rpm=10 > baseRpm=5, so use expOver=1.585
             // requiredTorque = 1 * (10/5)^1.585 = 1 * 2^1.585 ≈ 3.0, power = 3.0 * 10 = 30
-            AreEqual(30, gear1.CurrentPower);
-            AreEqual(30, gear2.CurrentPower);
-            AreEqual(30, gear3.CurrentPower);
+            AreEqual(30, gear1.CurrentRpm.AsPrimitive() * gear1.CurrentTorque.AsPrimitive());
+            AreEqual(30, gear2.CurrentRpm.AsPrimitive() * gear2.CurrentTorque.AsPrimitive());
+            AreEqual(30, gear3.CurrentRpm.AsPrimitive() * gear3.CurrentTorque.AsPrimitive());
         }
         
         [Test]
@@ -498,11 +498,6 @@ namespace Tests.CombinedTest.Game
         }
         
         private void AreEqual(float expected, Torque actual)
-        {
-            AreEqual(expected, actual.AsPrimitive());
-        }
-        
-        private void AreEqual(float expected, GearPower actual)
         {
             AreEqual(expected, actual.AsPrimitive());
         }


### PR DESCRIPTION
- IGearEnergyTransformer: 未参照のWorkingStateName/RockedStateName定数と テストのみ使用のCurrentPowerプロパティを削除、GearPower型ごと削除
- SimpleGearService: OnGearUpdate/GearUpdateTypeを廃止しBlockStateChangeへ一本化 （Rockedは一度も発火しない値、発火タイミングはBlockStateChangeと完全同一）
- FuelGearGeneratorFluidComponent: 読まれない_wasEverDisconnected削除、 _wasRefilledThisUpdateローカル変数化（セーブデータからも除去）、 未使用の_fluidConnectorフィールドをコンストラクタ引数ごと削除
- FuelGearGeneratorItemComponent.RestoreItems: internal→private
- GearChainPoleComponent.Destroy: _gearService.Destroy()呼び忘れを追加

Server.Tests 884/884パス、クライアントコンパイル確認済み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved fuel generator state saving and restoration for fluid levels and refill tracking.
  - Streamlined gear and energy state notifications for more consistent block updates.
  - Improved gear-chain component cleanup during destruction.
  - Simplified gear power and energy handling while preserving existing torque and consumption behavior.
- **Bug Fixes**
  - Increased reliability when restoring fuel generator contents from saved game data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->