### PR TITLE
perf(server): 送信スレッドの50msポーリングをイベント駆動待機に置換

### DIFF
--- a/moorestech_server/Assets/Scripts/Server.Boot/Loop/PacketProcessing/SendQueueProcessor.cs
+++ b/moorestech_server/Assets/Scripts/Server.Boot/Loop/PacketProcessing/SendQueueProcessor.cs
@@ -12,17 +12,15 @@ namespace Server.Boot.Loop.PacketProcessing
 {
     /// <summary>
     /// 送信キュープロセッサ
-    /// メインスレッドから送信データをEnqueueし、送信スレッドで50msごとにSocketに送信する
-    /// ConcurrentQueueを使用してlock-freeで高速処理
+    /// メインスレッドから送信データをEnqueueし、送信スレッドがEnqueueされ次第即座にSocketへ送信する
+    /// BlockingCollectionにより待機中はCPUを消費せず、Enqueueで即座に送信スレッドが起きる
     /// </summary>
     public class SendQueueProcessor : IPlayerEventSink
     {
         private readonly Socket _client;
-        private readonly ConcurrentQueue<byte[]> _sendQueue = new();
+        private readonly BlockingCollection<byte[]> _sendQueue = new();
         private readonly Thread _sendThread;
         private readonly CancellationTokenSource _cancellationTokenSource = new();
-
-        private const int SendIntervalMs = 50;
 
         public SendQueueProcessor(Socket client)
         {
@@ -44,7 +42,7 @@ namespace Server.Boot.Loop.PacketProcessing
             var sendData = new byte[header.Length + body.Length];
             header.CopyTo(sendData, 0);
             body.CopyTo(sendData, header.Length);
-            _sendQueue.Enqueue(sendData);
+            _sendQueue.Add(sendData);
         }
 
         // イベント経由のデータ送信
@@ -57,23 +55,22 @@ namespace Server.Boot.Loop.PacketProcessing
 
         private void SendThreadLoop()
         {
+            // 外部境界（Socket送信）の隔離try-catch。キャンセル時はTakeのOperationCanceledExceptionで抜ける
+            // Boundary try-catch isolating socket sends; cancellation exits via Take's OperationCanceledException
             try
             {
-                while (!_cancellationTokenSource.Token.IsCancellationRequested)
+                var token = _cancellationTokenSource.Token;
+                while (!token.IsCancellationRequested)
                 {
-                    // 50msごとにキューをチェックして送信
-                    Thread.Sleep(SendIntervalMs);
-
-                    // キューにあるすべてのデータを送信
-                    while (_sendQueue.TryDequeue(out var dataToSend))
-                    {
-                        SendAll(dataToSend);
-                    }
+                    // データが積まれるまでブロックし、積まれた瞬間に送信
+                    // Block until data is enqueued, then send immediately
+                    var dataToSend = _sendQueue.Take(token);
+                    SendAll(dataToSend);
                 }
             }
             catch (Exception e)
             {
-                if (!_cancellationTokenSource.Token.IsCancellationRequested)
+                if (!_cancellationTokenSource.IsCancellationRequested)
                 {
                     Debug.LogError("送信スレッドでエラーが発生しました");
                     Debug.LogException(e);


### PR DESCRIPTION
## Summary
- `SendQueueProcessor` の送信スレッドが `Thread.Sleep(50)` によるポーリングでキューを監視していたのを、`BlockingCollection.Take(token)` によるイベント駆動待機に置換
- 50msという値は2025-10のClaude生成コミット(90e1e8f59)由来で設計根拠がなく、パケット結合も行っていなかったため純粋な送信遅延源になっていた
- キューにデータが積まれた瞬間に即座に送信されるようになり、最大50msの無駄な遅延を解消

## Test plan
- [x] `uloop compile` でコンパイルエラー無しを確認
- [x] プレイテストDSL `sample-chest` シナリオを実行し、全Assert PASSを確認（設置往復・give・イベント同期のホットバー反映を実プレイ視点で確認）
- [x] `belt-line-via-ui` シナリオの2本目ドラッグ失敗は、未改変masterでも同一再現するmaster既存問題であることをベースライン比較で確認済み（本変更とは無関係）

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Network packets are now dispatched immediately when available, reducing send delays.
  * Improved shutdown responsiveness through cancellation-aware processing.

* **Reliability**
  * Updated queue processing to wait efficiently for outgoing packets and handle cancellation more cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->