### PR TITLE
feat: デバッグ設定をテスト・プレイテストからプロセス環境変数で隔離

### DIFF
--- a/moorestech_client/Assets/Scripts/Client.Playtest/Core/PlaytestPaths.cs
+++ b/moorestech_client/Assets/Scripts/Client.Playtest/Core/PlaytestPaths.cs
@@ -23,6 +23,10 @@ namespace Client.Playtest.Core
 
         public static string ReadyMarkerPath => Path.Combine(SessionDirectory, "ready.marker");
 
+        // デバッグ設定の隔離先。セッション毎に作り直すので前回実行の残骸を読まない
+        // Isolated debug parameter cache; recreated per session so a previous run's leftovers are never read
+        public static string DebugCacheDirectory => string.IsNullOrEmpty(SessionDirectory) ? string.Empty : Path.Combine(SessionDirectory, "debug-cache");
+
         public static void ResetSession()
         {
             // タイムスタンプ付きセッションディレクトリを新規作成して記録する

--- a/moorestech_client/Assets/Scripts/Client.Playtest/PlaytestBoot.cs
+++ b/moorestech_client/Assets/Scripts/Client.Playtest/PlaytestBoot.cs
@@ -17,27 +17,10 @@ namespace Client.Playtest
     {
         private const string GameInitializerScenePath = "Assets/Scenes/Game/GameInitialaizer.unity";
         private const string PendingBootKey = "Playtest_PendingBoot";
-        // DebugServerDirectoryは永続cacheに書かれるため、上書き前の値を退避し再生終了時に戻す
-        // DebugServerDirectory lives in the persistent cache, so back up the pre-override value and restore it on play-exit
-        private const string OverroteServerDirKey = "Playtest_OverroteServerDir";
-        private const string PriorServerDirKey = "Playtest_PriorServerDir";
-        private const string PriorServerDirExistedKey = "Playtest_PriorServerDirExisted";
 
         public static string PrepareAndEnterPlayMode(string serverDirectory, bool noSave)
         {
             if (EditorApplication.isPlayingOrWillChangePlaymode) return "ERROR: already playing";
-
-            // worktree必須のmasterパス設定（未指定なら既存設定を維持）。上書き前の値を退避して再生終了時に戻す
-            // Set the master data path required in worktrees (keep the existing value when unspecified); back up the pre-override value for play-exit restore
-            if (!string.IsNullOrEmpty(serverDirectory))
-            {
-                var key = ServerDirectory.DebugServerDirectorySettingKey;
-                var priorExisted = DebugParameters.ExistsString(key);
-                SessionState.SetBool(PriorServerDirExistedKey, priorExisted);
-                SessionState.SetString(PriorServerDirKey, priorExisted ? DebugParameters.GetValueOrDefaultString(key, "") : "");
-                SessionState.SetBool(OverroteServerDirKey, true);
-                DebugParameters.SaveString(key, serverDirectory);
-            }
 
             // NoSaveフラグと起動待ちフラグはSessionStateでドメインリロードを越えて保持される
             // The NoSave flag and pending-boot flag persist across domain reload via SessionState
@@ -48,6 +31,16 @@ namespace Client.Playtest
             // Disable debug object bootstrap as tests do (prevents IngameDebugConsole etc. noise)
             SessionState.SetBool("DebugObjectsBootstrap_Disabled", true);
             PlaytestPaths.ResetSession();
+
+            // デバッグ設定をセッション専用キャッシュへ隔離する。実キャッシュを複製するので開発者設定は引き継がれる
+            // Isolate debug parameters into a session-local cache; copying the real cache carries developer settings over
+            DebugParametersCacheDirectory.CopyDefaultTo(PlaytestPaths.DebugCacheDirectory);
+            DebugParametersCacheDirectory.SetOverride(PlaytestPaths.DebugCacheDirectory);
+
+            // worktree必須のmasterパス設定（未指定なら既存設定を維持）。隔離後に書くため実キャッシュは汚れない
+            // Set the master data path required in worktrees (keep the existing value when unspecified); written after isolation so the real cache stays clean
+            if (!string.IsNullOrEmpty(serverDirectory))
+                DebugParameters.SaveString(ServerDirectory.DebugServerDirectorySettingKey, serverDirectory);
 
             // ゲーム初期化シーンから再生を開始する
             // Start play mode from the game initializer scene
@@ -80,17 +73,11 @@ namespace Client.Playtest
             SessionState.SetBool("DebugObjectsBootstrap_Disabled", false);
             EditorSceneManager.playModeStartScene = null;
 
-            // 上書きしたmasterパスを元へ戻す。退避値が無ければ削除し、既定(ライブmaster)へ復帰させる
-            // Restore the overridden master path; remove it when there was no prior value so it falls back to the default (live master)
-            if (SessionState.GetBool(OverroteServerDirKey, false))
-            {
-                var key = ServerDirectory.DebugServerDirectorySettingKey;
-                if (SessionState.GetBool(PriorServerDirExistedKey, false))
-                    DebugParameters.SaveString(key, SessionState.GetString(PriorServerDirKey, ""));
-                else
-                    DebugParameters.RemoveString(key);
-                SessionState.SetBool(OverroteServerDirKey, false);
-            }
+            // このプレイテストが張った隔離だけを解除する。テスト側SetUpFixtureの隔離を巻き込まないため
+            // Clear only the isolation this playtest installed, so a test fixture's isolation is never torn down with it
+            var sessionDebugCache = PlaytestPaths.DebugCacheDirectory;
+            if (!string.IsNullOrEmpty(sessionDebugCache) && DebugParametersCacheDirectory.GetOverride() == sessionDebugCache)
+                DebugParametersCacheDirectory.SetOverride(null);
         }
     }
 }

--- a/moorestech_client/Assets/Scripts/Client.Tests/ClientTestsDebugParametersIsolationFixture.cs
+++ b/moorestech_client/Assets/Scripts/Client.Tests/ClientTestsDebugParametersIsolationFixture.cs
@@ -1,0 +1,25 @@
+using NUnit.Framework;
+using Tests.Module;
+
+// namespaceを付けないことでアセンブリ内の全テストを包むSetUpFixtureになる
+// Omitting the namespace makes this SetUpFixture wrap every test in the assembly
+[SetUpFixture]
+public class ClientTestsDebugParametersIsolationFixture
+{
+    private DebugParametersIsolationScope _isolationScope;
+
+    [OneTimeSetUp]
+    public void IsolateDebugParameters()
+    {
+        _isolationScope = DebugParametersIsolationScope.Begin("client-tests");
+    }
+
+    [OneTimeTearDown]
+    public void RestoreDebugParameters()
+    {
+        // ドメインリロードでインスタンスが失われても環境変数から後始末できるようにする
+        // Fall back to env-var-based cleanup when a domain reload has destroyed this instance
+        if (_isolationScope != null) _isolationScope.End();
+        else DebugParametersIsolationScope.EndOrphaned();
+    }
+}

--- a/moorestech_client/Assets/Scripts/Client.Tests/ClientTestsDebugParametersIsolationFixture.cs.meta
+++ b/moorestech_client/Assets/Scripts/Client.Tests/ClientTestsDebugParametersIsolationFixture.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9d983816a16b7486f8f6ca726da6c718

--- a/moorestech_client/Assets/Scripts/Client.Tests/EditModeInPlayingTest/DebugParametersIsolationAcrossDomainReloadTest.cs
+++ b/moorestech_client/Assets/Scripts/Client.Tests/EditModeInPlayingTest/DebugParametersIsolationAcrossDomainReloadTest.cs
@@ -1,0 +1,50 @@
+using System.Collections;
+using System.IO;
+using Common.Debug;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine.TestTools;
+using static Client.Tests.EditModeInPlayingTest.Util.EditModeInPlayingTestUtil;
+
+namespace Client.Tests.EditModeInPlayingTest
+{
+    /// <summary>
+    /// デバッグ設定の隔離がPlayMode遷移のドメインリロードを跨いで維持されることを実測する。
+    /// プロセス環境変数で切り替えている根拠がこれで、失われるとPlayMode中のサーバーが開発者の実cacheを読む。
+    /// Empirically verifies that debug parameter isolation survives the PlayMode transition's domain reload.
+    /// This is why a process environment variable is used; losing it would make the in-play server read the developer's real cache.
+    /// </summary>
+    public class DebugParametersIsolationAcrossDomainReloadTest
+    {
+        [UnityTest]
+        public IEnumerator DebugParametersIsolation_SurvivesPlayModeDomainReload()
+        {
+            EnterPlayModeUtil();
+
+            // yield return new EnterPlayMode　は必ず[UnityTest]関数の直下で呼び出すこと。そうでないとなぜかわからないがプレイモードに入らない
+            // Always call yield return new EnterPlayMode directly under the [UnityTest] function. Otherwise, for unknown reasons, it will not enter PlayMode.
+            yield return new EnterPlayMode(expectDomainReload: true);
+
+            // EnterPlayMode時のテストフレームワーク内部エラーでテストが失敗するのを防ぐ
+            // Prevent test failure from test framework internal errors during EnterPlayMode.
+            LogAssert.ignoreFailingMessages = true;
+
+            // リロード後も隔離先が生きており、既定の ../cache へ戻っていないこと
+            // The isolation target is still live after the reload and has not fallen back to the default ../cache
+            var cacheDirectory = DebugParametersCacheDirectory.Resolve();
+            Assert.IsFalse(string.IsNullOrEmpty(DebugParametersCacheDirectory.GetOverride()));
+            Assert.AreNotEqual(Path.GetFullPath("../cache"), cacheDirectory);
+            Assert.IsTrue(Directory.Exists(cacheDirectory));
+
+            // 隔離先は空なので、実cacheに何が書かれていても既定値が読まれる
+            // The isolated cache is empty, so defaults are read no matter what the real cache contains
+            Assert.IsFalse(DebugParameters.GetValueOrDefaultBool(DebugParameterKeys.FreeBlockPlacement));
+
+            yield return new ExitPlayMode();
+
+            // テスト終了後にデバッグオブジェクト無効化フラグをクリア
+            // Clear debug objects disabled flag after test.
+            SessionState.SetBool("DebugObjectsBootstrap_Disabled", false);
+        }
+    }
+}

--- a/moorestech_client/Assets/Scripts/Client.Tests/EditModeInPlayingTest/DebugParametersIsolationAcrossDomainReloadTest.cs.meta
+++ b/moorestech_client/Assets/Scripts/Client.Tests/EditModeInPlayingTest/DebugParametersIsolationAcrossDomainReloadTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 98577b15f6b484660b0686e22043bb2d

--- a/moorestech_client/Assets/Scripts/Client.Tests/Tests.asmdef
+++ b/moorestech_client/Assets/Scripts/Client.Tests/Tests.asmdef
@@ -32,7 +32,8 @@
         "Core.Inventory",
         "Client.WebUiHost",
         "Client.Skit",
-        "Game.UnlockState"
+        "Game.UnlockState",
+        "Common.Debug"
     ],
     "includePlatforms": [
         "Editor"

--- a/moorestech_server/Assets/Scripts/Common.Debug/DebugParameter.cs
+++ b/moorestech_server/Assets/Scripts/Common.Debug/DebugParameter.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
 using UnityEngine;
@@ -18,11 +17,6 @@ namespace Common.Debug
 
     public static class DebugParameters
     {
-        private static readonly string CachePath = Path.GetFullPath("../cache");
-        private const string BoolFileName = "BoolDebugParameters.json";
-        private const string IntFileName = "IntDebugParameters.json";
-        private const string StringFileName = "StringDebugParameters.json";
-
         private static Dictionary<string, bool> BoolDebugParameters { get; set; } = new();
         private static Dictionary<string, int> IntDebugParameters { get; set; } = new();
         private static Dictionary<string, string> StringDebugParameters { get; set; } = new();
@@ -134,26 +128,26 @@ namespace Common.Debug
 
         private static void Save()
         {
-            EnsureCacheDirectoryExists();
+            Directory.CreateDirectory(DebugParametersCacheDirectory.Resolve());
 
             // Save bool parameters
             var boolDict = new SerializableDictionary<string, bool>(BoolDebugParameters);
-            File.WriteAllText(GetFilePath(BoolFileName), JsonUtility.ToJson(boolDict));
+            File.WriteAllText(GetFilePath(DebugParametersCacheDirectory.BoolFileName), JsonUtility.ToJson(boolDict));
 
             // Save int parameters
             var intDict = new SerializableDictionary<string, int>(IntDebugParameters);
-            File.WriteAllText(GetFilePath(IntFileName), JsonUtility.ToJson(intDict));
+            File.WriteAllText(GetFilePath(DebugParametersCacheDirectory.IntFileName), JsonUtility.ToJson(intDict));
 
             // Save string parameters
             var stringDict = new SerializableDictionary<string, string>(StringDebugParameters);
-            File.WriteAllText(GetFilePath(StringFileName), JsonUtility.ToJson(stringDict));
+            File.WriteAllText(GetFilePath(DebugParametersCacheDirectory.StringFileName), JsonUtility.ToJson(stringDict));
         }
 
         private static void Load()
         {
-            BoolDebugParameters = LoadDictionary<string, bool>(GetFilePath(BoolFileName));
-            IntDebugParameters = LoadDictionary<string, int>(GetFilePath(IntFileName));
-            StringDebugParameters = LoadDictionary<string, string>(GetFilePath(StringFileName));
+            BoolDebugParameters = LoadDictionary<string, bool>(GetFilePath(DebugParametersCacheDirectory.BoolFileName));
+            IntDebugParameters = LoadDictionary<string, int>(GetFilePath(DebugParametersCacheDirectory.IntFileName));
+            StringDebugParameters = LoadDictionary<string, string>(GetFilePath(DebugParametersCacheDirectory.StringFileName));
         }
 
         private static Dictionary<TKey, TValue> LoadDictionary<TKey, TValue>(string filePath)
@@ -165,77 +159,11 @@ namespace Common.Debug
             return dict?.ToDictionary() ?? new Dictionary<TKey, TValue>();
         }
 
-        private static void EnsureCacheDirectoryExists()
-        {
-            if (!Directory.Exists(CachePath))
-            {
-                Directory.CreateDirectory(CachePath);
-            }
-        }
-
+        // 静的初期化時にキャッシュせずアクセス毎に解決する。環境変数設定より前に初期化されると切替が効かないため
+        // Resolve per access instead of caching at static init, since initializing before the env var is set would defeat the switch
         private static string GetFilePath(string fileName)
         {
-            return Path.Combine(CachePath, fileName);
-        }
-
-        #endregion
-    }
-
-    /// <summary>
-    /// Dictionary を JSON シリアライズできるようにするためのクラス
-    /// </summary>
-    /// <typeparam name="TKey"></typeparam>
-    /// <typeparam name="TValue"></typeparam>
-    [Serializable]
-    public class SerializableDictionary<TKey, TValue> : ISerializationCallbackReceiver
-    {
-        [SerializeField]
-        private List<TKey> keys = new();
-
-        [SerializeField]
-        private List<TValue> values = new();
-
-        // 実際の Dictionary データ。シリアライズ時・デシリアライズ時に keys/values と相互変換。
-        private Dictionary<TKey, TValue> dictionary = new();
-
-        public SerializableDictionary() { }
-
-        public SerializableDictionary(Dictionary<TKey, TValue> dict)
-        {
-            dictionary = dict;
-        }
-
-        /// <summary>
-        /// Dictionary 形式に変換して取得
-        /// </summary>
-        public Dictionary<TKey, TValue> ToDictionary()
-        {
-            return dictionary;
-        }
-
-        #region ISerializationCallbackReceiver implements
-
-        public void OnBeforeSerialize()
-        {
-            // JSON シリアライズされる前に、Dictionary の情報を keys/values に詰め込む
-            keys.Clear();
-            values.Clear();
-
-            foreach (var kvp in dictionary)
-            {
-                keys.Add(kvp.Key);
-                values.Add(kvp.Value);
-            }
-        }
-
-        public void OnAfterDeserialize()
-        {
-            // JSON デシリアライズ後に、keys/values から Dictionary を再構成する
-            dictionary = new Dictionary<TKey, TValue>();
-            for (int i = 0; i < Mathf.Min(keys.Count, values.Count); i++)
-            {
-                dictionary[keys[i]] = values[i];
-            }
+            return Path.Combine(DebugParametersCacheDirectory.Resolve(), fileName);
         }
 
         #endregion

--- a/moorestech_server/Assets/Scripts/Common.Debug/DebugParametersCacheDirectory.cs
+++ b/moorestech_server/Assets/Scripts/Common.Debug/DebugParametersCacheDirectory.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Common.Debug
+{
+    /// <summary>
+    ///     デバッグ設定JSONの置き場所を解決する。
+    ///     テスト・自動プレイテストはここを差し替えることで、開発者の永続デバッグ設定から隔離される。
+    ///     Resolves where the debug parameter JSON files live.
+    ///     Tests and automated playtests swap it to stay isolated from the developer's persistent debug settings.
+    /// </summary>
+    public static class DebugParametersCacheDirectory
+    {
+        public const string BoolFileName = "BoolDebugParameters.json";
+        public const string IntFileName = "IntDebugParameters.json";
+        public const string StringFileName = "StringDebugParameters.json";
+
+        public static readonly IReadOnlyList<string> ParameterFileNames = new[] { BoolFileName, IntFileName, StringFileName };
+
+        private const string DefaultRelativePath = "../cache";
+        private const string OverrideEnvironmentVariableName = "MOORESTECH_DEBUG_CACHE_DIR";
+
+        /// <summary>
+        ///     現在の解決先。上書きが無ければ既定の ../cache
+        ///     The currently resolved directory; the default ../cache when no override is set
+        /// </summary>
+        public static string Resolve()
+        {
+            var overrideDirectory = GetOverride();
+            return string.IsNullOrEmpty(overrideDirectory) ? GetDefault() : overrideDirectory;
+        }
+
+        public static string GetOverride()
+        {
+            return Environment.GetEnvironmentVariable(OverrideEnvironmentVariableName);
+        }
+
+        /// <summary>
+        ///     解決先を差し替える。nullで解除。
+        ///     プロセス環境変数なのでドメインリロードを跨いで維持され、クラッシュ・強制終了ではプロセスと共に消えるため残置事故が構造的に起きない。
+        ///     Swaps the resolved directory (null clears it).
+        ///     Being a process environment variable it survives domain reloads and dies with the process on crash, so a stale override can never be left behind.
+        /// </summary>
+        public static void SetOverride(string directoryPath)
+        {
+            var value = string.IsNullOrEmpty(directoryPath) ? null : directoryPath;
+            Environment.SetEnvironmentVariable(OverrideEnvironmentVariableName, value);
+        }
+
+        /// <summary>
+        ///     既定の解決先の内容を指定ディレクトリへ複製する（隔離環境に開発者設定を引き継がせる用途）
+        ///     Copies the default directory's contents into the given directory (to carry developer settings into an isolated environment)
+        /// </summary>
+        public static void CopyDefaultTo(string destinationDirectory)
+        {
+            Directory.CreateDirectory(destinationDirectory);
+
+            var sourceDirectory = GetDefault();
+            foreach (var fileName in ParameterFileNames)
+            {
+                var sourcePath = Path.Combine(sourceDirectory, fileName);
+                if (!File.Exists(sourcePath)) continue;
+                File.Copy(sourcePath, Path.Combine(destinationDirectory, fileName), true);
+            }
+        }
+
+        public static string GetDefault()
+        {
+            return Path.GetFullPath(DefaultRelativePath);
+        }
+    }
+}

--- a/moorestech_server/Assets/Scripts/Common.Debug/DebugParametersCacheDirectory.cs.meta
+++ b/moorestech_server/Assets/Scripts/Common.Debug/DebugParametersCacheDirectory.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3eb1665e9cca74108b6a8a8c1551abb2

--- a/moorestech_server/Assets/Scripts/Common.Debug/SerializableDictionary.cs
+++ b/moorestech_server/Assets/Scripts/Common.Debug/SerializableDictionary.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Common.Debug
+{
+    /// <summary>
+    /// Dictionary を JSON シリアライズできるようにするためのクラス
+    /// </summary>
+    /// <typeparam name="TKey"></typeparam>
+    /// <typeparam name="TValue"></typeparam>
+    [Serializable]
+    public class SerializableDictionary<TKey, TValue> : ISerializationCallbackReceiver
+    {
+        [SerializeField]
+        private List<TKey> keys = new();
+
+        [SerializeField]
+        private List<TValue> values = new();
+
+        // 実際の Dictionary データ。シリアライズ時・デシリアライズ時に keys/values と相互変換。
+        private Dictionary<TKey, TValue> dictionary = new();
+
+        public SerializableDictionary() { }
+
+        public SerializableDictionary(Dictionary<TKey, TValue> dict)
+        {
+            dictionary = dict;
+        }
+
+        /// <summary>
+        /// Dictionary 形式に変換して取得
+        /// </summary>
+        public Dictionary<TKey, TValue> ToDictionary()
+        {
+            return dictionary;
+        }
+
+        #region ISerializationCallbackReceiver implements
+
+        public void OnBeforeSerialize()
+        {
+            // JSON シリアライズされる前に、Dictionary の情報を keys/values に詰め込む
+            keys.Clear();
+            values.Clear();
+
+            foreach (var kvp in dictionary)
+            {
+                keys.Add(kvp.Key);
+                values.Add(kvp.Value);
+            }
+        }
+
+        public void OnAfterDeserialize()
+        {
+            // JSON デシリアライズ後に、keys/values から Dictionary を再構成する
+            dictionary = new Dictionary<TKey, TValue>();
+            for (int i = 0; i < Mathf.Min(keys.Count, values.Count); i++)
+            {
+                dictionary[keys[i]] = values[i];
+            }
+        }
+
+        #endregion
+    }
+}

--- a/moorestech_server/Assets/Scripts/Common.Debug/SerializableDictionary.cs.meta
+++ b/moorestech_server/Assets/Scripts/Common.Debug/SerializableDictionary.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fd46b2be7dd004463b7c67a3e236c326

--- a/moorestech_server/Assets/Scripts/Tests.Module/DebugParametersIsolationScope.cs
+++ b/moorestech_server/Assets/Scripts/Tests.Module/DebugParametersIsolationScope.cs
@@ -1,0 +1,73 @@
+using System;
+using System.IO;
+using Common.Debug;
+
+namespace Tests.Module
+{
+    /// <summary>
+    ///     テストアセンブリ実行中だけデバッグ設定をOS一時領域へ隔離する。
+    ///     開発者の ../cache を読まないので、全テストがデバッグ設定の既定値から開始する。
+    ///     Isolates debug parameters into an OS temp directory for the duration of a test assembly run.
+    ///     The developer's ../cache is never read, so every test starts from default debug parameter values.
+    /// </summary>
+    public sealed class DebugParametersIsolationScope
+    {
+        // 隔離ディレクトリは必ずこの直下に作る。後始末時に「隔離先かどうか」をパスだけで判定するため
+        // Every isolation directory lives here, so cleanup can tell isolation paths from real ones by path alone
+        private static string IsolationRoot => Path.Combine(Path.GetTempPath(), "moorestech-debug-cache");
+
+        private readonly string _isolatedCacheDirectory;
+        private readonly string _priorOverride;
+
+        private DebugParametersIsolationScope(string isolatedCacheDirectory, string priorOverride)
+        {
+            _isolatedCacheDirectory = isolatedCacheDirectory;
+            _priorOverride = priorOverride;
+        }
+
+        public static DebugParametersIsolationScope Begin(string label)
+        {
+            // 実行毎にユニークな空ディレクトリを作る。異常終了で残っても一時領域なのでOSが回収する
+            // Create a unique empty directory per run; an orphan left by an abnormal exit is reclaimed by the OS
+            var directory = Path.Combine(IsolationRoot, $"{label}-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(directory);
+
+            var priorOverride = DebugParametersCacheDirectory.GetOverride();
+            DebugParametersCacheDirectory.SetOverride(directory);
+            return new DebugParametersIsolationScope(directory, priorOverride);
+        }
+
+        public void End()
+        {
+            // 隔離先へは決して復元しない。ドメインリロードでBeginが重複しても最後は必ず解除に収束する
+            // Never restore into an isolation directory, so duplicated Begins from a domain reload still converge to cleared
+            DebugParametersCacheDirectory.SetOverride(IsIsolationDirectory(_priorOverride) ? null : _priorOverride);
+            DeleteIfIsolationDirectory(_isolatedCacheDirectory);
+        }
+
+        /// <summary>
+        ///     ドメインリロードでスコープ実体が失われた場合の後始末。環境変数から隔離先を割り出して解除する。
+        ///     解除しないと消えた一時ディレクトリを指したままになり、以降の手動プレイの設定変更が無言で捨てられる。
+        ///     Cleanup for when a domain reload loses the scope object; recovers the isolation target from the env var.
+        ///     Without it the override would point at a deleted temp directory and silently discard later manual play settings.
+        /// </summary>
+        public static void EndOrphaned()
+        {
+            var currentOverride = DebugParametersCacheDirectory.GetOverride();
+            if (!IsIsolationDirectory(currentOverride)) return;
+
+            DebugParametersCacheDirectory.SetOverride(null);
+            DeleteIfIsolationDirectory(currentOverride);
+        }
+
+        private static bool IsIsolationDirectory(string path)
+        {
+            return !string.IsNullOrEmpty(path) && path.StartsWith(IsolationRoot, StringComparison.Ordinal);
+        }
+
+        private static void DeleteIfIsolationDirectory(string path)
+        {
+            if (IsIsolationDirectory(path) && Directory.Exists(path)) Directory.Delete(path, true);
+        }
+    }
+}

--- a/moorestech_server/Assets/Scripts/Tests.Module/DebugParametersIsolationScope.cs.meta
+++ b/moorestech_server/Assets/Scripts/Tests.Module/DebugParametersIsolationScope.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a82701b5f38f545f0b3961cf7f47efc9

--- a/moorestech_server/Assets/Scripts/Tests.Module/Server.Tests.Module.asmdef
+++ b/moorestech_server/Assets/Scripts/Tests.Module/Server.Tests.Module.asmdef
@@ -13,6 +13,7 @@
         "Core.Item.Interface",
         "Core.Update",
         "Core.Util",
+        "Common.Debug",
         "Game.Block",
         "Game.Block.Interface",
         "Game.Crafting",

--- a/moorestech_server/Assets/Scripts/Tests/Server.Tests.asmdef
+++ b/moorestech_server/Assets/Scripts/Tests/Server.Tests.asmdef
@@ -55,7 +55,8 @@
         "Game.PlayerRiding",
         "Game.PlayerConnection",
         "Game.CleanRoom",
-        "Game.Blueprint"
+        "Game.Blueprint",
+        "Common.Debug"
     ],
     "includePlatforms": [
         "Editor"

--- a/moorestech_server/Assets/Scripts/Tests/ServerTestsDebugParametersIsolationFixture.cs
+++ b/moorestech_server/Assets/Scripts/Tests/ServerTestsDebugParametersIsolationFixture.cs
@@ -1,0 +1,25 @@
+using NUnit.Framework;
+using Tests.Module;
+
+// namespaceを付けないことでアセンブリ内の全テストを包むSetUpFixtureになる
+// Omitting the namespace makes this SetUpFixture wrap every test in the assembly
+[SetUpFixture]
+public class ServerTestsDebugParametersIsolationFixture
+{
+    private DebugParametersIsolationScope _isolationScope;
+
+    [OneTimeSetUp]
+    public void IsolateDebugParameters()
+    {
+        _isolationScope = DebugParametersIsolationScope.Begin("server-tests");
+    }
+
+    [OneTimeTearDown]
+    public void RestoreDebugParameters()
+    {
+        // ドメインリロードでインスタンスが失われても環境変数から後始末できるようにする
+        // Fall back to env-var-based cleanup when a domain reload has destroyed this instance
+        if (_isolationScope != null) _isolationScope.End();
+        else DebugParametersIsolationScope.EndOrphaned();
+    }
+}

--- a/moorestech_server/Assets/Scripts/Tests/ServerTestsDebugParametersIsolationFixture.cs.meta
+++ b/moorestech_server/Assets/Scripts/Tests/ServerTestsDebugParametersIsolationFixture.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 072838be247a04c24ae2d21c1da2ca54

--- a/moorestech_server/Assets/Scripts/Tests/UnitTest/CommonDebug.meta
+++ b/moorestech_server/Assets/Scripts/Tests/UnitTest/CommonDebug.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7e0cc468a18b7458986e3f65f5cacc5e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/moorestech_server/Assets/Scripts/Tests/UnitTest/CommonDebug/DebugParametersCacheDirectoryTest.cs
+++ b/moorestech_server/Assets/Scripts/Tests/UnitTest/CommonDebug/DebugParametersCacheDirectoryTest.cs
@@ -1,0 +1,90 @@
+using System;
+using System.IO;
+using Common.Debug;
+using NUnit.Framework;
+
+namespace Tests.UnitTest.CommonDebug
+{
+    /// <summary>
+    ///     デバッグ設定のキャッシュ先切替が実ファイルI/Oまで届き、環境間で値が漏れないことを検証する
+    ///     Verifies that switching the debug parameter cache directory reaches real file I/O and never leaks values across environments
+    /// </summary>
+    public class DebugParametersCacheDirectoryTest
+    {
+        private const string TestKey = "DebugParametersCacheDirectoryTest_Flag";
+
+        private string _priorOverride;
+        private string _temporaryRoot;
+
+        [SetUp]
+        public void CreateTemporaryRoot()
+        {
+            // このテスト自体が上書きするため、SetUpFixtureが張った隔離先を控えて必ず戻す
+            // This test overrides the setting itself, so remember the isolation installed by the SetUpFixture and always restore it
+            _priorOverride = DebugParametersCacheDirectory.GetOverride();
+            _temporaryRoot = Path.Combine(Path.GetTempPath(), "moorestech-debug-cache-test", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_temporaryRoot);
+        }
+
+        [TearDown]
+        public void RestoreOverride()
+        {
+            DebugParametersCacheDirectory.SetOverride(_priorOverride);
+            if (Directory.Exists(_temporaryRoot)) Directory.Delete(_temporaryRoot, true);
+        }
+
+        [Test]
+        public void SavedValueLandsInOverriddenDirectoryAndDoesNotLeakToAnother()
+        {
+            var firstDirectory = Path.Combine(_temporaryRoot, "first");
+            var secondDirectory = Path.Combine(_temporaryRoot, "second");
+
+            // 切替先へ書くと、そのディレクトリに実ファイルが生成され読み戻せる
+            // Writing after the switch creates a real file in that directory and reads back
+            DebugParametersCacheDirectory.SetOverride(firstDirectory);
+            DebugParameters.SaveBool(TestKey, true);
+            Assert.IsTrue(File.Exists(Path.Combine(firstDirectory, "BoolDebugParameters.json")));
+            Assert.IsTrue(DebugParameters.GetValueOrDefaultBool(TestKey));
+
+            // 別の切替先では既定値に戻る（環境をまたいで値が漏れない）
+            // Another target falls back to the default value, proving values do not leak across environments
+            DebugParametersCacheDirectory.SetOverride(secondDirectory);
+            Assert.IsFalse(DebugParameters.ExistsBool(TestKey));
+            Assert.IsFalse(DebugParameters.GetValueOrDefaultBool(TestKey));
+
+            // 元の切替先へ戻せば書いた値が残っている
+            // Switching back to the first target still has the written value
+            DebugParametersCacheDirectory.SetOverride(firstDirectory);
+            Assert.IsTrue(DebugParameters.GetValueOrDefaultBool(TestKey));
+        }
+
+        [Test]
+        public void CacheDirectoryResolvesOverrideFirstAndFallsBackToDefault()
+        {
+            DebugParametersCacheDirectory.SetOverride(_temporaryRoot);
+            Assert.AreEqual(_temporaryRoot, DebugParametersCacheDirectory.Resolve());
+
+            // 解除すると既定の ../cache 解決へ戻る（書き込みはしないので実キャッシュは不変）
+            // Clearing restores the default ../cache resolution (nothing is written, so the real cache stays untouched)
+            DebugParametersCacheDirectory.SetOverride(null);
+            Assert.AreEqual(Path.GetFullPath("../cache"), DebugParametersCacheDirectory.Resolve());
+        }
+
+        [Test]
+        public void CopyDefaultCacheToCreatesDestinationAndCopiesOnlyExistingFiles()
+        {
+            var destination = Path.Combine(_temporaryRoot, "copied");
+            DebugParametersCacheDirectory.CopyDefaultTo(destination);
+            Assert.IsTrue(Directory.Exists(destination));
+
+            // 既定キャッシュに無いファイルを勝手に作らない（複製元の内容だけが引き継がれる）
+            // Never fabricate files the default cache lacks; only the source contents carry over
+            var defaultDirectory = Path.GetFullPath("../cache");
+            foreach (var fileName in new[] { "BoolDebugParameters.json", "IntDebugParameters.json", "StringDebugParameters.json" })
+            {
+                var copiedExists = File.Exists(Path.Combine(destination, fileName));
+                Assert.AreEqual(File.Exists(Path.Combine(defaultDirectory, fileName)), copiedExists);
+            }
+        }
+    }
+}

--- a/moorestech_server/Assets/Scripts/Tests/UnitTest/CommonDebug/DebugParametersCacheDirectoryTest.cs.meta
+++ b/moorestech_server/Assets/Scripts/Tests/UnitTest/CommonDebug/DebugParametersCacheDirectoryTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: aa3f30c5cdf434053b82818eb664705d


### PR DESCRIPTION
DebugParametersのキャッシュ先を MOORESTECH_DEBUG_CACHE_DIR で切り替え可能にし、 アクセス毎に解決する（静的初期化キャッシュを廃止）。

- テスト: Server.Tests / Client.Tests に namespace無し SetUpFixture を追加し、 OS一時領域の空ディレクトリへ隔離。全テストがデバッグ設定の既定値で開始する
- プレイテストDSL: セッション配下の debug-cache/ へ実キャッシュを複製して隔離。 これに伴い DebugServerDirectory の SessionState 退避・復元機構を削除 （環境変数はプロセスと共に消えるためクラッシュ時の残置事故が構造的に起きない）

ドメインリロードでスコープ実体が失われても環境変数から後始末できるよう
EndOrphaned を用意し、消えた一時ディレクトリを指したまま手動プレイの設定変更が
無言で捨てられる事故を防ぐ。

200行超過となった DebugParameter.cs を
DebugParametersCacheDirectory / SerializableDictionary へ分割。

検証: 実cacheに FreeBlockPlacement:true を書いた状態で 919テスト全通過、 実cacheはバイト・mtime共に不変。PlayModeドメインリロード越しの隔離維持も実測。
プレイテスト起動では DebugServerDirectory が隔離側にのみ書かれ、
再生終了で環境変数が解除されることを確認。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Debug settings are now isolated per playtest session, preventing cached values from leaking between runs.
  - Temporary debug settings are automatically cleaned up when returning to edit mode.
  - Debug parameter files now resolve consistently across custom and default cache locations.

- **Tests**
  - Added coverage to verify isolation across play-mode domain reloads and test runs.
  - Added validation for cache overrides, file persistence, and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->