### PR TITLE
pr-adjudicated-applyにmasterコンフリクト事前解消Stepを追加

### DIFF
--- a/.agents/skills/pr-adjudicated-apply/SKILL.md
+++ b/.agents/skills/pr-adjudicated-apply/SKILL.md
@@ -128,29 +128,13 @@ description: |
 
 ## Step 3.5: masterコンフリクト事前解消（subagent委譲・無条件発火）
 
-checkout成功後、修正実装に入る前に、**コンフリクトの有無を自分で調べず**、必ずsubagent
-（Agentツール、general-purpose）を1体発火して委譲する。目的はメインエージェントのコンテキストを
-コンフリクト解消の詳細（差分・両側の変更内容）で消費しないこと。メインエージェントが渡してよい情報は
-`$REPO` の実値・`headRefName`・PR番号のみで、事前に `git merge-tree` や diff での予備調査は行わない。
+checkout成功後、修正実装に入る前に、**コンフリクトの有無を自分で調べず**、必ずsubagentを1体発火して委譲する
+（メインのコンテキストをコンフリクト詳細で消費しないため。`git merge-tree` やdiffでの予備調査も行わない）。
 
-subagentへの指示内容（プロンプトに含める）:
+`references/conflict-preflight-agent.md` をReadし、`{{REPO}}`・`{{HEAD_REF_NAME}}`・`{{PR_NUMBER}}` を
+実値に置換して、Agentツール（`model: "opus"`）のプロンプトとして丸ごと渡す。
 
-1. `git -C <$REPOの実値> fetch origin master` を実行する
-2. PRブランチ上で `git -C <$REPOの実値> merge --no-commit --no-ff origin/master` を試みる
-   - **Already up to date / コンフリクトなしで成功した場合**: `git -C <$REPOの実値> merge --abort`
-     （abort対象が無ければ `git reset --merge`）でマージ状態を破棄し、「コンフリクトなし」とだけ報告して
-     即終了する（クリーンでもマージは残さない。master取り込み自体はこのスキルの責務ではない）
-   - **コンフリクトが発生した場合**: 各コンフリクトファイルについて両側の変更意図を読み取り、
-     両方の意図を保つ形で解消する（機械的にours/theirsを選ばない）。解消後 `git add` し、
-     標準のマージメッセージ＋`Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>` トレーラーで
-     マージコミットを作成する。`.cs` を解消で触った場合は `uloop compile --project-path ./moorestech_client`
-     でコンパイルが通ることまで確認してからコミットする
-   - **自信を持って解消できないコンフリクトがある場合**: `git merge --abort` で完全に元へ戻し、
-     「解消不能」と対象ファイル一覧を報告して終了する（中途半端な解消状態を残さない）
-3. 報告は次の3値のいずれか＋最小限の情報のみとする（差分の中身は報告に含めない）:
-   「コンフリクトなし」／「解消済み: <マージコミットSHA> <解消ファイルパス一覧>」／「解消不能: <ファイル一覧と理由1行>」
-
-メインエージェント側の後続処理:
+subagentの報告（コンフリクトなし／解消済み／解消不能）への後続処理:
 
 - 「コンフリクトなし」→ そのままStep 4へ進む
 - 「解消済み」→ マージコミットSHAをStep 7の `summary` に記録し（`pushed_commits` にも含める）、Step 4へ進む。

--- a/.agents/skills/pr-adjudicated-apply/SKILL.md
+++ b/.agents/skills/pr-adjudicated-apply/SKILL.md
@@ -4,6 +4,7 @@ description: |
   人間の裁定結果（adjudications.json）に基づき、pr-independent-reviewが出力したfindings.jsonのうち
   reject以外の裁定（案キーA〜F・other）が付いた指摘だけをPRブランチへ実装・検証・pushする無人実行スキル。PR番号を受け取り、
   メインクローンでPRのheadブランチへcheckoutして修正し、コンパイル・関連テストで検証してからpushする。
+  checkout後は修正前にsubagentを無条件発火してmasterとのコンフリクトを検査し、あれば逆マージで事前解消する。
   裁定未完了時は即座にfailureとして終了し、却下された指摘・新規発見の問題には一切触れない。
   Use When:
   1. 「/pr-adjudicated-apply <PR番号>」で起動された時
@@ -125,6 +126,37 @@ description: |
 
 **この時点から先でどのように終了しても、Step 8（後片付け）を必ず実行してからapply-result.jsonを書く。**
 
+## Step 3.5: masterコンフリクト事前解消（subagent委譲・無条件発火）
+
+checkout成功後、修正実装に入る前に、**コンフリクトの有無を自分で調べず**、必ずsubagent
+（Agentツール、general-purpose）を1体発火して委譲する。目的はメインエージェントのコンテキストを
+コンフリクト解消の詳細（差分・両側の変更内容）で消費しないこと。メインエージェントが渡してよい情報は
+`$REPO` の実値・`headRefName`・PR番号のみで、事前に `git merge-tree` や diff での予備調査は行わない。
+
+subagentへの指示内容（プロンプトに含める）:
+
+1. `git -C <$REPOの実値> fetch origin master` を実行する
+2. PRブランチ上で `git -C <$REPOの実値> merge --no-commit --no-ff origin/master` を試みる
+   - **Already up to date / コンフリクトなしで成功した場合**: `git -C <$REPOの実値> merge --abort`
+     （abort対象が無ければ `git reset --merge`）でマージ状態を破棄し、「コンフリクトなし」とだけ報告して
+     即終了する（クリーンでもマージは残さない。master取り込み自体はこのスキルの責務ではない）
+   - **コンフリクトが発生した場合**: 各コンフリクトファイルについて両側の変更意図を読み取り、
+     両方の意図を保つ形で解消する（機械的にours/theirsを選ばない）。解消後 `git add` し、
+     標準のマージメッセージ＋`Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>` トレーラーで
+     マージコミットを作成する。`.cs` を解消で触った場合は `uloop compile --project-path ./moorestech_client`
+     でコンパイルが通ることまで確認してからコミットする
+   - **自信を持って解消できないコンフリクトがある場合**: `git merge --abort` で完全に元へ戻し、
+     「解消不能」と対象ファイル一覧を報告して終了する（中途半端な解消状態を残さない）
+3. 報告は次の3値のいずれか＋最小限の情報のみとする（差分の中身は報告に含めない）:
+   「コンフリクトなし」／「解消済み: <マージコミットSHA> <解消ファイルパス一覧>」／「解消不能: <ファイル一覧と理由1行>」
+
+メインエージェント側の後続処理:
+
+- 「コンフリクトなし」→ そのままStep 4へ進む
+- 「解消済み」→ マージコミットSHAをStep 7の `summary` に記録し（`pushed_commits` にも含める）、Step 4へ進む。
+  解消内容の再検証・diff閲覧は行わない（Step 5のコンパイル・テストが実効的な検証になる）
+- 「解消不能」→ 失敗として終了する（Step 8で元ブランチへ戻り、summaryに解消不能ファイルを記載）
+
 ## Step 4: 修正実装
 
 対象finding（Step 2で抽出したadopt分）それぞれについて、`recommendation` と `comment`（あれば）に従って
@@ -146,6 +178,7 @@ AGENTS.mdの規約を遵守する:
 ## Step 5: 検証
 
 - **.csファイルを1つでも変更したら** `cd <$REPOの実値> && uloop compile --project-path ./moorestech_client` を必ず実行する
+  （Step 3.5でマージコミットが作られた場合も、masterから流入した変更を含めた検証としてコンパイル必須）
 - 修正箇所に関連するテストを `cd <$REPOの実値> && uloop run-tests --project-path ./moorestech_client --filter-type regex --filter-value "<関連regex>"` で実行する
   （`<関連regex>` は修正したクラス・機能に対応するテストクラス名から組み立てる）
 - **コンパイルまたはテストが失敗し、かつStep 4の範囲内で直しきれない場合は、pushせず失敗として終了する**

--- a/.agents/skills/pr-adjudicated-apply/references/conflict-preflight-agent.md
+++ b/.agents/skills/pr-adjudicated-apply/references/conflict-preflight-agent.md
@@ -1,0 +1,43 @@
+# masterコンフリクト事前解消エージェント 指示テンプレート
+
+<!--
+メインエージェントへ: {{REPO}}（リポジトリルート絶対パス）・{{HEAD_REF_NAME}}（PRのheadブランチ名）・
+{{PR_NUMBER}}（PR番号）を実値に置換し、以下をsubagentのプロンプトとして丸ごと渡す。
+Main agent: replace the placeholders with real values and pass everything below as the subagent prompt verbatim.
+-->
+
+あなたはPR #{{PR_NUMBER}} の修正適用に先立つコンフリクト事前解消エージェントです。
+リポジトリ `{{REPO}}` はPRのheadブランチ `{{HEAD_REF_NAME}}` にcheckout済みです。
+以下を順に実行してください。
+
+## 手順
+
+1. `git -C {{REPO}} fetch origin master`
+2. `git -C {{REPO}} merge --no-commit --no-ff origin/master` を試みる
+   - **Already up to date / コンフリクトなしで成功**:
+     `git -C {{REPO}} merge --abort`（abort対象が無ければ `git -C {{REPO}} reset --merge`）で
+     マージ状態を破棄する。クリーンでもマージは残さない — master取り込み自体はあなたの責務ではない
+   - **コンフリクト発生**: 各コンフリクトファイルについて両側の変更意図を読み取り、
+     両方の意図を保つ形で解消する（機械的にours/theirsを選ばない）。
+     `.cs` を解消で触った場合は `cd {{REPO}} && uloop compile --project-path ./moorestech_client` で
+     コンパイルが通ることを確認してから、`git add` し標準のマージメッセージ＋次のトレーラーでコミットする:
+
+         Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+
+   - **自信を持って解消できないコンフリクトがある**: `git -C {{REPO}} merge --abort` で完全に元へ戻す。
+     中途半端な解消状態を絶対に残さない
+
+## 報告（最終メッセージ）
+
+次の3値のいずれか＋最小限の情報のみ。**差分の中身・両側の変更内容の説明は含めない**
+（呼び出し元のコンテキストを消費させないため）:
+
+- `コンフリクトなし`
+- `解消済み: <マージコミットSHA> <解消ファイルパス一覧>`
+- `解消不能: <ファイル一覧と理由1行>`
+
+## 禁止事項
+
+- コンフリクト解消以外のコード変更（気づいた問題の修正・リファクタ等）は一切行わない
+- push・ブランチ切り替え・reset --hard は行わない
+- AskUserQuestionは使わない（無人実行）


### PR DESCRIPTION
## Summary
- `pr-adjudicated-apply` スキルへ、対象PRのheadブランチをcheckoutした直後にmasterとのコンフリクトを検査するsubagent委譲Stepを追加（opusモデル・テンプレート渡し）
- コンフリクト検査の指示内容をテンプレート化し、`SKILL.md` 本体を圧縮

## 対象コミット
- 0969d0554 feat: pr-adjudicated-applyにmasterコンフリクト事前解消のsubagent委譲Stepを追加
- 95b498b72 refactor: コンフリクト事前解消の指示をテンプレート化しSKILL.mdを圧縮

## 注記
このブランチはmasterから古いコミット（c0344306a）で分岐しており、履歴操作（rebase/merge）は行わずそのままpushしている。差分・コンフリクト判定はGitHub側に委ねる。

## Test plan
- [ ] `.agents/skills/pr-adjudicated-apply/` 配下のドキュメント変更のみであり、コンパイル・テストへの影響なし

Generated with [Claude Code](https://claude.com/claude-code)