### PR TITLE
moores-code-review: 委譲の既知リスクと異常時の一旦停止・調査手順を明文化

### DIFF
--- a/.agents/skills/moores-code-review/SKILL.md
+++ b/.agents/skills/moores-code-review/SKILL.md
@@ -33,6 +33,17 @@ moorestechのコードレビューを **決定論チェック → 6系統の並�
 - 委譲は subagent 深度を 1 消費する。本体直下なら 本体→オーケストレータ→系統 の 3 層で収まる。
 - オーケストレータが返答せず死んだら、$RUNDIR の残骸を引き継いで再派遣する（テンプレに「$RUNDIR 内の完了済み工程はスキップして続きから」と 1 行足す）。最初からやり直さない。
 
+### 委譲の既知リスクと異常時の対応（導入時点 2026-08-18）
+
+導入時点で委譲構成の実走実績は all-code-review 側の 1 回のみで、**moores 版の委譲は未実走**。同型構成で実証済みなのは subagent からの Agent 入れ子起動・Bash バックグラウンド・ファイルハンドオフ・integrator 委譲まで。moores 版に固有で未検証なのは: (1) codex 3 本のバックグラウンド並列、(2) subagent からの `uloop compile`、(3) **大規模 PR 時の investigator 込み 30 体級を sonnet 監督が wave 規律（1 メッセージ 12 体・「起動が黙って消える」対応・失敗体の再起動）どおり捌けるか**。
+
+**回収時の検死（本体・毎回必須）**: オーケストレータの返答を受けたら、報告する前に次を突き合わせる —
+1. 返答の系統数が期待値と一致するか（期待値 = checks.json の `lenses` + `reviewers` + `verifiers_to_launch` + Fable 1 + Codex 3 + 決定論。分割深掘り発火時は + チャンク数×3）
+2. `integrated.md` の「系統別回収状況」に欠員・未回収がないか
+3. `$RUNDIR` に規定の成果物（checks.json / codex `.out.md` ×3 / `agents/` / integrated.md / final.diff / checks-final.json / design.md）が揃っているか
+
+**何か変なこと（規定数のエージェントが発火していない・モデル割り当てが指定と違う・成果物の欠落・integrated.md 不在・返答が契約と違う等）があれば、修正適用や再派遣を重ねる前に一旦止めて調査する。** 手順: セッション transcript（`~/.claude/projects/<プロジェクト>/<セッションID>/subagents/*.meta.json` で起動数とモデルを実測、`*.jsonl` で該当体の挙動を確認）→ 原因を特定してから再開の要否を決める。原因がスキル記述の穴なら `references/skill-improvement.md` の手順で恒久対応する。異常のまま結果だけ採用しない（欠員のある統合結果は「全系統レビュー済み」を偽装する）。
+
 ## Step 0: 実行ディレクトリ `$RUNDIR` を作る
 
 1回のレビューが作る生成物（patch・context・codex監査プロンプト3本・check_all出力・chunks・最終diff・最終detchecks）は


### PR DESCRIPTION
## 概要

PR #1158（委譲実行の既定化）のフォローアップ。委譲構成の**既知リスク**と、**異常時は一旦止めて調査する**運用規定を「委譲実行」節に追記する。

## 追記内容

- **既知リスク（導入時点）**: 委譲の実走実績は all-code-review 側の 1 回のみで moores 版は未実走。固有の未検証点は codex 3 本並列 / subagent からの `uloop compile` / 大規模 PR 時の investigator 込み 30 体級を sonnet 監督が wave 規律どおり捌けるか。
- **回収時の検死（毎回必須）**: 系統数を checks.json 由来の期待値と照合 / integrated.md の系統別回収状況 / $RUNDIR の規定成果物の実在。
- **異常時の一旦停止**: 規定数のエージェントが発火していない・モデル割り当て相違・成果物欠落などがあれば、修正適用や再派遣を重ねる前に止め、セッション transcript（subagents/*.meta.json・*.jsonl）で実測調査してから再開を判断する。欠員のある統合結果をそのまま採用しない（「全系統レビュー済み」の偽装になるため）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)