### PR TITLE
feat: クライアント操作を共通tick末尾FIFOへ統合

### DIFF
--- a/moorestech_server/Assets/Scripts/Core.Update/GameUpdater.cs
+++ b/moorestech_server/Assets/Scripts/Core.Update/GameUpdater.cs
@@ -23,6 +23,10 @@ namespace Core.Update
         // Tick-end handlers (batch-applying reserved removals etc.), run after block updates and before LateUpdate
         public static List<Action> TickEndUpdates = new();
 
+        // 世界変更完了後のセーブ等を実行する最終tick末尾処理
+        // Final tick-end handlers for saving after all world mutations complete
+        public static List<Action> FinalTickEndUpdates = new();
+
         public static void Update()
         {
             // AdditionalUpdatesのやつ。テストでも呼ぶので関数化
@@ -36,6 +40,10 @@ namespace Core.Update
             // tick末尾処理の実行
             // Execute tick-end handlers
             ExecuteTickEndUpdates();
+
+            // 世界変更の確定後にだけ最終処理を実行する
+            // Execute final handlers only after world mutations are committed
+            ExecuteFinalTickEndUpdates();
 
             // LateUpdateの実行
             // Execute LateUpdate
@@ -71,6 +79,7 @@ namespace Core.Update
             // Reset additional tick updates and tick-end handlers as well.
             AdditionalUpdates.Clear();
             TickEndUpdates.Clear();
+            FinalTickEndUpdates.Clear();
         }
 
         public static void Dispose()
@@ -125,6 +134,14 @@ namespace Core.Update
             }
         }
 
+        private static void ExecuteFinalTickEndUpdates()
+        {
+            foreach (var finalTickEndUpdate in FinalTickEndUpdates)
+            {
+                finalTickEndUpdate();
+            }
+        }
+
 #if UNITY_EDITOR
         public static void UpdateOneTick()
         {
@@ -142,6 +159,7 @@ namespace Core.Update
                 ExecuteAdditionalUpdates();
                 _updateSubject.OnNext(Unit.Default);
                 ExecuteTickEndUpdates();
+                ExecuteFinalTickEndUpdates();
                 _lateUpdateSubject.OnNext(Unit.Default);
             }
         }

--- a/moorestech_server/Assets/Scripts/Server.Boot/Loop/PacketProcessing/ITickEndPacketEntry.cs
+++ b/moorestech_server/Assets/Scripts/Server.Boot/Loop/PacketProcessing/ITickEndPacketEntry.cs
@@ -1,0 +1,8 @@
+namespace Server.Boot.Loop.PacketProcessing
+{
+    public interface ITickEndPacketEntry
+    {
+        bool IsActive { get; }
+        void Process();
+    }
+}

--- a/moorestech_server/Assets/Scripts/Server.Boot/Loop/PacketProcessing/ITickEndPacketEntry.cs.meta
+++ b/moorestech_server/Assets/Scripts/Server.Boot/Loop/PacketProcessing/ITickEndPacketEntry.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 06bd66d56ebf00c4b8c17741a509555f

--- a/moorestech_server/Assets/Scripts/Server.Boot/Loop/PacketProcessing/ReceiveQueueProcessor.cs
+++ b/moorestech_server/Assets/Scripts/Server.Boot/Loop/PacketProcessing/ReceiveQueueProcessor.cs
@@ -1,59 +1,71 @@
-using System;
-using System.Collections.Concurrent;
-using Core.Update;
+using System.Threading;
 using Server.Protocol;
-using UniRx;
 
 namespace Server.Boot.Loop.PacketProcessing
 {
-    /// <summary>
-    /// 受信キュープロセッサ
-    /// 受信スレッドからパケットをEnqueueし、メインスレッドでGetPacketResponseを実行
-    /// 処理結果をSendQueueProcessorに送信
-    /// ConcurrentQueueを使用してlock-freeで高速処理
-    /// </summary>
     public class ReceiveQueueProcessor
     {
         private readonly PacketResponseCreator _packetResponseCreator;
         private readonly SendQueueProcessor _sendQueueProcessor;
         private readonly PacketResponseContext _packetResponseContext;
-        private readonly IDisposable _updateSubscription;
-        private readonly ConcurrentQueue<byte[]> _receiveQueue = new();
+        private readonly TickEndPacketQueue _tickEndPacketQueue;
+        private int _isActive = 1;
 
-        public ReceiveQueueProcessor(PacketResponseCreator packetResponseCreator, SendQueueProcessor sendQueueProcessor, PacketResponseContext packetResponseContext)
+        public ReceiveQueueProcessor(
+            PacketResponseCreator packetResponseCreator,
+            SendQueueProcessor sendQueueProcessor,
+            PacketResponseContext packetResponseContext,
+            TickEndPacketQueue tickEndPacketQueue)
         {
             _packetResponseCreator = packetResponseCreator;
             _sendQueueProcessor = sendQueueProcessor;
             _packetResponseContext = packetResponseContext;
-
-            // GameUpdaterのUpdate時にキューを処理
-            _updateSubscription = GameUpdater.LateUpdateObservable.Subscribe(_ => ProcessReceiveQueue());
+            _tickEndPacketQueue = tickEndPacketQueue;
         }
 
         public void EnqueuePacket(byte[] packet)
         {
-            _receiveQueue.Enqueue(packet);
-        }
-
-        private void ProcessReceiveQueue()
-        {
-            // 受信キューからパケットを取り出してゲームロジックで処理
-            // この処理は常に一瞬で終わる（送信はSendQueueProcessorに委譲）
-            while (_receiveQueue.TryDequeue(out var packet))
-            {
-                var results = _packetResponseCreator.GetPacketResponse(packet, _packetResponseContext);
-                foreach (var result in results)
-                {
-                    // 送信キューに追加（長さヘッダ付与と実送信はSendQueueProcessorが行う）
-                    // Enqueue for send; SendQueueProcessor handles length framing and the actual send
-                    _sendQueueProcessor.EnqueueMessage(result);
-                }
-            }
+            // 受信スレッドでは世界を変更せず、全接続共通FIFOへ渡す
+            // Keep world mutation off the receive thread and hand the packet to the shared FIFO
+            _tickEndPacketQueue.Enqueue(new ReceivedPacketEntry(this, packet));
         }
 
         public void Dispose()
         {
-            _updateSubscription.Dispose();
+            // 固定済みキューに残る項目も実行されないよう接続状態だけを落とす
+            // Mark only connection state so already-frozen entries are skipped
+            Volatile.Write(ref _isActive, 0);
+        }
+
+        private void ProcessPacket(byte[] packet)
+        {
+            var results = _packetResponseCreator.GetPacketResponse(packet, _packetResponseContext);
+
+            foreach (var result in results)
+            {
+                // 送信キューに追加（長さヘッダ付与と実送信はSendQueueProcessorが行う）
+                // Enqueue for send; SendQueueProcessor handles length framing and the actual send
+                _sendQueueProcessor.EnqueueMessage(result);
+            }
+        }
+
+        private sealed class ReceivedPacketEntry : ITickEndPacketEntry
+        {
+            private readonly ReceiveQueueProcessor _owner;
+            private readonly byte[] _packet;
+
+            public bool IsActive => Volatile.Read(ref _owner._isActive) != 0;
+
+            public ReceivedPacketEntry(ReceiveQueueProcessor owner, byte[] packet)
+            {
+                _owner = owner;
+                _packet = packet;
+            }
+
+            public void Process()
+            {
+                _owner.ProcessPacket(_packet);
+            }
         }
     }
 }

--- a/moorestech_server/Assets/Scripts/Server.Boot/Loop/PacketProcessing/TickEndPacketQueue.cs
+++ b/moorestech_server/Assets/Scripts/Server.Boot/Loop/PacketProcessing/TickEndPacketQueue.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+
+namespace Server.Boot.Loop.PacketProcessing
+{
+    public class TickEndPacketQueue
+    {
+        private readonly object _gate = new();
+        private Queue<ITickEndPacketEntry> _receiving = new();
+        private Queue<ITickEndPacketEntry> _frozen = new();
+
+        public void Enqueue(ITickEndPacketEntry entry)
+        {
+            // 格納を一つのロックで直列化し、接続を跨いだ到着順を確定する
+            // Serialize enqueue under one lock to establish arrival order across connections
+            lock (_gate)
+            {
+                _receiving.Enqueue(entry);
+            }
+        }
+
+        public void FreezeCurrentPackets()
+        {
+            // tick末尾開始時のキューを交換し、以後の受信を次tickへ分離する
+            // Swap the queue at tick-end start so later arrivals belong to the next tick
+            lock (_gate)
+            {
+                _frozen = _receiving;
+                _receiving = new Queue<ITickEndPacketEntry>();
+            }
+        }
+
+        public void ProcessFrozenPackets()
+        {
+            // 問い合わせは今tickの確定済み状態で即答する（設置tickと網反映tickのズレは仕様）
+            // Queries answer immediately from this tick's settled state; the placement-vs-network tick gap is by design
+            while (_frozen.Count != 0)
+            {
+                var entry = _frozen.Dequeue();
+                if (!entry.IsActive) continue;
+                entry.Process();
+            }
+        }
+    }
+}

--- a/moorestech_server/Assets/Scripts/Server.Boot/Loop/PacketProcessing/TickEndPacketQueue.cs.meta
+++ b/moorestech_server/Assets/Scripts/Server.Boot/Loop/PacketProcessing/TickEndPacketQueue.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bbefa85f5d38bdc4cb5514840ffad8c2

--- a/moorestech_server/Assets/Scripts/Server.Boot/Loop/PacketProcessing/WorldMutationTickEndUpdater.cs
+++ b/moorestech_server/Assets/Scripts/Server.Boot/Loop/PacketProcessing/WorldMutationTickEndUpdater.cs
@@ -1,0 +1,30 @@
+using Game.World.Interface.DataStore;
+
+namespace Server.Boot.Loop.PacketProcessing
+{
+    public class WorldMutationTickEndUpdater
+    {
+        private readonly TickEndPacketQueue _packetQueue;
+        private readonly IBlockRemovalReservationService _blockRemovalReservationService;
+
+        public WorldMutationTickEndUpdater(
+            TickEndPacketQueue packetQueue,
+            IBlockRemovalReservationService blockRemovalReservationService)
+        {
+            _packetQueue = packetQueue;
+            _blockRemovalReservationService = blockRemovalReservationService;
+        }
+
+        public void Update()
+        {
+            // tick末尾開始時の入力を固定してから過負荷破断を優先する
+            // Freeze tick-end input first, then prioritize overload breakage
+            _packetQueue.FreezeCurrentPackets();
+            _blockRemovalReservationService.ApplyReservedRemovals();
+
+            // 破断後の確定済み世界へ固定パケットをFIFO適用する
+            // Apply frozen packets in FIFO order to the post-breakage world
+            _packetQueue.ProcessFrozenPackets();
+        }
+    }
+}

--- a/moorestech_server/Assets/Scripts/Server.Boot/Loop/PacketProcessing/WorldMutationTickEndUpdater.cs.meta
+++ b/moorestech_server/Assets/Scripts/Server.Boot/Loop/PacketProcessing/WorldMutationTickEndUpdater.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 98e45b5e0e8f33d428c56ac80aa9f40b

--- a/moorestech_server/Assets/Scripts/Server.Boot/Loop/ServerListenAcceptor.cs
+++ b/moorestech_server/Assets/Scripts/Server.Boot/Loop/ServerListenAcceptor.cs
@@ -13,7 +13,12 @@ namespace Server.Boot.Loop
     {
         private const int Port = 11564;
 
-        public static void StartServer(PacketResponseCreator packetResponseCreator, PlayerConnectionRegistry connectionRegistry, EventProtocolProvider eventProtocolProvider, CancellationToken token)
+        public static void StartServer(
+            PacketResponseCreator packetResponseCreator,
+            PlayerConnectionRegistry connectionRegistry,
+            EventProtocolProvider eventProtocolProvider,
+            TickEndPacketQueue tickEndPacketQueue,
+            CancellationToken token)
         {
             //ソケットの作成
             var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
@@ -31,7 +36,8 @@ namespace Server.Boot.Loop
                 // 送信・受信キュープロセッサを作成
                 var sendQueueProcessor = new SendQueueProcessor(client);
                 var packetResponseContext = new PacketResponseContext(sendQueueProcessor);
-                var receiveQueueProcessor = new ReceiveQueueProcessor(packetResponseCreator, sendQueueProcessor, packetResponseContext);
+                var receiveQueueProcessor = new ReceiveQueueProcessor(
+                    packetResponseCreator, sendQueueProcessor, packetResponseContext, tickEndPacketQueue);
 
                 // 受信スレッドを起動
                 var receiveThread = new Thread(() => new UserPacketHandler(client, receiveQueueProcessor, sendQueueProcessor, connectionRegistry, eventProtocolProvider, packetResponseContext).StartListen(token));

--- a/moorestech_server/Assets/Scripts/Server.Boot/MoorestechServerDIContainerGenerator.cs
+++ b/moorestech_server/Assets/Scripts/Server.Boot/MoorestechServerDIContainerGenerator.cs
@@ -57,6 +57,7 @@ using Newtonsoft.Json;
 using Server.Event;
 using Server.Event.EventReceive;
 using Server.Event.EventReceive.UnifiedInventoryEvent;
+using Server.Boot.Loop.PacketProcessing;
 using Server.Protocol;
 using Server.Protocol.PacketResponse.Util.InventoryService;
 using Server.Util.MessagePack;
@@ -203,6 +204,10 @@ namespace Server.Boot
             services.AddSingleton<FluidTickUpdater>();
             services.AddSingleton<MasterTickUpdater>();
             services.AddSingleton<IBlockRemovalReservationService, BlockRemovalReservationService>();
+            // クライアント操作は全接続共通FIFOへ集め、tick末尾に一括適用する
+            // Client operations funnel into one shared FIFO applied in batch at tick end
+            services.AddSingleton<TickEndPacketQueue>();
+            services.AddSingleton<WorldMutationTickEndUpdater>();
 
             // 乗車コア。実接続レジストリを IPlayerConnectionChecker として共有する。
             // Riding core. Shares the real connection registry as IPlayerConnectionChecker.
@@ -265,13 +270,13 @@ namespace Server.Boot
             // The tick order (spec 2.1) lives in MasterTickUpdater; register just that one entry here
             GameUpdater.AdditionalUpdates.Add(serviceProvider.GetRequiredService<MasterTickUpdater>().Update);
 
-            // tick末尾: 予約された破壊を一括確定する。派生する網の再構築は次tick先頭のRebuildIfDirtyに委ねる
-            // Tick end: commit reserved removals in batch; derived network rebuilding is deferred to RebuildIfDirty at the next tick head
-            GameUpdater.TickEndUpdates.Add(serviceProvider.GetRequiredService<IBlockRemovalReservationService>().ApplyReservedRemovals);
+            // tick末尾: 固定した入力と予約破壊を一つの更新器で確定する。派生する網の再構築は次tick先頭のRebuildIfDirtyに委ねる
+            // Tick end: commit frozen input and reserved removals through one updater; derived network rebuilding is deferred to RebuildIfDirty at the next tick head
+            GameUpdater.TickEndUpdates.Add(serviceProvider.GetRequiredService<WorldMutationTickEndUpdater>().Update);
 
-            // 破壊確定後が唯一のセーブ可能な安定点（仕様2.1⑦）。将来の初回snapshot取得もこの位置に登録する
-            // The point after removal commits is the only save-stable boundary (spec 2.1-7); future initial-snapshot capture also registers here
-            GameUpdater.TickEndUpdates.Add(serviceProvider.GetRequiredService<WorldSaveCoordinator>().SaveIfRequested);
+            // 全世界変更の確定後が唯一のセーブ可能な安定点（仕様2.1⑦）。将来の初回snapshot取得もこの位置に登録する
+            // The point after every world mutation commits is the only save-stable boundary (spec 2.1-7); future initial-snapshot capture also registers here
+            GameUpdater.FinalTickEndUpdates.Add(serviceProvider.GetRequiredService<WorldSaveCoordinator>().SaveIfRequested);
 
             //IBootInitializable実装を一括生成し、起動時初期化のLoadを呼ぶ
             // Create all IBootInitializable implementations and invoke their boot-time Load.

--- a/moorestech_server/Assets/Scripts/Server.Boot/ServerInstanceManager.cs
+++ b/moorestech_server/Assets/Scripts/Server.Boot/ServerInstanceManager.cs
@@ -12,6 +12,7 @@ using Mod.Base;
 using Mod.Loader;
 using Server.Boot.Args;
 using Server.Boot.Loop;
+using Server.Boot.Loop.PacketProcessing;
 using Server.Event;
 using UnityEngine;
 
@@ -74,9 +75,11 @@ namespace Server.Boot
             var token = cancellationToken.Token;
             var connectionRegistry = (PlayerConnectionRegistry)serviceProvider.GetService<IPlayerConnectionChecker>();
             var eventProtocolProvider = serviceProvider.GetService<EventProtocolProvider>();
+            var tickEndPacketQueue = serviceProvider.GetRequiredService<TickEndPacketQueue>();
 
             // パケットキュープロセッサを作成してメインスレッドで処理を開始
-            var connectionUpdateThread = new Thread(() => ServerListenAcceptor.StartServer(packet, connectionRegistry, eventProtocolProvider, token));
+            var connectionUpdateThread = new Thread(() =>
+                ServerListenAcceptor.StartServer(packet, connectionRegistry, eventProtocolProvider, tickEndPacketQueue, token));
             connectionUpdateThread.Name = "[moorestech]通信受け入れスレッド";
             connectionUpdateThread.Start();
             

--- a/moorestech_server/Assets/Scripts/Tests/CombinedTest/Server/PacketTest/TickEndWorldMutationConflictTest.cs
+++ b/moorestech_server/Assets/Scripts/Tests/CombinedTest/Server/PacketTest/TickEndWorldMutationConflictTest.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using Core.Update;
+using Game.Block.Interface;
+using Game.Context;
+using Game.World.Interface.DataStore;
+using MessagePack;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Server.Boot.Loop.PacketProcessing;
+using Server.Protocol;
+using Server.Protocol.PacketResponse;
+using Tests.Module.TestMod;
+using UnityEngine;
+using static Tests.CombinedTest.Server.PacketTest.PlaceBlockProtocolTestSupport;
+
+namespace Tests.CombinedTest.Server.PacketTest
+{
+    public class TickEndWorldMutationConflictTest
+    {
+        private static readonly Guid Material1Guid = Guid.Parse("00000000-0000-0000-1234-000000000003");
+        private static readonly Guid Material2Guid = Guid.Parse("00000000-0000-0000-1234-000000000004");
+
+        [Test]
+        public void 重なる長尺設置はFIFO先頭だけが設置と課金を行う()
+        {
+            // 縦3セルの電柱を1セルずらして重ね、占有競合を起こす
+            // Overlap two 3-cell-tall electric poles offset by one cell to create an occupancy conflict
+            var (packet, provider) = CreateServer();
+            GrantRequiredItems(provider, ForUnitTestModBlockId.ElectricPoleId, 1);
+            UnlockBlock(provider, ForUnitTestModBlockId.ElectricPoleId);
+            var first = new PlaceInfo
+            {
+                Position = new Vector3Int(30, 0, 10), Direction = BlockDirection.North,
+                VerticalDirection = BlockVerticalDirection.Horizontal, BlockId = ForUnitTestModBlockId.ElectricPoleId,
+            };
+            var second = new PlaceInfo
+            {
+                Position = new Vector3Int(30, 1, 10), Direction = BlockDirection.North,
+                VerticalDirection = BlockVerticalDirection.Horizontal, BlockId = ForUnitTestModBlockId.ElectricPoleId,
+            };
+
+            // 二つを同じ固定batchへ積み、先着の占有範囲を後着に再検証させる
+            // Put both in one frozen batch so the later entry rechecks the first footprint
+            var queue = provider.GetRequiredService<TickEndPacketQueue>();
+            queue.Enqueue(new ProtocolEntry(packet, CreatePlacePayload(new List<PlaceInfo> { first })));
+            queue.Enqueue(new ProtocolEntry(packet, CreatePlacePayload(new List<PlaceInfo> { second })));
+            GameUpdater.UpdateOneTick();
+
+            var world = ServerContext.WorldBlockDatastore;
+            var placed = world.GetBlock(new Vector3Int(30, 0, 10));
+            Assert.IsNotNull(placed);
+            Assert.AreSame(placed, world.GetBlock(new Vector3Int(30, 2, 10)));
+            AssertInventoryEmptyOfRequiredItems(provider, ForUnitTestModBlockId.ElectricPoleId);
+        }
+
+        [Test]
+        public void 同じブロックの二重撤去は返却を一回だけ行う()
+        {
+            var (packet, provider) = CreateServer();
+            var position = new Vector3Int(40, 0, 40);
+            ServerContext.WorldBlockDatastore.TryAddBlock(
+                ForUnitTestModBlockId.BlockId, position, BlockDirection.North, Array.Empty<BlockCreateParam>(), out _);
+            var payload = MessagePackSerializer.Serialize(
+                new RemoveBlockProtocol.RemoveBlockProtocolMessagePack(PlayerId, position));
+
+            var queue = provider.GetRequiredService<TickEndPacketQueue>();
+            queue.Enqueue(new ProtocolEntry(packet, payload));
+            queue.Enqueue(new ProtocolEntry(packet, payload));
+            GameUpdater.UpdateOneTick();
+
+            Assert.IsFalse(ServerContext.WorldBlockDatastore.Exists(position));
+            Assert.AreEqual(2, GetItemCount(GetInventory(provider), Material1Guid));
+            Assert.AreEqual(1, GetItemCount(GetInventory(provider), Material2Guid));
+        }
+
+        private sealed class ProtocolEntry : ITickEndPacketEntry
+        {
+            private readonly PacketResponseCreator _packet;
+            private readonly byte[] _payload;
+            public bool IsActive => true;
+
+            public ProtocolEntry(PacketResponseCreator packet, byte[] payload)
+            {
+                _packet = packet;
+                _payload = payload;
+            }
+
+            public void Process()
+            {
+                _packet.GetPacketResponse(_payload, new PacketResponseContext(null));
+            }
+        }
+    }
+}

--- a/moorestech_server/Assets/Scripts/Tests/CombinedTest/Server/PacketTest/TickEndWorldMutationConflictTest.cs.meta
+++ b/moorestech_server/Assets/Scripts/Tests/CombinedTest/Server/PacketTest/TickEndWorldMutationConflictTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: aed8ec178290b5243ab2f7f7056f115e

--- a/moorestech_server/Assets/Scripts/Tests/CombinedTest/Server/PacketTest/TickEndWorldMutationTest.cs
+++ b/moorestech_server/Assets/Scripts/Tests/CombinedTest/Server/PacketTest/TickEndWorldMutationTest.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using Core.Update;
+using Game.Block.Interface;
+using Game.Context;
+using Game.World.Interface.DataStore;
+using MessagePack;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Server.Boot.Loop.PacketProcessing;
+using Server.Protocol;
+using Server.Protocol.PacketResponse;
+using Tests.Module.TestMod;
+using UnityEngine;
+using static Tests.CombinedTest.Server.PacketTest.PlaceBlockProtocolTestSupport;
+
+namespace Tests.CombinedTest.Server.PacketTest
+{
+    public class TickEndWorldMutationTest
+    {
+        private static readonly Guid Material1Guid = Guid.Parse("00000000-0000-0000-1234-000000000003");
+        private static readonly Guid Material2Guid = Guid.Parse("00000000-0000-0000-1234-000000000004");
+
+        [Test]
+        public void 同じ座標への二つの設置は先着だけが設置と課金を行う()
+        {
+            var (packet, provider) = CreateServer();
+            var queue = provider.GetRequiredService<TickEndPacketQueue>();
+            GrantRequiredItems(provider, ForUnitTestModBlockId.BlockId, 2);
+            var payload = CreatePlaceBlockPayload(ForUnitTestModBlockId.BlockId, (4, 5));
+
+            queue.Enqueue(new ProtocolEntry(packet, payload));
+            queue.Enqueue(new ProtocolEntry(packet, payload));
+            GameUpdater.UpdateOneTick();
+
+            Assert.IsTrue(ServerContext.WorldBlockDatastore.Exists(new Vector3Int(4, 5)));
+            Assert.AreEqual(2, GetItemCount(GetInventory(provider), Material1Guid));
+            Assert.AreEqual(1, GetItemCount(GetInventory(provider), Material2Guid));
+        }
+
+        [Test]
+        public void 一件分の素材を競合する設置は先着だけが成功する()
+        {
+            var (packet, provider) = CreateServer();
+            var queue = provider.GetRequiredService<TickEndPacketQueue>();
+            GrantRequiredItems(provider, ForUnitTestModBlockId.BlockId, 1);
+
+            queue.Enqueue(new ProtocolEntry(packet, CreatePlaceBlockPayload(ForUnitTestModBlockId.BlockId, (7, 0))));
+            queue.Enqueue(new ProtocolEntry(packet, CreatePlaceBlockPayload(ForUnitTestModBlockId.BlockId, (8, 0))));
+            GameUpdater.UpdateOneTick();
+
+            Assert.IsTrue(ServerContext.WorldBlockDatastore.Exists(new Vector3Int(7, 0)));
+            Assert.IsFalse(ServerContext.WorldBlockDatastore.Exists(new Vector3Int(8, 0)));
+            AssertInventoryEmptyOfRequiredItems(provider, ForUnitTestModBlockId.BlockId);
+        }
+
+        [Test]
+        public void 撤去と設置は全体FIFOの順で最終状態が変わる()
+        {
+            var (packet, provider) = CreateServer();
+            var position = new Vector3Int(10, 10);
+            ServerContext.WorldBlockDatastore.TryAddBlock(
+                ForUnitTestModBlockId.BlockId, position, BlockDirection.North, Array.Empty<BlockCreateParam>(), out _);
+            var queue = provider.GetRequiredService<TickEndPacketQueue>();
+            var remove = CreateRemovePayload(position);
+            var place = CreatePlaceBlockPayload(ForUnitTestModBlockId.BlockId, (10, 10));
+
+            queue.Enqueue(new ProtocolEntry(packet, remove));
+            queue.Enqueue(new ProtocolEntry(packet, place));
+            GameUpdater.UpdateOneTick();
+            Assert.IsTrue(ServerContext.WorldBlockDatastore.Exists(position));
+            AssertInventoryEmptyOfRequiredItems(provider, ForUnitTestModBlockId.BlockId);
+
+            (packet, provider) = CreateServer();
+            ServerContext.WorldBlockDatastore.TryAddBlock(
+                ForUnitTestModBlockId.BlockId, position, BlockDirection.North, Array.Empty<BlockCreateParam>(), out _);
+            queue = provider.GetRequiredService<TickEndPacketQueue>();
+            queue.Enqueue(new ProtocolEntry(packet, place));
+            queue.Enqueue(new ProtocolEntry(packet, remove));
+            GameUpdater.UpdateOneTick();
+            Assert.IsFalse(ServerContext.WorldBlockDatastore.Exists(position));
+        }
+
+        [Test]
+        public void 過負荷予約破断は手動撤去より先で返却を発生させない()
+        {
+            var (packet, provider) = CreateServer();
+            var position = new Vector3Int(12, 0, 12);
+            ServerContext.WorldBlockDatastore.TryAddBlock(
+                ForUnitTestModBlockId.BlockId, position, BlockDirection.North, Array.Empty<BlockCreateParam>(), out var block);
+            provider.GetRequiredService<IBlockRemovalReservationService>()
+                .ReserveRemoval(block.BlockInstanceId, BlockRemoveReason.Broken);
+            provider.GetRequiredService<TickEndPacketQueue>()
+                .Enqueue(new ProtocolEntry(packet, CreateRemovePayload(position)));
+
+            GameUpdater.UpdateOneTick();
+
+            Assert.IsFalse(ServerContext.WorldBlockDatastore.Exists(position));
+            AssertInventoryEmptyOfRequiredItems(provider, ForUnitTestModBlockId.BlockId);
+        }
+
+        private static byte[] CreateRemovePayload(Vector3Int position)
+        {
+            return MessagePackSerializer.Serialize(
+                new RemoveBlockProtocol.RemoveBlockProtocolMessagePack(PlayerId, position));
+        }
+
+        private sealed class ProtocolEntry : ITickEndPacketEntry
+        {
+            private readonly PacketResponseCreator _packet;
+            private readonly byte[] _payload;
+            public readonly List<byte[]> Responses = new();
+            public bool IsActive => true;
+
+            public ProtocolEntry(PacketResponseCreator packet, byte[] payload)
+            {
+                _packet = packet;
+                _payload = payload;
+            }
+
+            public void Process()
+            {
+                Responses.AddRange(_packet.GetPacketResponse(_payload, new PacketResponseContext(null)));
+            }
+        }
+    }
+}

--- a/moorestech_server/Assets/Scripts/Tests/CombinedTest/Server/PacketTest/TickEndWorldMutationTest.cs.meta
+++ b/moorestech_server/Assets/Scripts/Tests/CombinedTest/Server/PacketTest/TickEndWorldMutationTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1ce1cc3bff16f094abbdda1a86926cb8

--- a/moorestech_server/Assets/Scripts/Tests/UnitTest/Server/TickEndPacketQueueTest.cs
+++ b/moorestech_server/Assets/Scripts/Tests/UnitTest/Server/TickEndPacketQueueTest.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using Server.Boot.Loop.PacketProcessing;
+
+namespace Tests.UnitTest.Server
+{
+    public class TickEndPacketQueueTest
+    {
+        [Test]
+        public void 固定時点までの全接続パケットを到着順に処理する()
+        {
+            var queue = new TickEndPacketQueue();
+            var log = new List<string>();
+
+            queue.Enqueue(new FakeEntry("A1", log));
+            queue.Enqueue(new FakeEntry("B1", log));
+            queue.Enqueue(new FakeEntry("A2", log));
+            queue.FreezeCurrentPackets();
+            queue.ProcessFrozenPackets();
+
+            CollectionAssert.AreEqual(new[] { "A1", "B1", "A2" }, log);
+        }
+
+        [Test]
+        public void 固定後に到着したパケットは次の固定まで処理しない()
+        {
+            var queue = new TickEndPacketQueue();
+            var log = new List<string>();
+            queue.Enqueue(new FakeEntry("first", log));
+
+            queue.FreezeCurrentPackets();
+            queue.Enqueue(new FakeEntry("next", log));
+            queue.ProcessFrozenPackets();
+            CollectionAssert.AreEqual(new[] { "first" }, log);
+
+            queue.FreezeCurrentPackets();
+            queue.ProcessFrozenPackets();
+            CollectionAssert.AreEqual(new[] { "first", "next" }, log);
+        }
+
+        [Test]
+        public void 切断済み接続のパケットは実行しない()
+        {
+            var queue = new TickEndPacketQueue();
+            var log = new List<string>();
+            queue.Enqueue(new FakeEntry("inactive", log, false));
+
+            queue.FreezeCurrentPackets();
+            queue.ProcessFrozenPackets();
+
+            CollectionAssert.IsEmpty(log);
+        }
+
+        private sealed class FakeEntry : ITickEndPacketEntry
+        {
+            private readonly string _name;
+            private readonly List<string> _log;
+            public bool IsActive { get; }
+
+            public FakeEntry(string name, List<string> log) : this(name, log, true) { }
+
+            public FakeEntry(string name, List<string> log, bool isActive)
+            {
+                _name = name;
+                _log = log;
+                IsActive = isActive;
+            }
+
+            public void Process()
+            {
+                _log.Add(_name);
+            }
+        }
+    }
+}

--- a/moorestech_server/Assets/Scripts/Tests/UnitTest/Server/TickEndPacketQueueTest.cs.meta
+++ b/moorestech_server/Assets/Scripts/Tests/UnitTest/Server/TickEndPacketQueueTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 47857253456906d428f9af43a935828b


### PR DESCRIPTION
## 概要
受信スレッドは世界を変更せず、全接続共通のFIFO（TickEndPacketQueue）へエントリを積むだけにする。
tick末尾にWorldMutationTickEndUpdaterが「凍結→予約破壊確定→FIFO一括適用」を行い、
セーブは全変更確定後の新設FinalTickEndUpdatesへ移動する。

- tick末尾順序: Freeze→予約破壊→FIFO適用→セーブ
- 同一tickに到着した競合操作（同座標への二重設置・素材競合・撤去/設置順）は到着順で先着が勝つ（TickEndWorldMutationTest / ConflictTestで検証）
- 問い合わせ系プロトコルは今tickの確定済み状態で即答する。設置tickと網反映tickのズレは仕様（tick単位で状態が完結しているため一貫。クライアント同時tick計算で問い合わせ自体を全廃する将来方針とも整合）
- PacketResponseCreatorは無変更（GetPacketResponseのまま）

## 既知事項（明記）
- FreezeCurrentPacketsは_frozenを無条件交換する。ProcessFrozenPacketsから例外が漏れると未処理分が捨てられ得るが、全例外はPacketResponseCreator内でcatchされるため現状実害経路なし

## テスト
918件PASS（fluid統合済みブランチ上でフルテスト実行）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deterministic end-of-tick processing for incoming actions and world updates.
  * Ensured queued actions are handled in arrival order after world changes are committed.
  * Prevented processing of actions from inactive connections.
  * Save operations now run after all end-of-tick world mutations are complete.

* **Bug Fixes**
  * Improved handling of conflicting placements, duplicate removals, resource usage, and item returns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->