### PR TITLE
docs(skill): プレイテストのテンプレートに開幕スキットSkipを既定で入れる

### DIFF
--- a/.agents/skills/unity-playmode-recorded-playtest/references/hotbar-driven-systems.md
+++ b/.agents/skills/unity-playmode-recorded-playtest/references/hotbar-driven-systems.md
@@ -10,10 +10,8 @@
 ## 基本パターン（このまま使う）
 
 ```csharp
-// 0. フレッシュワールドの開幕スキットを飛ばしGameScreenへ（落とし穴8参照。無ければ省略可）
-var skitStore = Client.Skit.UI.SkitPresentationStateStore.Instance;
-await p.Until(() => { var s = skitStore.GetCurrent(); return s != null && skitStore.TrySkip(s.SessionId, s.SceneRevision).Ok; }, 30f, "開幕スキットSkip");
-await p.WaitUiState(Client.Game.InGame.UI.UIState.UIStateEnum.GameScreen, 15f);
+// 0. フレッシュワールドの開幕スキットを飛ばしGameScreenへ（落とし穴8参照）
+await p.SkipOpeningSkit();
 
 // 1. アンロック（ブロックと接続ツールは別枠のアンロック状態を持つ）
 p.UnlockBlock("歯車チェーンポール");
@@ -122,8 +120,8 @@ p.Assert(!networkOf(a1).Equals(networkOf(b1)), "別セグメント");
    大量に必要なら100以下に収めるか複数回`GiveItem`を呼ぶ
 8. **フレッシュワールドの開幕スキット(Story)がホットバー入力より優先**される（`GameScreenState`の
    スキット遷移チェックがホットバー遷移チェックより後にあり、スキット中は`GameScreen`にすら入れない）。
-   `SetupFlatGround`直後に`Client.Skit.UI.SkitPresentationStateStore.Instance`のSkipインテントで
-   飛ばし`GameScreen`到達を待ってから`Hotbar.AssignHotbar`/`Hotbar.SelectHotbar`する（前例: `electric-wire-mutual-range-via-ui.cs`）
+   環境構築直後に`await p.SkipOpeningSkit()`で飛ばし`GameScreen`到達を待ってから
+   `Hotbar.AssignHotbar`/`Hotbar.SelectHotbar`する（前例: `electric-wire-mutual-range-via-ui.cs`）
 9. **`Hotbar.SelectHotbar`自体はUIState遷移完了を待たない**（キータップ+固定0.5秒インターバルのみ）。
    同キーで抜けてすぐ入り直す・別枠へ持ち替えてすぐ操作するなど連続呼び出しは、各タップの後に
    `p.WaitUiState(UIStateEnum.GameScreen/PlaceBlock, 10f)`を挟まないと、前の遷移未完了のまま次のタップが

--- a/.agents/skills/unity-playmode-recorded-playtest/references/place-blocks-via-ui.md
+++ b/.agents/skills/unity-playmode-recorded-playtest/references/place-blocks-via-ui.md
@@ -7,6 +7,7 @@
 
 ```csharp
 await p.SetupDebugEnvironment(new PlaytestEnvironmentConfig());   // 足場+ワープ+無料設置を1行で
+await p.SkipOpeningSkit();                          // 開幕スキットは全UI入力を塞ぐため必ず先に飛ばす
 p.WarpPlayer(new Vector3(3.5f, 33.5f, -1f));       // 設置エリアの南側へ（設置カメラは北向き・浅ピッチ）
 
 // 遠いセルから設置する（手前の既設ブロックが奥セルへのレイを遮るため。単クリックは隣接が埋まる前に）

--- a/.agents/skills/unity-playmode-recorded-playtest/references/write-scenario.md
+++ b/.agents/skills/unity-playmode-recorded-playtest/references/write-scenario.md
@@ -18,6 +18,8 @@ return PlaytestRunner.Run("my-scenario", options, async p =>
 {
     // デバッグ環境を1行構築（無限落下防止の足場+ワープ+無料設置）。設定値は冒頭ログとTimelineに流れる
     await p.SetupDebugEnvironment(new PlaytestEnvironmentConfig());
+    // 開幕スキットは全UI入力を塞ぐため必ず先に飛ばす（プレイテストのフレッシュワールドでは常に再生される）
+    await p.SkipOpeningSkit();
     p.Note("チェスト設置フェーズ開始");                       // AIナレーション（動画とTimelineに残る）
     // ...操作...
     p.Assert(条件, "ラベル");                                // 失敗しても続行し記録される
@@ -37,6 +39,7 @@ return PlaytestRunner.Run("my-scenario", options, async p =>
 | API | 用途 |
 |---|---|
 | `SetupDebugEnvironment(config)` | **推奨の最初の1行**。足場生成+ワープ+無料設置トグルを`PlaytestEnvironmentConfig`で一括設定し、全設定値をログ/Timelineへ出力 |
+| `SkipOpeningSkit()` | 開幕スキットをSkipインテントで飛ばし`GameScreen`到達まで待つ。スキット中は全UI入力が塞がるため**`SetupDebugEnvironment`直後の定型2行目** |
 | `SetupFlatGround()` | 足場(50x4x50 @ y30、**上面y=32ちょうど**、`GroundGameObject`付与)生成+ワープのみ（旧API・互換） |
 | `WarpPlayer(pos)` / `PlayerPosition` | テレポート/現在地。UI設置前に対象範囲の中央へワープ推奨 |
 | `GiveItemDirect(name, count)` | サーバーインベントリ直挿入（即時） |


### PR DESCRIPTION
## 概要
unity-playmode-recorded-playtest スキルのシナリオテンプレートに、開幕スキットのスキップ（`await p.SkipOpeningSkit();`）を既定行として追加する。

開幕スキットはホットバー・ビルドメニュー等の全UI入力を塞ぎ、プレイテスト起動時は `SkitPlaySettingsKey` が強制trueのためフレッシュワールドで必ず再生される。既存シナリオ5本と docs/playtest-dsl.md は既にヘルパーを使っており、テンプレート側だけが未記載だった。

## 変更内容（ドキュメントのみ・コード変更なし）
- `references/write-scenario.md`: テンプレートの `SetupDebugEnvironment` 直後に追記＋セットアップAPI表へ `SkipOpeningSkit()` の行を追加
- `references/place-blocks-via-ui.md`: 「最小コード」に同じ行を追記
- `references/hotbar-driven-systems.md`: 生の `SkitPresentationStateStore` を直接叩く4行イディオム（基本パターン・落とし穴8）を既存ヘルパー呼び出しへ置換

🤖 Generated with [Claude Code](https://claude.com/claude-code)