### PR TITLE
fix: tick force slip警告を強制スリップ時のみに限定

### DIFF
--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/Train/View/TrainUnitHashVerifier.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/Train/View/TrainUnitHashVerifier.cs
@@ -73,8 +73,14 @@ namespace Client.Game.InGame.Train.View
             // If there is no message for the current tick but there are messages for future ticks, it's likely that the current tick's message won't arrive. In that case, we will force advance the tick.
             if (!_futureMessageBuffer.TryDequeueHashAtTickSequenceId(currentTickUnifiedId, out var message))
             {
-                Debug.LogWarning("tick force slip!");
-                return _futureMessageBuffer.TryGetFirstHashTickUnifiedId(out _);                
+                // バッファが空なら次バンドル待ちの正常状態なので警告しない
+                // An empty buffer just means waiting for the next bundle, so stay silent
+                if (!_futureMessageBuffer.TryGetFirstHashTickUnifiedId(out var firstBufferedTickUnifiedId))
+                    return false;
+                Debug.LogWarning(
+                    $"tick force slip! expected={currentTickUnifiedId >> 32}_{(uint)currentTickUnifiedId}, " +
+                    $"firstBuffered={firstBufferedTickUnifiedId >> 32}_{(uint)firstBufferedTickUnifiedId}");
+                return true;
             }
             
             var isVerified = ValidateCurrentTickHash();


### PR DESCRIPTION
バッファ空（次バンドル待ちの正常状態）でも同じ警告が毎フレーム出ていたため、
将来hashが存在して実際にtickをスキップする場合のみ、期待tickと先頭バッファtickを添えて警告する。 挙動（戻り値）は変更なし。


Claude-Session: https://claude.ai/code/session_0189xH1YvHJbFJULRZGLtCN3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when tick data is temporarily unavailable.
  * Prevented unnecessary warnings when no buffered tick exists.
  * Added clearer diagnostic information when buffered tick data is out of sync.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->