### PR TITLE
fix: 無料設置デバッグで未解放ブロックを設置できない不具合を修正

### DIFF
--- a/.claude/skills/unity-playmode-recorded-playtest/scenarios/free-placement-locked-block.cs
+++ b/.claude/skills/unity-playmode-recorded-playtest/scenarios/free-placement-locked-block.cs
@@ -1,0 +1,51 @@
+// 無料設置デバッグ検証: FreeBlockPlacementをONにすると、未解放かつ建設コストを1つも持たないブロックでも
+// ビルドメニューUI経路で設置できることをE2Eで確認する。修正前はサーバーのunlock/costゲートで無言拒否されていた
+// Free-placement debug verification: with FreeBlockPlacement ON, a locked block with zero required items in
+// inventory can still be placed via the build-menu UI route. Before the fix the server's unlock/cost gates silently rejected it
+using Client.Playtest;
+using Client.Playtest.Operations;
+using Common.Debug;
+using Core.Master;
+using Cysharp.Threading.Tasks;
+using Game.Block.Interface;
+using Game.UnlockState;
+using UnityEngine;
+
+var options = new PlaytestRunOptions { Record = true };
+return PlaytestRunner.Run("free-placement-locked-block", options, async p =>
+{
+    await p.SetupFlatGround();
+    p.WarpPlayer(new Vector3(4f, 33.5f, 5f));
+
+    // 無料設置デバッグをON（クライアントのビルドメニュー全表示＆サーバーの強制設置を有効化）
+    // Turn on the free-placement debug toggle (enables client's full build menu + server's forced placement)
+    DebugParameters.SaveBool(DebugParameterKeys.FreeBlockPlacement, true);
+    p.Note("無料設置デバッグをONにした");
+
+    // 対象は未解放・建設コスト持ちの非電気ブロック。前提が「未解放かつ在庫ゼロ」であることを設置前に固める
+    // Target is a locked, cost-bearing, non-electric block. Pin the premise (locked + zero stock) before placing
+    const string blockName = "鉄のコンベアチェスト";
+    var blockGuid = System.Guid.Parse("ab1a47dd-94fe-4e62-a005-a8318fc304a9");
+    var unlockController = p.ServerService<IGameUnlockStateDataController>();
+    var isUnlockedBefore = unlockController.BlockUnlockStateInfos[blockGuid].IsUnlocked;
+    p.Assert(!isUnlockedBefore, $"前提: {blockName} は未解放である");
+    p.Note($"{blockName} は未解放・建設コスト未所持のまま設置を試みる");
+
+    // ビルドメニューUI経路で設置（未解放なので全表示モードでのみメニューに出る）。反映Until内蔵
+    // Place via the build-menu UI route (only visible thanks to show-all mode). Placement wait is built in
+    var placePos = new Vector3Int(4, 32, 5);
+    await p.PlaceBlockViaUi(blockName, placePos, BlockDirection.North);
+    await p.ExitToGameScreen();
+
+    // 設置が実際に成立したことを検証（修正前はここでブロックがnullのまま）
+    // Verify placement actually took effect (before the fix the block stayed null here)
+    var placed = p.GetBlock(placePos);
+    p.Assert(placed != null, "未解放ブロックが無料設置で設置された");
+    p.Assert(placed != null && placed.BlockId == MasterHolder.BlockMaster.GetBlockId(blockGuid), "設置されたのは対象ブロックである");
+
+    // 建設コスト素材を1つも渡していないので在庫は空のまま＝コスト非消費の証拠
+    // No required items were ever granted, so stock stays empty = proof cost was not consumed
+    await p.WaitBlockGameObject(placePos);
+    await p.Screenshot("01-locked-block-placed-free");
+    p.Note("未解放ブロックがコスト無しで設置された。無料設置デバッグは機能している");
+});

--- a/.claude/skills/unity-playmode-recorded-playtest/scenarios/free-placement-locked-block.cs
+++ b/.claude/skills/unity-playmode-recorded-playtest/scenarios/free-placement-locked-block.cs
@@ -1,7 +1,13 @@
 // 無料設置デバッグ検証: FreeBlockPlacementをONにすると、未解放かつ建設コストを1つも持たないブロックでも
-// ビルドメニューUI経路で設置できることをE2Eで確認する。修正前はサーバーのunlock/costゲートで無言拒否されていた
-// Free-placement debug verification: with FreeBlockPlacement ON, a locked block with zero required items in
-// inventory can still be placed via the build-menu UI route. Before the fix the server's unlock/cost gates silently rejected it
+// 本番の設置プロトコル(va:placeBlock)経由で設置できることをE2E録画で確認する。
+// web UI移行でuGUIビルドメニューのスロット自動選択は駆動できないため、UIが送るのと同一のPlaceBlockパケットを直接送出し、
+// 修正対象のサーバー PlaceBlockProtocol を実経路で叩く（サーバー直挿入 PlaceBlockDirect ではなくプロトコル経路である点が重要）
+// Free-placement debug verification (recorded E2E): with FreeBlockPlacement ON, locked blocks with zero required items
+// are placed through the real placement protocol (va:placeBlock). We send the exact PlaceBlock packet the UI would send
+// (not the direct datastore insert), so the fixed server-side PlaceBlockProtocol is exercised end-to-end
+using System;
+using System.Collections.Generic;
+using Client.Game.InGame.Context;
 using Client.Playtest;
 using Client.Playtest.Operations;
 using Common.Debug;
@@ -9,43 +15,78 @@ using Core.Master;
 using Cysharp.Threading.Tasks;
 using Game.Block.Interface;
 using Game.UnlockState;
+using Server.Protocol.PacketResponse;
 using UnityEngine;
 
 var options = new PlaytestRunOptions { Record = true };
 return PlaytestRunner.Run("free-placement-locked-block", options, async p =>
 {
+    // ブロック列(x0..12, z2..6)の手前(低Z側)に立たせ、TPSカメラ(既定で+Z向き)が列を正面に捉えるようにする
+    // Stand in front of the block row (low-Z side) so the TPS camera (default +Z facing) frames the blocks
     await p.SetupFlatGround();
-    p.WarpPlayer(new Vector3(4f, 33.5f, 5f));
+    p.WarpPlayer(new Vector3(6f, 33.5f, -8f));
 
-    // 無料設置デバッグをON（クライアントのビルドメニュー全表示＆サーバーの強制設置を有効化）
-    // Turn on the free-placement debug toggle (enables client's full build menu + server's forced placement)
+    // 無料設置デバッグをON（サーバーの強制設置分岐を有効化）
+    // Turn on the free-placement debug toggle (enables the server's forced-placement branch)
     DebugParameters.SaveBool(DebugParameterKeys.FreeBlockPlacement, true);
-    p.Note("無料設置デバッグをONにした");
+    p.Note("無料設置デバッグをONにした。未解放・在庫ゼロで設置できるか検証する");
+    await p.Screenshot("00-before-placement");
 
-    // 対象は未解放・建設コスト持ちの非電気ブロック。前提が「未解放かつ在庫ゼロ」であることを設置前に固める
-    // Target is a locked, cost-bearing, non-electric block. Pin the premise (locked + zero stock) before placing
-    const string blockName = "鉄のコンベアチェスト";
-    var blockGuid = System.Guid.Parse("ab1a47dd-94fe-4e62-a005-a8318fc304a9");
+    // 検証対象: いずれも未解放・建設コスト持ち。チェスト=非電気、石窯=電気(電線ゲート)、粉砕機=歯車機械
+    // Targets: all locked with construction cost. Chest=non-electric, kiln=electric(wire gate), crusher=gear machine
     var unlockController = p.ServerService<IGameUnlockStateDataController>();
-    var isUnlockedBefore = unlockController.BlockUnlockStateInfos[blockGuid].IsUnlocked;
-    p.Assert(!isUnlockedBefore, $"前提: {blockName} は未解放である");
-    p.Note($"{blockName} は未解放・建設コスト未所持のまま設置を試みる");
+    // ブロックは大きい(3x2x4等)ため、フットプリントが重ならないよう十分に離して配置する
+    // Blocks are large (3x2x4 etc.), so space them far apart to avoid footprint overlap
+    var targets = new (string name, Guid guid, Vector3Int pos)[]
+    {
+        ("鉄のコンベアチェスト", Guid.Parse("ab1a47dd-94fe-4e62-a005-a8318fc304a9"), new Vector3Int(0, 32, 2)),
+        ("石窯",               Guid.Parse("26096ad0-d355-4e2c-9e45-a5c5e91856e0"), new Vector3Int(5, 32, 2)),
+        ("原始的な粉砕機",      Guid.Parse("e5a2b42a-3608-432e-a814-7dbd85095fb1"), new Vector3Int(10, 32, 2)),
+    };
 
-    // ビルドメニューUI経路で設置（未解放なので全表示モードでのみメニューに出る）。反映Until内蔵
-    // Place via the build-menu UI route (only visible thanks to show-all mode). Placement wait is built in
-    var placePos = new Vector3Int(4, 32, 5);
-    await p.PlaceBlockViaUi(blockName, placePos, BlockDirection.North);
-    await p.ExitToGameScreen();
+    // 前提を固める: 全対象が未解放であること
+    // Pin the premise: every target is locked
+    foreach (var t in targets)
+    {
+        var unlocked = unlockController.BlockUnlockStateInfos[t.guid].IsUnlocked;
+        p.Assert(!unlocked, $"前提: {t.name} は未解放");
+    }
 
-    // 設置が実際に成立したことを検証（修正前はここでブロックがnullのまま）
-    // Verify placement actually took effect (before the fix the block stayed null here)
-    var placed = p.GetBlock(placePos);
-    p.Assert(placed != null, "未解放ブロックが無料設置で設置された");
-    p.Assert(placed != null && placed.BlockId == MasterHolder.BlockMaster.GetBlockId(blockGuid), "設置されたのは対象ブロックである");
+    // 本番プロトコルで1つずつ設置し、都度ワールド反映を待って録画に映す
+    // Place one at a time via the real protocol, waiting for world reflection each time so the video shows it
+    foreach (var t in targets)
+    {
+        var blockId = MasterHolder.BlockMaster.GetBlockId(t.guid);
+        p.Note($"{t.name}(未解放/在庫0)を無料設置プロトコルで送信 @ {t.pos}");
 
-    // 建設コスト素材を1つも渡していないので在庫は空のまま＝コスト非消費の証拠
+        var placeInfo = new PlaceInfo
+        {
+            Position = t.pos,
+            Direction = BlockDirection.North,
+            VerticalDirection = BlockVerticalDirection.Horizontal,
+            BlockId = blockId,
+            Placeable = true,
+            CreateParams = Array.Empty<BlockCreateParam>(),
+        };
+        ClientContext.VanillaApi.SendOnly.PlaceBlock(new List<PlaceInfo> { placeInfo });
+
+        // 設置がサーバーで成立しクライアントViewが出るまで待つ（修正前はnullのまま＝timeoutで失敗）
+        // Wait until placement takes effect and the client view spawns (before the fix it stayed null = timeout)
+        await p.Until(() => p.GetBlock(t.pos) != null, 20f, $"{t.name} が無料設置された @ {t.pos}");
+        await p.WaitBlockGameObject(t.pos);
+        await p.WaitSeconds(0.5f);
+    }
+
+    await p.Screenshot("01-locked-blocks-placed-free");
+
+    // 建設コスト素材は一切渡していないので在庫は空のまま＝コスト非消費の証拠
     // No required items were ever granted, so stock stays empty = proof cost was not consumed
-    await p.WaitBlockGameObject(placePos);
-    await p.Screenshot("01-locked-block-placed-free");
-    p.Note("未解放ブロックがコスト無しで設置された。無料設置デバッグは機能している");
+    p.Assert(p.CountItem("鉄インゴット") == 0, "鉄インゴット在庫は0のまま（コスト非消費）");
+    foreach (var t in targets)
+    {
+        var placed = p.GetBlock(t.pos);
+        p.Assert(placed != null && placed.BlockId == MasterHolder.BlockMaster.GetBlockId(t.guid), $"{t.name} が対象IDで設置されている");
+    }
+    p.Note("未解放ブロック4種がコスト無しで設置された。無料設置デバッグは機能している");
+    await p.Screenshot("02-verified");
 });

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/BuildMenu/BuildMenuEntryCatalog.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/BuildMenu/BuildMenuEntryCatalog.cs
@@ -6,6 +6,7 @@ using Client.Game.InGame.BlockSystem.PlaceSystem.Blueprint;
 using Client.Game.InGame.BlockSystem.PlaceSystem.ConnectTool;
 using Client.Game.InGame.BlockSystem.PlaceSystem.Targets;
 using Client.Game.InGame.Context;
+using Common.Debug;
 using Game.Block.Interface.Extension;
 using Client.Mod.Texture;
 using Core.Master;
@@ -25,10 +26,14 @@ namespace Client.Game.InGame.UI.BuildMenu
         {
             var entries = new List<BuildMenuEntry>();
 
-            // 解放済みブロックをソート順に列挙し、ベルトの坂は除外する
-            // Enumerate unlocked blocks in sort order while excluding belt slopes
+            // 無料設置デバッグ時は未解放も含め設置可能な全ブロック/車両を表示する
+            // In free-placement debug mode, show every placeable block/train car including locked ones
+            var showAllPlaceable = DebugParameters.GetValueOrDefaultBool(DebugParameterKeys.FreeBlockPlacement);
+
+            // 解放済み（無料設置時は全）ブロックをソート順に列挙し、ベルトの坂は除外する
+            // Enumerate unlocked (all in free mode) blocks in sort order while excluding belt slopes
             var unlockedBlocks = MasterHolder.BlockMaster.Blocks.Data
-                .Where(b => IsBlockUnlocked(unlockState, b))
+                .Where(b => showAllPlaceable || IsBlockUnlocked(unlockState, b))
                 .Where(b => !BeltConveyorPlaceFamilyUtil.IsSlopeBlock(b.BlockGuid))
                 .OrderBy(b => b.SortPriority ?? 0)
                 .ThenBy(b => b.Name);
@@ -43,7 +48,7 @@ namespace Client.Game.InGame.UI.BuildMenu
             // Enumerate unlocked train cars
             foreach (var trainCar in MasterHolder.TrainUnitMaster.Train.TrainCars)
             {
-                if (!unlockState.TrainCarUnlockStateInfos.TryGetValue(trainCar.TrainCarGuid, out var state) || !state.IsUnlocked) continue;
+                if (!showAllPlaceable && (!unlockState.TrainCarUnlockStateInfos.TryGetValue(trainCar.TrainCarGuid, out var state) || !state.IsUnlocked)) continue;
                 var iconView = ClientContext.TrainCarImageContainer.GetTrainCarView(trainCar.TrainCarGuid);
                 entries.Add(new BuildMenuEntry(new TrainCarPlacementTarget(trainCar.TrainCarGuid), iconView, CreateTrainCarToolTip(trainCar, iconView)));
             }

--- a/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/PlaceBlockProtocol.cs
+++ b/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/PlaceBlockProtocol.cs
@@ -59,19 +59,27 @@ namespace Server.Protocol.PacketResponse
                 if (ServerContext.WorldBlockDatastore.Exists(placeInfo.Position)) return;
 
                 var placeBlockId = placeInfo.BlockId;
+                var createParams = placeInfo.BlockCreateParams.Select(v => new BlockCreateParam(v.Key, v.Value)).ToArray();
+
+                // 無料設置デバッグ: 解放・コスト・電線を一切見ず強制設置して即return
+                // Free placement debug: force-place ignoring unlock/cost/wire entirely, then return
+                if (isFreePlacement)
+                {
+                    ServerContext.WorldBlockDatastore.TryAddBlock(placeBlockId, placeInfo.Position, placeInfo.Direction, createParams, out _);
+                    return;
+                }
+
                 var blockMaster = MasterHolder.BlockMaster.GetBlockMaster(placeBlockId);
 
                 // 未解放セルはスキップし、ベルトの坂はファミリー直線の状態で判定する
                 // Skip locked cells and resolve belt slopes through their family straight block
                 if (!IsUnlocked(placeBlockId, blockMaster.BlockGuid)) return;
 
-                var createParams = placeInfo.BlockCreateParams.Select(v => new BlockCreateParam(v.Key, v.Value)).ToArray();
-
-                // コスト不足セルはスキップ（無料設置時はコスト判定を無視）
-                // Skip cells whose construction cost cannot be covered; ignore the check when free placement is on
+                // コスト不足セルはスキップ
+                // Skip cells whose construction cost cannot be covered
                 var inventory = inventoryData.MainOpenableInventory;
                 var costItemCounts = ConstructionCostService.ToItemCounts(blockMaster.RequiredItems);
-                if (!isFreePlacement && !ConstructionCostService.HasRequiredItems(costItemCounts, inventory.InventoryItems)) return;
+                if (!ConstructionCostService.HasRequiredItems(costItemCounts, inventory.InventoryItems)) return;
 
                 // 電気なら自動接続を事前検証
                 // For electric blocks, validate the auto-connect plan before placement; skip when wires are insufficient
@@ -89,9 +97,7 @@ namespace Server.Protocol.PacketResponse
                 // Do not consume the cost when placement fails
                 if (!ServerContext.WorldBlockDatastore.TryAddBlock(placeBlockId, placeInfo.Position, placeInfo.Direction, createParams, out var block)) return;
 
-                // 無料設置時はコストを消費しない
-                // Do not consume the cost when free placement is on
-                if (!isFreePlacement) ConstructionCostService.ConsumeRequiredItems(costItemCounts, inventory);
+                ConstructionCostService.ConsumeRequiredItems(costItemCounts, inventory);
 
                 // 計画を実行しワイヤー消費
                 // Execute the validated plan: add wires and consume wire items

--- a/moorestech_web/webui/src/app/App.tsx
+++ b/moorestech_web/webui/src/app/App.tsx
@@ -62,8 +62,12 @@ export default function App() {
   const uiVisible = useTopicSelector(Topics.uiVisibility, (d) => d?.visible ?? true);
   const cutScene = useTopicSelector(Topics.gameState, (d) => d?.state === "CutScene");
   const stageRef = useUiScale(uiVisible);
-  const inventoryScreen = screen === "playerInventory" || screen === "subInventory" || screen === "researchTree" || screen === "buildMenu" || screen === "challengeList";
-  const modalScreen = inventoryScreen || screen === "pauseMenu" || screen === "trainPause";
+  // プレイヤーインベントリ本体を出すのは uGUI 準拠で持ち物・サブインベントリ画面のみ
+  // Show the player inventory itself only on the inventory / sub-inventory screens, matching uGUI
+  const inventoryScreen = screen === "playerInventory" || screen === "subInventory";
+  // ビルドメニュー等の独立メニューも背景ディムは共有するが、インベントリは重畳しない
+  // Standalone menus (build menu, etc.) share the dim backdrop but do not overlay the inventory
+  const modalScreen = inventoryScreen || screen === "researchTree" || screen === "buildMenu" || screen === "challengeList" || screen === "pauseMenu" || screen === "trainPause";
 
   // Ctrl+U中はPortalを含む全Web UIをunmountする
   // Unmount the entire Web UI, including portals, while Ctrl+U is active


### PR DESCRIPTION
## 概要
Free block placement デバッグトグルをONにしても、未解放ブロックを設置できない不具合を修正する。

## 原因
`feat: 無料設置デバッグ時にビルドメニューへ全設置可能物を表示`(20a294cd) でビルドメニューは未解放ブロックも表示するようになったが、サーバーの `PlaceBlockProtocol` は無料設置時も **unlock ゲート**（`if (!IsUnlocked(...)) return;`）と電線ゲートで設置を無言拒否していた。ビルドメニュー（表示）とサーバー（設置可否）の判定が不整合だった。

## 修正
`PlaceBlockProtocol.PlaceBlock` に **無料設置専用の分岐** を新設し、`isFreePlacement` のときは解放・建設コスト・電線を一切見ずに `TryAddBlock` で強制設置して即 return する。これにより通常経路に散在していた `!isFreePlacement &&` 条件をすべて除去し、主要フローが読みやすくなった。

```csharp
if (isFreePlacement)
{
    ServerContext.WorldBlockDatastore.TryAddBlock(placeBlockId, placeInfo.Position, placeInfo.Direction, createParams, out _);
    return;
}
```

## 含まれるコミット
- `feat: 無料設置デバッグ時にビルドメニューへ全設置可能物を表示`(20a294cd)
- `fix: ビルドメニュー等の独立画面でインベントリが重畳する不具合を修正`(6f4dd9af)
- `fix: 無料設置デバッグで未解放ブロックが設置できない不具合を修正`(本PRの主眼)
- `test: 無料設置検証シナリオを本番プロトコル経路に変更しE2E録画取得`

## 検証（E2E録画あり）
- `uloop compile`: エラー0で通過
- プレイテストDSLで **本番の設置プロトコル(va:placeBlock)経由** の録画付きE2E検証を実施（`free-placement-locked-block.cs`）。**未解放・在庫ゼロ** のブロック3種を無料設置し、全て設置成立＋在庫非消費を確認:
  - 鉄のコンベアチェスト（非電気・unlockゲート）
  - 石窯（電気・電線ゲート）
  - 原始的な粉砕機（歯車機械）
- result.json: **10/10 assert PASS**（前提「未解放」・設置成立・「鉄インゴット在庫0のまま=コスト非消費」）
- 録画・スクショにアバター/地面/HUD＋設置された未解放ブロック列が映る（ホットバーは空=アイテム未所持のまま設置できている）

> 補足: web UI 移行の影響で uGUI ビルドメニューのスロット自動選択は自動化ハーネスで駆動できないため、検証はUIが送るのと同一のパケットを直接送出する経路で実施した（修正対象のサーバー PlaceBlockProtocol を実経路で叩いている）。