### PR TITLE
feat: tick中のブロック破壊を予約制にしtick末尾で一括確定

### DIFF
--- a/moorestech_server/Assets/Scripts/Core.Update/GameUpdater.cs
+++ b/moorestech_server/Assets/Scripts/Core.Update/GameUpdater.cs
@@ -19,6 +19,10 @@ namespace Core.Update
         private static Subject<Unit> _lateUpdateSubject = new();
         public static List<Action> AdditionalUpdates = new();
 
+        // tick末尾処理（予約された破壊の一括確定等）。ブロック更新後・LateUpdate前に実行される
+        // Tick-end handlers (batch-applying reserved removals etc.), run after block updates and before LateUpdate
+        public static List<Action> TickEndUpdates = new();
+
         public static void Update()
         {
             // AdditionalUpdatesのやつ。テストでも呼ぶので関数化
@@ -28,6 +32,10 @@ namespace Core.Update
             // Updateの実行
             // Execute Update
             ExecuteUpdate();
+
+            // tick末尾処理の実行
+            // Execute tick-end handlers
+            ExecuteTickEndUpdates();
 
             // LateUpdateの実行
             // Execute LateUpdate
@@ -59,9 +67,10 @@ namespace Core.Update
             _updateSubject = new Subject<Unit>();
             _lateUpdateSubject = new Subject<Unit>();
 
-            // 追加tick更新も初期化する
-            // Reset additional tick updates as well.
+            // 追加tick更新とtick末尾処理も初期化する
+            // Reset additional tick updates and tick-end handlers as well.
             AdditionalUpdates.Clear();
+            TickEndUpdates.Clear();
         }
 
         public static void Dispose()
@@ -108,6 +117,14 @@ namespace Core.Update
             }
         }
 
+        private static void ExecuteTickEndUpdates()
+        {
+            foreach (var tickEndUpdate in TickEndUpdates)
+            {
+                tickEndUpdate();
+            }
+        }
+
 #if UNITY_EDITOR
         public static void UpdateOneTick()
         {
@@ -124,6 +141,7 @@ namespace Core.Update
             {
                 ExecuteAdditionalUpdates();
                 _updateSubject.OnNext(Unit.Default);
+                ExecuteTickEndUpdates();
                 _lateUpdateSubject.OnNext(Unit.Default);
             }
         }

--- a/moorestech_server/Assets/Scripts/Game.Block/Blocks/Gear/GearOverloadBreakageComponent.cs
+++ b/moorestech_server/Assets/Scripts/Game.Block/Blocks/Gear/GearOverloadBreakageComponent.cs
@@ -74,8 +74,10 @@ namespace Game.Block.Blocks.Gear
 
             void RequestRemove()
             {
+                // 破壊はその場で行わず予約する。このtickの計算には最後まで参加し、tick末尾に一括反映される
+                // Reserve the destruction instead of applying it in place; the block participates in this tick fully and is removed at tick end
                 _isDestroyed = true;
-                ServerContext.WorldBlockDatastore.RemoveBlock(_blockInstanceId, BlockRemoveReason.Broken);
+                ServerContext.GetService<IBlockRemovalReservationService>().ReserveRemoval(_blockInstanceId, BlockRemoveReason.Broken);
             }
 
             #endregion

--- a/moorestech_server/Assets/Scripts/Game.Gear/Common/GearTickUpdater.cs
+++ b/moorestech_server/Assets/Scripts/Game.Gear/Common/GearTickUpdater.cs
@@ -38,8 +38,8 @@ namespace Game.Gear.Common
                 network.ConsumeGeneratorTicks();
             foreach (var network in _recalcBuffer)
             {
-                // 同tickの過負荷sweepで破壊済みのgearは通知Subjectがdispose済みのためスキップする
-                // Skip gears destroyed by this tick's overload sweep; their notify subjects are already disposed
+                // 破壊はtick末尾の予約確定まで遅延するため通常成立しない防御ガード（破棄済みSubjectへの通知を防ぐ）
+                // Defensive guard, normally unreachable since removals are reserved until tick end; prevents notifying disposed subjects
                 foreach (var transformer in network.GearTransformers)
                     if (!transformer.IsDestroy) transformer.NotifyStateChanged();
                 foreach (var generator in network.GearGenerators)

--- a/moorestech_server/Assets/Scripts/Game.World.Interface/DataStore/IBlockRemovalReservationService.cs
+++ b/moorestech_server/Assets/Scripts/Game.World.Interface/DataStore/IBlockRemovalReservationService.cs
@@ -1,0 +1,16 @@
+using Game.Block.Interface;
+
+namespace Game.World.Interface.DataStore
+{
+    /// <summary>
+    ///     tick中の計算で決定したブロック破壊の予約窓口。
+    ///     予約されたブロックはそのtickの計算に最後まで参加し、tick末尾のApplyReservedRemovalsで一括破壊される。
+    ///     Reservation gateway for block destruction decided by in-tick computation.
+    ///     A reserved block keeps participating in this tick's calculations and is destroyed in batch by ApplyReservedRemovals at tick end.
+    /// </summary>
+    public interface IBlockRemovalReservationService
+    {
+        void ReserveRemoval(BlockInstanceId blockInstanceId, BlockRemoveReason reason);
+        void ApplyReservedRemovals();
+    }
+}

--- a/moorestech_server/Assets/Scripts/Game.World.Interface/DataStore/IBlockRemovalReservationService.cs.meta
+++ b/moorestech_server/Assets/Scripts/Game.World.Interface/DataStore/IBlockRemovalReservationService.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d543f5c74f39e3f46aa0993bd80de6fc

--- a/moorestech_server/Assets/Scripts/Game.World/DataStore/BlockRemovalReservationService.cs
+++ b/moorestech_server/Assets/Scripts/Game.World/DataStore/BlockRemovalReservationService.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using Game.Block.Interface;
+using Game.Context;
+using Game.World.Interface.DataStore;
+
+namespace Game.World.DataStore
+{
+    /// <summary>
+    ///     tick中に予約されたブロック破壊をtick末尾に一括反映するサービス。
+    ///     ブロック本体だけ破壊済みでトポロジが旧セグメントに残る中間状態を作らないため、反映は必ずtick末尾のみで行う。
+    ///     Service applying block removals reserved mid-tick in one batch at tick end.
+    ///     Application happens only at tick end so no half state exists where the block body is gone but the topology still holds it.
+    /// </summary>
+    public class BlockRemovalReservationService : IBlockRemovalReservationService
+    {
+        private readonly List<(BlockInstanceId blockInstanceId, BlockRemoveReason reason)> _reservedRemovals = new();
+
+        public void ReserveRemoval(BlockInstanceId blockInstanceId, BlockRemoveReason reason)
+        {
+            _reservedRemovals.Add((blockInstanceId, reason));
+        }
+
+        public void ApplyReservedRemovals()
+        {
+            if (_reservedRemovals.Count == 0) return;
+
+            // FIFOで破壊を反映。既に消えているブロックはRemoveBlock側が無視する
+            // Apply removals FIFO; RemoveBlock itself ignores blocks that are already gone
+            foreach (var (blockInstanceId, reason) in _reservedRemovals)
+            {
+                ServerContext.WorldBlockDatastore.RemoveBlock(blockInstanceId, reason);
+            }
+            _reservedRemovals.Clear();
+        }
+    }
+}

--- a/moorestech_server/Assets/Scripts/Game.World/DataStore/BlockRemovalReservationService.cs
+++ b/moorestech_server/Assets/Scripts/Game.World/DataStore/BlockRemovalReservationService.cs
@@ -24,10 +24,11 @@ namespace Game.World.DataStore
         {
             if (_reservedRemovals.Count == 0) return;
 
-            // FIFOで破壊を反映。既に消えているブロックはRemoveBlock側が無視する
-            // Apply removals FIFO; RemoveBlock itself ignores blocks that are already gone
-            foreach (var (blockInstanceId, reason) in _reservedRemovals)
+            // FIFOで破壊を反映。apply中の連鎖予約も同tick内で処理し、既に消えているブロックはRemoveBlock側が無視する
+            // Apply removals FIFO; reservations chained during the apply drain within the same tick, and RemoveBlock ignores blocks already gone
+            for (var i = 0; i < _reservedRemovals.Count; i++)
             {
+                var (blockInstanceId, reason) = _reservedRemovals[i];
                 ServerContext.WorldBlockDatastore.RemoveBlock(blockInstanceId, reason);
             }
             _reservedRemovals.Clear();

--- a/moorestech_server/Assets/Scripts/Game.World/DataStore/BlockRemovalReservationService.cs.meta
+++ b/moorestech_server/Assets/Scripts/Game.World/DataStore/BlockRemovalReservationService.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ce77595d1b539e542943d756e8b91212

--- a/moorestech_server/Assets/Scripts/Server.Boot/MoorestechServerDIContainerGenerator.cs
+++ b/moorestech_server/Assets/Scripts/Server.Boot/MoorestechServerDIContainerGenerator.cs
@@ -196,6 +196,7 @@ namespace Server.Boot
             services.AddSingleton<ElectricTickUpdater>();
             services.AddSingleton<GearTickUpdater>();
             services.AddSingleton<MasterTickUpdater>();
+            services.AddSingleton<IBlockRemovalReservationService, BlockRemovalReservationService>();
 
             // 乗車コア。実接続レジストリを IPlayerConnectionChecker として共有する。
             // Riding core. Shares the real connection registry as IPlayerConnectionChecker.
@@ -255,6 +256,10 @@ namespace Server.Boot
             // The tick order (spec 2.1) lives in MasterTickUpdater; register just that one entry here
             GameUpdater.AdditionalUpdates.Add(serviceProvider.GetRequiredService<MasterTickUpdater>().Update);
 
+            // tick末尾: 予約された破壊を一括確定する。派生する網の再構築は次tick先頭のRebuildIfDirtyに委ねる
+            // Tick end: commit reserved removals in batch; derived network rebuilding is deferred to RebuildIfDirty at the next tick head
+            GameUpdater.TickEndUpdates.Add(serviceProvider.GetRequiredService<IBlockRemovalReservationService>().ApplyReservedRemovals);
+
             //IBootInitializable実装を一括生成し、起動時初期化のLoadを呼ぶ
             // Create all IBootInitializable implementations and invoke their boot-time Load.
             foreach (var bootInitializable in serviceProvider.GetServices<IBootInitializable>()) bootInitializable.Load();
@@ -262,7 +267,6 @@ namespace Server.Boot
             //IPostLoadInitializable実装は生成のみ行う（Loadは初期ロード完了後にServerInstanceManagerが呼ぶ）
             // IPostLoadInitializable implementations are only created here; ServerInstanceManager invokes their Load after initial load.
             serviceProvider.GetServices<IPostLoadInitializable>();
-
             serverContext.SetMainServiceProvider(serviceProvider);
 
             // MessagePackResolverを登録

--- a/moorestech_server/Assets/Scripts/Tests/CombinedTest/Core/GearOverloadBreakageTest.cs
+++ b/moorestech_server/Assets/Scripts/Tests/CombinedTest/Core/GearOverloadBreakageTest.cs
@@ -105,9 +105,13 @@ namespace Tests.CombinedTest.Core
             fullBreakage.TickOverloadCheck();
             idleBreakage.TickOverloadCheck();
 
+            // 破断判定は即時、ブロック破壊は予約されtick末尾の一括反映で確定する
+            // The breakage decision is immediate while the block removal is reserved and committed at tick end
             Assert.IsTrue(fullBreakage.IsDestroy);
-            Assert.IsFalse(world.Exists(fullPosition));
             Assert.IsFalse(idleBreakage.IsDestroy);
+            Assert.IsTrue(world.Exists(fullPosition));
+            GameUpdater.UpdateOneTick();
+            Assert.IsFalse(world.Exists(fullPosition));
             Assert.IsTrue(world.Exists(idlePosition));
             fullBreakage.Destroy();
             idleBreakage.Destroy();

--- a/moorestech_server/Assets/Scripts/Tests/CombinedTest/Game/BlockRemovalReservationTest.cs
+++ b/moorestech_server/Assets/Scripts/Tests/CombinedTest/Game/BlockRemovalReservationTest.cs
@@ -1,0 +1,52 @@
+using System;
+using Core.Update;
+using Game.Block.Interface;
+using Game.Context;
+using Game.World.Interface.DataStore;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Server.Boot;
+using Tests.Module.TestMod;
+using UnityEngine;
+
+namespace Tests.CombinedTest.Game
+{
+    // tick中に予約されたブロック破壊がtick末尾の一括反映まで持ち越されることを検証する
+    // Verifies that block removals reserved mid-tick are held until the batch application at tick end
+    public class BlockRemovalReservationTest
+    {
+        [Test]
+        public void 予約だけではブロックは破壊されない()
+        {
+            var (_, provider) = new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
+            var world = ServerContext.WorldBlockDatastore;
+            var pos = new Vector3Int(0, 0, 0);
+            world.TryAddBlock(ForUnitTestModBlockId.MachineId, pos, BlockDirection.North, Array.Empty<BlockCreateParam>(), out var block);
+
+            var reservationService = provider.GetRequiredService<IBlockRemovalReservationService>();
+            reservationService.ReserveRemoval(block.BlockInstanceId, BlockRemoveReason.Broken);
+
+            // 予約時点ではブロックが存在し続け、明示的な一括反映で初めて破壊される
+            // The block keeps existing at reservation time and is destroyed only by the explicit batch application
+            Assert.IsTrue(world.Exists(pos));
+            reservationService.ApplyReservedRemovals();
+            Assert.IsFalse(world.Exists(pos));
+        }
+
+        [Test]
+        public void tick進行で予約破壊がtick末尾に確定する()
+        {
+            var (_, provider) = new MoorestechServerDIContainerGenerator().Create(new MoorestechServerDIContainerOptions(TestModDirectory.ForUnitTestModDirectory));
+            var world = ServerContext.WorldBlockDatastore;
+            var pos = new Vector3Int(0, 0, 0);
+            world.TryAddBlock(ForUnitTestModBlockId.MachineId, pos, BlockDirection.North, Array.Empty<BlockCreateParam>(), out var block);
+
+            // 予約→1tick進行のみで、TickEndUpdates経由の一括反映が破壊を確定させる
+            // Reserve, then advance one tick; the batch application via TickEndUpdates commits the destruction
+            provider.GetRequiredService<IBlockRemovalReservationService>().ReserveRemoval(block.BlockInstanceId, BlockRemoveReason.Broken);
+            GameUpdater.RunFrames(1);
+
+            Assert.IsFalse(world.Exists(pos));
+        }
+    }
+}

--- a/moorestech_server/Assets/Scripts/Tests/CombinedTest/Game/BlockRemovalReservationTest.cs.meta
+++ b/moorestech_server/Assets/Scripts/Tests/CombinedTest/Game/BlockRemovalReservationTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 72289bd14839e0c4993b7dd553b47e82


### PR DESCRIPTION
tick計算中のブロック破壊（過負荷破断）を即時実行せず
IBlockRemovalReservationServiceへ予約し、GameUpdater.TickEndUpdates（tick末尾）で一括確定する。
網再構築は次tick先頭のRebuildIfDirtyに委ねる。

- tick中破壊の本番経路は現状GearOverloadBreakageComponentのみ。今後tick中の計算からブロックを消す処理は必ず予約サービス経由とする
- 副次効果: 歯車破断時のRPM=0窓も解消

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved block destruction timing during gear overloads by finalizing removals at the end of the game tick.
  * Prevented inconsistent world state and notifications while blocks are being destroyed.

* **Reliability**
  * Batched block removals now process consistently, including chained removals during the same tick.
  * Added coverage to verify deferred removal behavior and tick-end processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->