### PR TITLE
feat: MasterTickUpdater新設、tick順序を1ファイルに集約

### DIFF
--- a/moorestech_server/Assets/Scripts/Game.EnergySystem/ElectricTickUpdater.cs
+++ b/moorestech_server/Assets/Scripts/Game.EnergySystem/ElectricTickUpdater.cs
@@ -13,8 +13,8 @@ namespace Game.EnergySystem
 
         public void Update()
         {
-            // 再構築はtick先頭の先行登録（RebuildIfDirty）が担い、ここでは需給計算だけ行う
-            // A preceding tick-head registration (RebuildIfDirty) owns the rebuild; this updater performs settlement only
+            // 再構築はtick先頭のMasterTickUpdaterが担い、ここでは需給計算だけ行う
+            // MasterTickUpdater owns the tick-head rebuild; this updater performs settlement only
             foreach (var segment in _electricWireNetworkDatastore.GetSegments())
             {
                 segment.SettleTick();

--- a/moorestech_server/Assets/Scripts/Game.EnergySystem/ElectricWire/IElectricWireNetworkDatastore.cs
+++ b/moorestech_server/Assets/Scripts/Game.EnergySystem/ElectricWire/IElectricWireNetworkDatastore.cs
@@ -3,8 +3,8 @@ using Game.Block.Interface;
 
 namespace Game.EnergySystem
 {
-    // live電線と適用済みsegmentを分離する。dirty再構築はtick先頭で具象datastore経由
-    // Separates live wire registration from applied segments; the dirty rebuild runs at tick head via the concrete datastore
+    // live電線と適用済みsegmentを分離する。dirty再構築はtick先頭で具象datastore経由（MasterTickUpdater）
+    // Separates live wire registration from applied segments; the dirty rebuild runs at tick head via the concrete datastore (MasterTickUpdater)
     public interface IElectricWireNetworkDatastore
     {
         void AddConnector(IElectricWireConnector connector);

--- a/moorestech_server/Assets/Scripts/Server.Boot/MasterTickUpdater.cs
+++ b/moorestech_server/Assets/Scripts/Server.Boot/MasterTickUpdater.cs
@@ -1,0 +1,39 @@
+using Game.EnergySystem;
+using Game.Gear.Common;
+
+namespace Server.Boot
+{
+    // 仕様2.1のtick順序を1箇所で明示する（①電力網再構築→②歯車網再構築→③電力tick→④歯車tick）
+    // Declares the spec 2.1 tick order in one place: rebuild electric, rebuild gear, settle electric, settle gear
+    public class MasterTickUpdater
+    {
+        private readonly ElectricWireNetworkDatastore _electricWireNetworkDatastore;
+        private readonly GearNetworkDatastore _gearNetworkDatastore;
+        private readonly ElectricTickUpdater _electricTickUpdater;
+        private readonly GearTickUpdater _gearTickUpdater;
+
+        public MasterTickUpdater(
+            ElectricWireNetworkDatastore electricWireNetworkDatastore,
+            GearNetworkDatastore gearNetworkDatastore,
+            ElectricTickUpdater electricTickUpdater,
+            GearTickUpdater gearTickUpdater)
+        {
+            _electricWireNetworkDatastore = electricWireNetworkDatastore;
+            _gearNetworkDatastore = gearNetworkDatastore;
+            _electricTickUpdater = electricTickUpdater;
+            _gearTickUpdater = gearTickUpdater;
+        }
+
+        public void Update()
+        {
+            // トポロジ反映は両網とも需給計算より先（tick途中でセグメント所属を変えないため）
+            // Apply both topologies before any settlement so segment membership never changes mid tick
+            _electricWireNetworkDatastore.RebuildIfDirty();
+            _gearNetworkDatastore.RebuildIfDirty();
+            _electricTickUpdater.Update();
+            _gearTickUpdater.Update();
+            // 将来のFluid/Train等のtickはここに追記する
+            // Future ticks such as fluid and train are appended here
+        }
+    }
+}

--- a/moorestech_server/Assets/Scripts/Server.Boot/MasterTickUpdater.cs.meta
+++ b/moorestech_server/Assets/Scripts/Server.Boot/MasterTickUpdater.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 398a9b221a57df04ebf1169d65914506

--- a/moorestech_server/Assets/Scripts/Server.Boot/MoorestechServerDIContainerGenerator.cs
+++ b/moorestech_server/Assets/Scripts/Server.Boot/MoorestechServerDIContainerGenerator.cs
@@ -145,8 +145,8 @@ namespace Server.Boot
             services.AddSingleton<IPlayerInventoryDataStore, PlayerInventoryDataStore>();
             services.AddSingleton<IInventorySubscriptionStore, InventorySubscriptionStore>();
             services.AddSingleton<OpenableInventoryResolver>();
-            // 具象はtick先頭の再構築登録用、interfaceは参照系向け。同一インスタンスを共有する
-            // The concrete type serves the tick-head rebuild registration; the interface serves readers. Both share one instance
+            // 具象はMasterTickUpdaterの再構築用、interfaceは参照系向け。同一インスタンスを共有する
+            // The concrete type serves MasterTickUpdater's rebuild; the interface serves readers. Both share one instance
             services.AddSingleton<ElectricWireNetworkDatastore>();
             services.AddSingleton<IElectricWireNetworkDatastore>(provider => provider.GetRequiredService<ElectricWireNetworkDatastore>());
             services.AddSingleton<MaxElectricPoleMachineConnectionRange, MaxElectricPoleMachineConnectionRange>();
@@ -194,6 +194,7 @@ namespace Server.Boot
             // Register electric and gear tick updates through DI.
             services.AddSingleton<ElectricTickUpdater>();
             services.AddSingleton<GearTickUpdater>();
+            services.AddSingleton<MasterTickUpdater>();
 
             // 乗車コア。実接続レジストリを IPlayerConnectionChecker として共有する。
             // Riding core. Shares the real connection registry as IPlayerConnectionChecker.
@@ -249,12 +250,9 @@ namespace Server.Boot
             var serviceProvider = services.BuildServiceProvider();
             var packetResponse = new PacketResponseCreator(serviceProvider);
 
-            // tick更新を固定順で登録する。トポロジ反映は全網とも需給計算より先（tick途中でセグメント所属を変えないため）
-            // Register tick handlers in fixed order: apply both topologies before any settlement so segment membership never changes mid tick
-            GameUpdater.AdditionalUpdates.Add(serviceProvider.GetRequiredService<ElectricWireNetworkDatastore>().RebuildIfDirty);
-            GameUpdater.AdditionalUpdates.Add(serviceProvider.GetRequiredService<GearNetworkDatastore>().RebuildIfDirty);
-            GameUpdater.AdditionalUpdates.Add(serviceProvider.GetRequiredService<ElectricTickUpdater>().Update);
-            GameUpdater.AdditionalUpdates.Add(serviceProvider.GetRequiredService<GearTickUpdater>().Update);
+            // tick順序（仕様2.1）はMasterTickUpdaterの1ファイルに集約し、ここでは1本だけ登録する
+            // The tick order (spec 2.1) lives in MasterTickUpdater; register just that one entry here
+            GameUpdater.AdditionalUpdates.Add(serviceProvider.GetRequiredService<MasterTickUpdater>().Update);
 
             //IBootInitializable実装を一括生成し、起動時初期化のLoadを呼ぶ
             // Create all IBootInitializable implementations and invoke their boot-time Load.

--- a/moorestech_server/Assets/Scripts/Tests/CombinedTest/Game/ElectricTickUnificationTest.cs
+++ b/moorestech_server/Assets/Scripts/Tests/CombinedTest/Game/ElectricTickUnificationTest.cs
@@ -28,13 +28,15 @@ namespace Tests.CombinedTest.Game
     public class ElectricTickUnificationTest
     {
         [Test]
-        public void tick更新はトポロジ反映が需給計算より先に登録される()
+        public void tick順序はMasterTickUpdaterに集約される()
         {
-            new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
+            var (_, provider) = new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
+            var masterTickUpdater = provider.GetRequiredService<MasterTickUpdater>();
 
-            // 登録順: 電力網再構築→歯車網再構築→電力tick→歯車tick（tick途中でセグメント所属を変えないため）
-            // Registration order: electric rebuild, gear rebuild, electric tick, gear tick — segment membership never changes mid tick
-            Assert.AreEqual(4, GameUpdater.AdditionalUpdates.Count);
+            // AdditionalUpdatesへの登録はMasterTickUpdater1本だけ（内部順序は仕様2.1）
+            // MasterTickUpdater is the only AdditionalUpdates entry; its body carries the spec 2.1 order
+            Assert.AreEqual(1, GameUpdater.AdditionalUpdates.Count);
+            Assert.AreEqual((Action)masterTickUpdater.Update, GameUpdater.AdditionalUpdates[0]);
         }
 
         // 発電機を撤去された機械は、供給率0の導出により自然に停止する
@@ -83,22 +85,18 @@ namespace Tests.CombinedTest.Game
             Assert.AreEqual(mode0.RequiredPower * 0.5f, detail.BatteryRemaining, 0.01f);
         }
 
-        // 電力tickの先行登録を検証する
-        // Verify that DI registers the electric tick before the gear tick
+        // tick登録がMasterTickUpdaterの1本に集約されていることを検証する（電力→歯車の順序はMasterTickUpdater内のコードで固定）
+        // Verify tick registration is consolidated into the single MasterTickUpdater entry (electric-before-gear order is fixed inside it)
         [Test]
         public void ElectricTickIsRegisteredBeforeGearTick()
         {
             new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
 
-            // 両tickの存在と順序を固定する
-            // Require both updaters and pin the electric updater to an earlier registration position
-            Assert.AreEqual(1, GameUpdater.AdditionalUpdates.FindAll(update => update.Target is ElectricTickUpdater).Count);
-            Assert.AreEqual(1, GameUpdater.AdditionalUpdates.FindAll(update => update.Target is GearTickUpdater).Count);
-            var electricTickIndex = GameUpdater.AdditionalUpdates.FindIndex(update => update.Target is ElectricTickUpdater);
-            var gearTickIndex = GameUpdater.AdditionalUpdates.FindIndex(update => update.Target is GearTickUpdater);
-            Assert.GreaterOrEqual(electricTickIndex, 0);
-            Assert.GreaterOrEqual(gearTickIndex, 0);
-            Assert.Less(electricTickIndex, gearTickIndex);
+            // 個別Updaterの直接登録は存在せず、MasterTickUpdaterだけが1本登録される
+            // No individual updater registrations remain; only the single MasterTickUpdater entry exists
+            Assert.AreEqual(1, GameUpdater.AdditionalUpdates.FindAll(update => update.Target is MasterTickUpdater).Count);
+            Assert.AreEqual(0, GameUpdater.AdditionalUpdates.FindAll(update => update.Target is ElectricTickUpdater).Count);
+            Assert.AreEqual(0, GameUpdater.AdditionalUpdates.FindAll(update => update.Target is GearTickUpdater).Count);
         }
 
         // 歯車→電力変換機のバッテリー残量はセーブ・ロードを跨いで維持される


### PR DESCRIPTION
個別に4本登録していたtick更新（電力網再構築→歯車網再構築→電力tick→歯車tick）を
MasterTickUpdater（Server.Boot）1ファイルに集約し、AdditionalUpdatesへの登録を1本にする。 tick順序の正典がコード上の1箇所で読めるようになり、以後のtick追加（流体・鉄道・
ブロック更新等）はこのファイルへの追記で行う。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Centralized network topology rebuilding and electric/gear tick processing into a single coordinated update.
  * Ensured topology updates occur before tick calculations, with electric processing consistently preceding gear processing.
  * Updated related documentation and validation to reflect the unified tick sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->