### PR TITLE
chore: レビューのdiffからプレイテストシナリオの.csを除外する

### DIFF
--- a/.agents/skills/moores-code-review/SKILL.md
+++ b/.agents/skills/moores-code-review/SKILL.md
@@ -51,6 +51,14 @@ AskUserQuestionは**最後の報告フェーズに集約**する。修正適用�
 ## Step 1: レビュー対象と4カテゴリcontextを確定する
 
 1. **作業範囲を特定** — このセッションで生成・変更した成果物をコミット範囲・staged・unstagedから確定し、統合unified diffを `<$RUNDIRの実値>/patch.diff` に書く（**PATCH_PATH**）。`git diff <base>^..<last>` + `git diff --cached` + `git diff` を連結。ユーザーがレビュー範囲を明示したらそれを優先。
+   - **プレイテストシナリオの除外（省略禁止）** — 各 `git diff` に必ず次のpathspecを付け、
+     `unity-playmode-recorded-playtest` 配下の `.cs` をpatchへ入れない:
+
+         -- . ':(exclude,glob)**/unity-playmode-recorded-playtest/**/*.cs'
+
+     シナリオは実プレイを踏ませるための使い捨ての操作台本であり、プロダクトコードの規約（重複排除・
+     命名・行数）で裁く対象ではない。指摘しても設計判断の裁定コストだけが増える
+     （ユーザー裁定 2026-08-16 / PR#1137-F12）。`Client.Playtest` のDSL本体はこのパス外なので通常どおり見る
 2. **4カテゴリcontextを書く** — `<$RUNDIRの実値>/context.md`（**USER_PROMPT_PATH**）に埋める。埋め忘れるとレンズ/reviewerがfalse-positiveを量産する:
    - **目指す（ゴール）** / **目指さない（非目標）** / **許容するトレードオフ** / **尊重すべき制約**
    - **4カテゴリは必ず `##` 見出しで書く**（太字箇条書き形式は出所ラベル検査の対象外になり沈黙故障する。見出しゼロはfail-closedでconfirmedになる）。

--- a/.agents/skills/moores-code-review/tests/test_skill_wiring.py
+++ b/.agents/skills/moores-code-review/tests/test_skill_wiring.py
@@ -95,6 +95,17 @@ class SkillWiringTest(unittest.TestCase):
             self.assertIn("必ず回帰テストを実行", head,
                           f"scripts/{s.name} に回帰テスト必須バナーが無い")
 
+    def test_playtest_scenarios_are_excluded_from_patch(self):
+        # patch生成のpathspecからプレイテストシナリオ除外が消えていないこと
+        # （消えると使い捨ての操作台本が再びレビュー対象になる。ユーザー裁定 2026-08-16 / PR#1137-F12）
+        # The playtest-scenario exclusion must stay in every patch-building pathspec
+        pathspec = "':(exclude,glob)**/unity-playmode-recorded-playtest/**/*.cs'"
+        self.assertIn(pathspec, SKILL_MD,
+                      "moores-code-review Step 1 のpatch生成からプレイテストシナリオ除外が消えている")
+        independent = (REPO_ROOT / ".agents/skills/pr-independent-review/SKILL.md").read_text(encoding="utf-8")
+        self.assertIn(pathspec, independent,
+                      "pr-independent-review Step 3 のpatch生成からプレイテストシナリオ除外が消えている")
+
     def test_every_reviewer_and_lens_has_frontmatter(self):
         # selector発見可能性: reviewers/lensesはfrontmatter（extensions等）を持つこと
         # Selector discoverability: reviewers/lenses must carry frontmatter

--- a/.agents/skills/pr-independent-review/SKILL.md
+++ b/.agents/skills/pr-independent-review/SKILL.md
@@ -171,9 +171,12 @@ cwdがリセットされるため、単独の `cd` は次のコマンドに効�
       <BASE_REF>...HEAD -- . \
       ':(exclude)*.meta' ':(exclude)*.prefab' ':(exclude)*.asset' ':(exclude)*.unity' \
       ':(exclude)*.png' ':(exclude)*.jpg' ':(exclude)*.controller' ':(exclude)*.mat' ':(exclude)*.fbx' \
+      ':(exclude,glob)**/unity-playmode-recorded-playtest/**/*.cs' \
       > <$RUNDIRの実値>/patch.diff
 
 `<BASE_REF>` はStep 1.5で確定した実値。yml/jsonは残す（master-data系レンズの守備範囲のため）。
+**プレイテストシナリオの `.cs` も除外する** — 使い捨ての操作台本をプロダクトコードの規約で裁かない
+（ユーザー裁定 2026-08-16 / PR#1137-F12）。moores-code-review Step 1と同一のpathspecで揃える
 
 **フラグは省略禁止（本体パーサ保護）** — このpatchは `deterministic_checks.py` とレンズ/reviewer/Codexが読む唯一の
 差分実体であり、次はいずれもユーザー側git設定で有効化され得て、**patchを静かに痩せさせる**:

--- a/.decisions/2026-08-16-プレイテストシナリオはレビューのdiffから除外する.md
+++ b/.decisions/2026-08-16-プレイテストシナリオはレビューのdiffから除外する.md
@@ -1,0 +1,15 @@
+# プレイテストシナリオはレビューのdiffから除外する
+
+決定: moores-code-review Step 1 と pr-independent-review Step 3 のpatch生成pathspecに
+`':(exclude,glob)**/unity-playmode-recorded-playtest/**/*.cs'` を足し、プレイテストシナリオの
+`.cs` をレビュー対象diffへ入れない。`test_skill_wiring.py` の不変条件で消失を検出する。
+
+棄却案: 指摘は出したうえで裁定時に個別で流す（PR#1137-F12はこの形で、シナリオの重複指摘に
+設計判断の裁定コストを払った）。
+
+理由: シナリオは実プレイを踏ませるための使い捨ての操作台本で、プロダクトコードの規約
+（重複排除・命名・行数）で裁く対象ではない。ユーザー発言「moores-code-reviewのdiff作成の時に
+unity-playmode-recorded-playtestのパスを含む.csファイルは対象外にする」。
+`Client.Playtest` のDSL本体はこのパス外なので従来どおりレビューする。
+
+リンク: PR#1137-F12の裁定コメント「テストについては厳密に見なくてOK。それでSKILL側も更新しておいて」


### PR DESCRIPTION
## 背景

PR#1137-F12 で `unity-playmode-recorded-playtest` のシナリオ（`block-eyedropper-via-ui.cs` 等）の
重複が設計判断として上がり、裁定コストを払った。シナリオは実プレイを踏ませるための使い捨ての
操作台本であり、プロダクトコードの規約（重複排除・命名・行数）で裁く対象ではない。

ユーザー裁定（2026-08-16）: 「moores-code-review の diff 作成の時に unity-playmode-recorded-playtest の
パスを含む .cs ファイルは対象外にする」

## 変更

- `moores-code-review` Step 1（patch生成）に pathspec `':(exclude,glob)**/unity-playmode-recorded-playtest/**/*.cs'` を追加
- `pr-independent-review` Step 3（patch生成・exclude方式）にも同一 pathspec を追加
  — 無人パイプラインはこちらで patch を作って moores-code-review へ渡すため、片方だけでは F12 の事象が再発する
- `tests/test_skill_wiring.py` に不変条件を追加し、両 SKILL.md から pathspec が消えたら落ちるようにした
- `.decisions/` に裁定レコードを追加

`Client.Playtest`（DSL本体）はこのパス外なので従来どおりレビュー対象。

## 動作確認

1. 実コミット `5ff1f5e8d`（F12の対応コミット）に対して pathspec 有無で比較
   - 除外なし: シナリオ2本の `.cs` + `PlaytestPickOps.cs` + references の `.md`
   - 除外あり: **シナリオ2本の `.cs` だけが消え**、`PlaytestPickOps.cs` と `.md` は残る
2. `dec3e6a21...c0344306a`（PR#1127相当の広い範囲）で pr-independent-review Step 3 のフルコマンドを実行
   - `unity-playmode-recorded-playtest/**/*.cs` の残存 0 件（`scenarios/misc/` の入れ子・直下の両方が消えることを確認）
   - patch は 138 ファイルで非空（Step 3 の非空ガードを満たす）
3. `python3 -m unittest discover -s .claude/skills/moores-code-review/tests` → **49 tests OK**
   - 追加した不変条件は pathspec を削ると AssertionError で落ちることを確認済み（red→green）

Unity のコンパイル/テストは対象外（`.cs` プロダクトコードの変更なし・スキル文書とpythonテストのみ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)