### PR TITLE
refactor: GearNetworkDatastoreのDI化とcomponent内dirty化（レビュー裁定）

### DIFF
--- a/moorestech_server/Assets/Scripts/Game.Block/Blocks/ElectricToGear/ElectricToGearGeneratorComponent.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Blocks/ElectricToGear/ElectricToGearGeneratorComponent.cs
@@ -10,6 +10,7 @@ using Mooresmaster.Model.BlocksModule;
 using Newtonsoft.Json;
 using UniRx;
 using UnityEngine;
+using Game.Context;
 
 namespace Game.Block.Blocks.ElectricToGear
 {
@@ -126,7 +127,7 @@ namespace Game.Block.Blocks.ElectricToGear
 
             if (changed)
             {
-                GearNetworkDatastore.NotifyGeneratorOutputChanged(this);
+                ServerContext.GetService<IGearNetworkDatastore>().NotifyGeneratorOutputChanged(this);
                 _onChangeBlockState.OnNext(Unit.Default);
             }
             return true;
@@ -178,7 +179,7 @@ namespace Game.Block.Blocks.ElectricToGear
         {
             if (_isOutputting == isOutputting) return;
             _isOutputting = isOutputting;
-            GearNetworkDatastore.NotifyGeneratorOutputChanged(this);
+            ServerContext.GetService<IGearNetworkDatastore>().NotifyGeneratorOutputChanged(this);
             _onChangeBlockState.OnNext(Unit.Default);
         }
     }

--- a/moorestech_server/Assets/Scripts/Game.Block/Blocks/ElectricWire/ElectricWireConnectorComponent.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Blocks/ElectricWire/ElectricWireConnectorComponent.cs
@@ -69,6 +69,9 @@ namespace Game.Block.Blocks.ElectricWire
             var connector = ResolveWireTarget(partnerId);
             if (connector == null) return false;
             _wireConnections.Add(partnerId, (connector, connectionCost));
+            // 接続集合の変更点自身でdirty化し、呼び出し元の再構築漏れを構造的に防ぐ
+            // Mark dirty at the mutation itself so no caller can ever forget the rebuild
+            ServerContext.GetService<IElectricWireNetworkDatastore>().MarkTopologyDirty();
             // 状態変更を通知する
             // Notify state change
             _onChangeBlockState.OnNext(Unit.Default);
@@ -83,6 +86,7 @@ namespace Game.Block.Blocks.ElectricWire
                 return false;
             }
             cost = connection.Cost;
+            ServerContext.GetService<IElectricWireNetworkDatastore>().MarkTopologyDirty();
             _onChangeBlockState.OnNext(Unit.Default);
             return true;
         }

--- a/moorestech_server/Assets/Scripts/Game.Block/Blocks/Gear/FuelGearGeneratorComponent.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Blocks/Gear/FuelGearGeneratorComponent.cs
@@ -8,6 +8,7 @@ using MessagePack;
 using Mooresmaster.Model.BlocksModule;
 using UniRx;
 using UnityEngine;
+using Game.Context;
 
 namespace Game.Block.Blocks.Gear
 {
@@ -84,7 +85,7 @@ namespace Game.Block.Blocks.Gear
 
             // 出力が実際に変化したtickだけ所属networkへ再配分を要求する
             // Request redistribution for the owning network only on ticks where output actually changed
-            if (changed) GearNetworkDatastore.NotifyGeneratorOutputChanged(this);
+            if (changed) ServerContext.GetService<IGearNetworkDatastore>().NotifyGeneratorOutputChanged(this);
 
             if (changed || newRpm.AsPrimitive() > 0f)
             {
@@ -103,7 +104,7 @@ namespace Game.Block.Blocks.Gear
         {
             BlockException.CheckDestroy(this);
             
-            var network = GearNetworkDatastore.GetGearNetwork(BlockInstanceId);
+            var network = ServerContext.GetService<IGearNetworkDatastore>().GetGearNetwork(BlockInstanceId);
             var fuelGearGeneratorDetail = CreateFuelGearGeneratorStateDetail();
             var powerGeneratorDetail = CreatePowerGeneratorStateDetail();
             

--- a/moorestech_server/Assets/Scripts/Game.Block/Blocks/Gear/GearEnergyTransformerComponent.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Blocks/Gear/GearEnergyTransformerComponent.cs
@@ -7,6 +7,7 @@ using Game.Gear.Common;
 using Mooresmaster.Model.GearConsumptionModule;
 using UniRx;
 using UnityEngine;
+using Game.Context;
 
 namespace Game.Block.Blocks.Gear
 {
@@ -37,7 +38,7 @@ namespace Game.Block.Blocks.Gear
             BlockInstanceId = blockInstanceId;
             _simpleGearService = new SimpleGearService(this, connectorComponent);
 
-            GearNetworkDatastore.AddGear(this);
+            ServerContext.GetService<IGearNetworkDatastore>().AddGear(this);
         }
 
         public void SetTorqueRequestRate(float rate)
@@ -46,7 +47,7 @@ namespace Game.Block.Blocks.Gear
             // Notify the owning network of the demand change only when the rate actually changes, scheduling recalculation
             if (Mathf.Approximately(_torqueRequestRate, rate)) return;
             _torqueRequestRate = rate;
-            GearNetworkDatastore.NotifyConsumerDemandChanged(this);
+            ServerContext.GetService<IGearNetworkDatastore>().NotifyConsumerDemandChanged(this);
         }
 
         public BlockStateDetail[] GetBlockStateDetails()
@@ -89,7 +90,7 @@ namespace Game.Block.Blocks.Gear
         public void Destroy()
         {
             IsDestroy = true;
-            GearNetworkDatastore.RemoveGear(this);
+            ServerContext.GetService<IGearNetworkDatastore>().RemoveGear(this);
             _simpleGearService.Destroy();
         }
     }

--- a/moorestech_server/Assets/Scripts/Game.Block/Blocks/Gear/GearOverloadBreakageComponent.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Blocks/Gear/GearOverloadBreakageComponent.cs
@@ -36,7 +36,7 @@ namespace Game.Block.Blocks.Gear
 
             // 過負荷設定を持つ場合のみsweep対象として登録する
             // Register into the sweep only when overload params are effective
-            if (_overloadEnabled) GearNetworkDatastore.RegisterOverloadTickTarget(this);
+            if (_overloadEnabled) ServerContext.GetService<IGearNetworkDatastore>().RegisterOverloadTickTarget(this);
         }
 
         public void TickOverloadCheck()
@@ -88,7 +88,7 @@ namespace Game.Block.Blocks.Gear
             // 破断経由(RequestRemoveで_isDestroyed済み)でも必ず登録解除する。HashSetのRemoveなので重複解除は無害
             // Always unregister, including the breakage path (where RequestRemove already set _isDestroyed); duplicate removal from the HashSet is harmless
             _isDestroyed = true;
-            if (_overloadEnabled) GearNetworkDatastore.UnregisterOverloadTickTarget(this);
+            if (_overloadEnabled) ServerContext.GetService<IGearNetworkDatastore>().UnregisterOverloadTickTarget(this);
         }
     }
 }

--- a/moorestech_server/Assets/Scripts/Game.Block/Blocks/Gear/SimpleGearService.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Blocks/Gear/SimpleGearService.cs
@@ -5,6 +5,7 @@ using Game.Gear.Common;
 using MessagePack;
 using UniRx;
 using UnityEngine;
+using Game.Context;
 
 namespace Game.Block.Blocks.Gear
 {
@@ -116,7 +117,7 @@ namespace Game.Block.Blocks.Gear
         {
             rpm = new RPM(0);
             isClockwise = true;
-            if (!GearNetworkDatastore.TryGetGearNetwork(_owner.BlockInstanceId, out var network)) return false;
+            if (!ServerContext.GetService<IGearNetworkDatastore>().TryGetGearNetwork(_owner.BlockInstanceId, out var network)) return false;
             return network.TryResolveRotation(_owner.BlockInstanceId, out rpm, out isClockwise);
         }
     }

--- a/moorestech_server/Assets/Scripts/Game.Block/Blocks/GearChainPole/GearChainPoleComponent.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Blocks/GearChainPole/GearChainPoleComponent.cs
@@ -49,7 +49,7 @@ namespace Game.Block.Blocks.GearChainPole
             _gearService.BlockStateChange.Subscribe(_ => _onChangeBlockState.OnNext(Unit.Default));
             
             _componentStates = componentStates;
-            GearNetworkDatastore.AddGear(this);
+            ServerContext.GetService<IGearNetworkDatastore>().AddGear(this);
         }
 
 
@@ -79,6 +79,9 @@ namespace Game.Block.Blocks.GearChainPole
             var transformer = ResolveChainTarget(partnerId);
             if (transformer == null) return false;
             _chainTargets.Add(partnerId, (transformer, connectionCost));
+            // 接続集合の変更点自身でdirty化し、呼び出し元の再構築漏れを構造的に防ぐ
+            // Mark dirty at the mutation itself so no caller can ever forget the rebuild
+            ServerContext.GetService<IGearNetworkDatastore>().MarkTopologyDirty();
             // 状態変更を通知する
             // Notify state change
             _onChangeBlockState.OnNext(Unit.Default);
@@ -94,6 +97,7 @@ namespace Game.Block.Blocks.GearChainPole
             }
 
             cost = connection.Cost;
+            ServerContext.GetService<IGearNetworkDatastore>().MarkTopologyDirty();
             _onChangeBlockState.OnNext(Unit.Default);
             return true;
         }
@@ -162,7 +166,7 @@ namespace Game.Block.Blocks.GearChainPole
             
             // 復元したチェーン接続を次tick先頭の再構築対象にする
             // Mark restored chain connections for rebuilding at the next tick head
-            GearNetworkDatastore.MarkTopologyDirty();
+            ServerContext.GetService<IGearNetworkDatastore>().MarkTopologyDirty();
             _onChangeBlockState.OnNext(Unit.Default);
         }
 
@@ -182,7 +186,7 @@ namespace Game.Block.Blocks.GearChainPole
 
             // ギアネットワークから除去する。隣接ギアの噛み合いを次数判定に含めるため、コネクタ生存中に実行する
             // Remove from the gear network while the connector is still alive so adjacent gear meshing counts toward the degree check
-            GearNetworkDatastore.RemoveGear(this);
+            ServerContext.GetService<IGearNetworkDatastore>().RemoveGear(this);
 
             // コネクタはBlockComponentManagerが別コンポーネントとして破棄するため、ここでは破棄しない
             // The connector is destroyed separately by BlockComponentManager, so it must not be destroyed here

--- a/moorestech_server/Assets/Scripts/Game.Gear/Common/GearNetworkDatastore.cs
+++ b/moorestech_server/Assets/Scripts/Game.Gear/Common/GearNetworkDatastore.cs
@@ -7,10 +7,8 @@ namespace Game.Gear.Common
 {
     // live gearと適用済み状態を分離する
     // Separates live gear registration from all derived state applied at the tick boundary
-    public class GearNetworkDatastore
+    public class GearNetworkDatastore : IGearNetworkDatastore
     {
-        private static GearNetworkDatastore _instance;
-
         private readonly Dictionary<BlockInstanceId, IGearEnergyTransformer> _registeredGears = new();
         private readonly HashSet<IGearOverloadTickTarget> _overloadTickTargets = new();
         private GearNetworkTopologyMap _topologyMap;
@@ -20,7 +18,6 @@ namespace Game.Gear.Common
 
         public GearNetworkDatastore()
         {
-            _instance = this;
             _topologyMap = GearNetworkTopologyMap.CreateEmpty();
             _networksRequiringRecalc = new HashSet<GearNetwork>();
             _continuousTickNetworks = new HashSet<GearNetwork>();
@@ -28,21 +25,21 @@ namespace Game.Gear.Common
 
         internal IReadOnlyCollection<GearNetwork> ContinuousTickNetworks => _continuousTickNetworks;
 
-        public static void AddGear(IGearEnergyTransformer gear)
+        public void AddGear(IGearEnergyTransformer gear)
         {
-            _instance._registeredGears[gear.BlockInstanceId] = gear;
-            _instance._isTopologyDirty = true;
+            _registeredGears[gear.BlockInstanceId] = gear;
+            _isTopologyDirty = true;
         }
 
-        public static void RemoveGear(IGearEnergyTransformer gear)
+        public void RemoveGear(IGearEnergyTransformer gear)
         {
-            _instance._registeredGears.Remove(gear.BlockInstanceId);
-            _instance._isTopologyDirty = true;
+            _registeredGears.Remove(gear.BlockInstanceId);
+            _isTopologyDirty = true;
         }
 
-        public static void MarkTopologyDirty()
+        public void MarkTopologyDirty()
         {
-            _instance._isTopologyDirty = true;
+            _isTopologyDirty = true;
         }
 
         public void RebuildIfDirty()
@@ -62,14 +59,14 @@ namespace Game.Gear.Common
             _isTopologyDirty = false;
         }
 
-        public static void RegisterOverloadTickTarget(IGearOverloadTickTarget target)
+        public void RegisterOverloadTickTarget(IGearOverloadTickTarget target)
         {
-            _instance._overloadTickTargets.Add(target);
+            _overloadTickTargets.Add(target);
         }
 
-        public static void UnregisterOverloadTickTarget(IGearOverloadTickTarget target)
+        public void UnregisterOverloadTickTarget(IGearOverloadTickTarget target)
         {
-            _instance._overloadTickTargets.Remove(target);
+            _overloadTickTargets.Remove(target);
         }
 
         internal void CollectOverloadTickTargets(List<IGearOverloadTickTarget> buffer)
@@ -77,24 +74,24 @@ namespace Game.Gear.Common
             buffer.AddRange(_overloadTickTargets);
         }
 
-        public static void NotifyGeneratorOutputChanged(IGearEnergyTransformer generator)
+        public void NotifyGeneratorOutputChanged(IGearEnergyTransformer generator)
         {
             AddAppliedNetworkToRecalculation(generator);
         }
 
-        public static void NotifyConsumerDemandChanged(IGearEnergyTransformer consumer)
+        public void NotifyConsumerDemandChanged(IGearEnergyTransformer consumer)
         {
             AddAppliedNetworkToRecalculation(consumer);
         }
 
-        public static bool TryGetGearNetwork(BlockInstanceId blockInstanceId, out GearNetwork network)
+        public bool TryGetGearNetwork(BlockInstanceId blockInstanceId, out GearNetwork network)
         {
-            return _instance._topologyMap.TryGetNetwork(blockInstanceId, out network);
+            return _topologyMap.TryGetNetwork(blockInstanceId, out network);
         }
 
-        public static GearNetwork GetGearNetwork(BlockInstanceId blockInstanceId)
+        public GearNetwork GetGearNetwork(BlockInstanceId blockInstanceId)
         {
-            return _instance._topologyMap.GetNetwork(blockInstanceId);
+            return _topologyMap.GetNetwork(blockInstanceId);
         }
 
         internal void CollectNetworksRequiringRecalc(List<GearNetwork> buffer)
@@ -103,10 +100,10 @@ namespace Game.Gear.Common
             _networksRequiringRecalc.Clear();
         }
 
-        private static void AddAppliedNetworkToRecalculation(IGearEnergyTransformer gear)
+        private void AddAppliedNetworkToRecalculation(IGearEnergyTransformer gear)
         {
-            if (_instance._topologyMap.TryGetNetwork(gear.BlockInstanceId, out var network))
-                _instance._networksRequiringRecalc.Add(network);
+            if (_topologyMap.TryGetNetwork(gear.BlockInstanceId, out var network))
+                _networksRequiringRecalc.Add(network);
         }
     }
 }

--- a/moorestech_server/Assets/Scripts/Game.Gear/Common/IGearNetworkDatastore.cs
+++ b/moorestech_server/Assets/Scripts/Game.Gear/Common/IGearNetworkDatastore.cs
@@ -1,0 +1,20 @@
+using Game.Block.Interface;
+using Game.Gear.Tick;
+
+namespace Game.Gear.Common
+{
+    // live gearと適用済みgear網を分離する。dirty再構築はtick先頭で具象datastore経由（MasterTickUpdater）
+    // Separates live gear registration from applied networks; the dirty rebuild runs at tick head via the concrete datastore (MasterTickUpdater)
+    public interface IGearNetworkDatastore
+    {
+        void AddGear(IGearEnergyTransformer gear);
+        void RemoveGear(IGearEnergyTransformer gear);
+        void MarkTopologyDirty();
+        void NotifyGeneratorOutputChanged(IGearEnergyTransformer generator);
+        void NotifyConsumerDemandChanged(IGearEnergyTransformer consumer);
+        void RegisterOverloadTickTarget(IGearOverloadTickTarget target);
+        void UnregisterOverloadTickTarget(IGearOverloadTickTarget target);
+        bool TryGetGearNetwork(BlockInstanceId blockInstanceId, out GearNetwork network);
+        GearNetwork GetGearNetwork(BlockInstanceId blockInstanceId);
+    }
+}

--- a/moorestech_server/Assets/Scripts/Game.Gear/Common/IGearNetworkDatastore.cs.meta
+++ b/moorestech_server/Assets/Scripts/Game.Gear/Common/IGearNetworkDatastore.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 66009ffc3b62a3d4a8405dbc4b4c3397

--- a/moorestech_server/Assets/Scripts/Server.Boot/MoorestechServerDIContainerGenerator.cs
+++ b/moorestech_server/Assets/Scripts/Server.Boot/MoorestechServerDIContainerGenerator.cs
@@ -155,6 +155,7 @@ namespace Server.Boot
             var railGraphDatastore = initializerProvider.GetService<RailGraphDatastore>();
             var trainUnitDatastore = initializerProvider.GetService<TrainUnitDatastore>();
             services.AddSingleton(initializerProvider.GetService<GearNetworkDatastore>());
+            services.AddSingleton<IGearNetworkDatastore>(provider => provider.GetRequiredService<GearNetworkDatastore>());
             services.AddSingleton(initializerProvider.GetService<CleanRoomDatastore>());
             services.AddSingleton(railGraphDatastore);
             services.AddSingleton<IRailGraphDatastore>(railGraphDatastore);

--- a/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/GetGearNetworkInfoProtocol.cs
+++ b/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/GetGearNetworkInfoProtocol.cs
@@ -12,8 +12,11 @@ namespace Server.Protocol.PacketResponse
     {
         public const string ProtocolTag = "va:getGearNetInfo";
 
+        private readonly IGearNetworkDatastore _gearNetworkDatastore;
+
         public GetGearNetworkInfoProtocol(ServiceProvider serviceProvider)
         {
+            _gearNetworkDatastore = serviceProvider.GetService<IGearNetworkDatastore>();
         }
 
         public ProtocolMessagePackBase GetResponse(byte[] payload, PacketResponseContext context)
@@ -22,7 +25,7 @@ namespace Server.Protocol.PacketResponse
 
             // 対象ブロックがギアネットワーク未登録なら Info=null を返す
             // Return Info=null when the target block is not registered in any gear network
-            if (!GearNetworkDatastore.TryGetGearNetwork(request.BlockInstanceId, out var network))
+            if (!_gearNetworkDatastore.TryGetGearNetwork(request.BlockInstanceId, out var network))
             {
                 return new ResponseGetGearNetworkInfoMessagePack(null);
             }

--- a/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/Util/ElectricWire/AutoConnect/ElectricWireAutoConnectService.cs
+++ b/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/Util/ElectricWire/AutoConnect/ElectricWireAutoConnectService.cs
@@ -155,7 +155,6 @@ namespace Server.Protocol.PacketResponse.Util.ElectricWire.AutoConnect
                 ConnectToolMaterialConsumer.Consume(target.Cost.Materials, inventory);
             }
 
-            ServerContext.GetService<IElectricWireNetworkDatastore>().MarkTopologyDirty();
         }
     }
 }

--- a/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/Util/ElectricWire/Connection/ElectricWireSystemUtil.cs
+++ b/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/Util/ElectricWire/Connection/ElectricWireSystemUtil.cs
@@ -76,7 +76,6 @@ namespace Server.Protocol.PacketResponse.Util.ElectricWire.Connection
             }
 
             ConnectToolMaterialConsumer.Consume(judgement.WireCost.Materials, inventory);
-            ServerContext.GetService<IElectricWireNetworkDatastore>().MarkTopologyDirty();
 
             return true;
         }
@@ -152,7 +151,6 @@ namespace Server.Protocol.PacketResponse.Util.ElectricWire.Connection
             connectorB.TryRemoveWireConnection(connectorA.BlockInstanceId, out _);
             foreach (var refundStack in refundStacks) inventory.InsertItem(refundStack);
 
-            ServerContext.GetService<IElectricWireNetworkDatastore>().MarkTopologyDirty();
 
             return true;
         }

--- a/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/Util/ElectricWire/ElectricWireExtendService.cs
+++ b/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/Util/ElectricWire/ElectricWireExtendService.cs
@@ -137,10 +137,9 @@ namespace Server.Protocol.PacketResponse.Util.ElectricWire
                     ConnectToolMaterialConsumer.Consume(cost.Materials, inventory);
                 }
 
-                // 建設コストを消費してから再構築を予約する
-                // Consume the construction cost, then mark topology for the next tick rebuild
+                // 建設コストを消費する（dirty化は接続処理内で行われる）
+                // Consume the construction cost; the connection mutation itself marks the topology dirty
                 ConstructionCostService.ConsumeRequiredItems(costItemCounts, inventory);
-                ServerContext.GetService<IElectricWireNetworkDatastore>().MarkTopologyDirty();
 
                 return ExtendResult.Success(polePlaceInfo.Position, selfConnector.BlockInstanceId.AsPrimitive());
 

--- a/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/Util/GearChain/GearChainSystemUtil.cs
+++ b/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/Util/GearChain/GearChainSystemUtil.cs
@@ -70,7 +70,6 @@ namespace Server.Protocol.PacketResponse.Util.GearChain
             }
 
             ConnectToolMaterialConsumer.Consume(cost.Materials, inventory);
-            GearNetworkDatastore.MarkTopologyDirty();
 
             return true;
         }

--- a/moorestech_server/Assets/Scripts/Tests/CombinedTest/Core/ChainEnergyTransmissionTest.cs
+++ b/moorestech_server/Assets/Scripts/Tests/CombinedTest/Core/ChainEnergyTransmissionTest.cs
@@ -191,10 +191,10 @@ namespace Tests.CombinedTest.Core
 
             // チェーン接続先を含めた単一ネットワークへ統合されていることを確認する
             // Ensure the chain-connected endpoints are merged into one network
-            Assert.True(GearNetworkDatastore.TryGetGearNetwork(generatorId, out var generatorNetwork));
-            Assert.True(GearNetworkDatastore.TryGetGearNetwork(poleAId, out var poleANetwork));
-            Assert.True(GearNetworkDatastore.TryGetGearNetwork(poleBId, out var poleBNetwork));
-            Assert.True(GearNetworkDatastore.TryGetGearNetwork(targetGearId, out var targetGearNetwork));
+            Assert.True(ServerContext.GetService<IGearNetworkDatastore>().TryGetGearNetwork(generatorId, out var generatorNetwork));
+            Assert.True(ServerContext.GetService<IGearNetworkDatastore>().TryGetGearNetwork(poleAId, out var poleANetwork));
+            Assert.True(ServerContext.GetService<IGearNetworkDatastore>().TryGetGearNetwork(poleBId, out var poleBNetwork));
+            Assert.True(ServerContext.GetService<IGearNetworkDatastore>().TryGetGearNetwork(targetGearId, out var targetGearNetwork));
             Assert.AreSame(generatorNetwork, poleANetwork);
             Assert.AreSame(generatorNetwork, poleBNetwork);
             Assert.AreSame(generatorNetwork, targetGearNetwork);

--- a/moorestech_server/Assets/Scripts/Tests/CombinedTest/Core/SimpleGearServiceNotifyStateChangedTest.cs
+++ b/moorestech_server/Assets/Scripts/Tests/CombinedTest/Core/SimpleGearServiceNotifyStateChangedTest.cs
@@ -57,7 +57,7 @@ namespace Tests.CombinedTest.Core
             // generator不変でも再計算を模擬
             // Simulate a recalc without generator change
             var generator = generatorBlock.GetComponent<IGearEnergyTransformer>();
-            GearNetworkDatastore.NotifyGeneratorOutputChanged(generator);
+            ServerContext.GetService<IGearNetworkDatastore>().NotifyGeneratorOutputChanged(generator);
             GameUpdater.UpdateOneTick();
 
             Assert.AreEqual(firedAfterFirstTick, fired, "値が変化していないtickでは再発火しないべき");

--- a/moorestech_server/Assets/Scripts/Tests/UnitTest/Game/GearTopology/GearNetworkTestDirtyRebuild.cs
+++ b/moorestech_server/Assets/Scripts/Tests/UnitTest/Game/GearTopology/GearNetworkTestDirtyRebuild.cs
@@ -23,19 +23,19 @@ namespace Tests.UnitTest.Game.GearTopology
 
             // add/remove履歴ではなく境界時点のlive登録だけをBFS対象にする
             // Run BFS over only the live registry at the boundary, not add/remove history
-            GearNetworkDatastore.AddGear(removed);
-            GearNetworkDatastore.RemoveGear(removed);
-            GearNetworkDatastore.AddGear(a);
-            GearNetworkDatastore.AddGear(b);
-            GearNetworkDatastore.AddGear(c);
+            datastore.AddGear(removed);
+            datastore.RemoveGear(removed);
+            datastore.AddGear(a);
+            datastore.AddGear(b);
+            datastore.AddGear(c);
             datastore.RebuildIfDirty();
 
             Assert.AreEqual(1, a.AdjacencyEnumerationCount);
             Assert.AreEqual(1, b.AdjacencyEnumerationCount);
             Assert.AreEqual(1, c.AdjacencyEnumerationCount);
             Assert.AreEqual(0, removed.AdjacencyEnumerationCount);
-            Assert.IsTrue(GearNetworkDatastore.TryGetGearNetwork(a.BlockInstanceId, out var networkA));
-            Assert.IsTrue(GearNetworkDatastore.TryGetGearNetwork(c.BlockInstanceId, out var networkC));
+            Assert.IsTrue(datastore.TryGetGearNetwork(a.BlockInstanceId, out var networkA));
+            Assert.IsTrue(datastore.TryGetGearNetwork(c.BlockInstanceId, out var networkC));
             Assert.AreSame(networkA, networkC);
         }
 
@@ -43,7 +43,7 @@ namespace Tests.UnitTest.Game.GearTopology
         public void dirtyでない再構築は適用済みmapを維持する()
         {
             var datastore = new GearNetworkDatastore();
-            GearNetworkDatastore.AddGear(new FakeGear(1));
+            datastore.AddGear(new FakeGear(1));
             datastore.RebuildIfDirty();
             var appliedMap = GearNetworkDatastoreReflectionTestUtil.GetTopologyMap(datastore);
 

--- a/moorestech_server/Assets/Scripts/Tests/Util/EnergySystem/ElectricWireTestUtil.cs
+++ b/moorestech_server/Assets/Scripts/Tests/Util/EnergySystem/ElectricWireTestUtil.cs
@@ -17,8 +17,8 @@ namespace Tests.Util
     /// </summary>
     public static class ElectricWireTestUtil
     {
-        // 両端のIElectricWireConnectorを解決し、コスト0で双方向接続してから連結成分を再計算する
-        // Resolve the connectors on both ends, add a cost-0 connection both ways, then recompute components
+        // 両端のIElectricWireConnectorを解決し、コスト0で双方向接続する（dirty化は接続メソッド内で行われる）
+        // Resolve the connectors on both ends and add a cost-0 connection both ways; the mutation itself marks the topology dirty
         public static void Connect(Vector3Int posA, Vector3Int posB)
         {
             var connectorA = ResolveConnector(posA);
@@ -27,8 +27,6 @@ namespace Tests.Util
             var cost = ElectricWireConnectionCost.Empty;
             connectorA.TryAddWireConnection(connectorB.BlockInstanceId, cost);
             connectorB.TryAddWireConnection(connectorA.BlockInstanceId, cost);
-
-            ServerContext.GetService<IElectricWireNetworkDatastore>().MarkTopologyDirty();
         }
 
         private static IElectricWireConnector ResolveConnector(Vector3Int pos)

--- a/moorestech_server/Assets/Scripts/Tests/Util/GearNetworkDatastoreReflectionTestUtil.cs
+++ b/moorestech_server/Assets/Scripts/Tests/Util/GearNetworkDatastoreReflectionTestUtil.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Game.Block.Interface;
+using Game.Context;
 using Game.Gear.Common;
 using NUnit.Framework;
 
@@ -37,7 +38,7 @@ namespace Tests.Util
 
         public static GearNetwork GetAppliedNetwork(BlockInstanceId blockInstanceId)
         {
-            Assert.True(GearNetworkDatastore.TryGetGearNetwork(blockInstanceId, out var network));
+            Assert.True(ServerContext.GetService<IGearNetworkDatastore>().TryGetGearNetwork(blockInstanceId, out var network));
             return network;
         }
 

--- a/moorestech_server/Assets/Scripts/Tests/Util/SimpleGearGeneratorExtension.cs
+++ b/moorestech_server/Assets/Scripts/Tests/Util/SimpleGearGeneratorExtension.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using Game.Block.Blocks.Gear;
 using Game.Gear.Common;
+using Game.Context;
 
 namespace Tests.Util
 {
@@ -18,7 +19,7 @@ namespace Tests.Util
 
             // 出力変化を本番と同じ経路で通知し、所属networkの再計算を要求する
             // Notify the output change through the production path so the owning network is recalculated
-            GearNetworkDatastore.NotifyGeneratorOutputChanged(simpleGearGeneratorComponent);
+            ServerContext.GetService<IGearNetworkDatastore>().NotifyGeneratorOutputChanged(simpleGearGeneratorComponent);
         }
 
         public static void SetGenerateTorque(this SimpleGearGeneratorComponent component, float torque)
@@ -33,7 +34,7 @@ namespace Tests.Util
 
             // 出力変化を本番と同じ経路で通知し、所属networkの再計算を要求する
             // Notify the output change through the production path so the owning network is recalculated
-            GearNetworkDatastore.NotifyGeneratorOutputChanged(component);
+            ServerContext.GetService<IGearNetworkDatastore>().NotifyGeneratorOutputChanged(component);
         }
     }
 }


### PR DESCRIPTION
- static全廃、IGearNetworkDatastore新設。電力側と同じDI注入形へ統一
- 接続集合を変更するcomponentメソッド（TryAddWireConnection/TryAddChainConnection等） 自身がMarkTopologyDirtyを呼び、呼び出し元utilの冗長dirty化を全削除
- 電線側が既に同型（GetService<IElectricWireNetworkDatastore>().AddConnector(this)）なので対称形に揃えた

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Electric wire and gear-network changes now trigger topology updates consistently when connections or output states change.
  * Network information and recalculation behavior remain synchronized after connection changes, loading, and state updates.

* **Refactor**
  * Improved network service integration for more reliable gear and electric-wire system behavior.
  * Simplified topology update handling by centralizing notifications at connection changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->