### PR TITLE
feat(skill): SDDに規模ゲート(インライン既定)を追加

### DIFF
--- a/.agents/skills/subagent-driven-development/SKILL.md
+++ b/.agents/skills/subagent-driven-development/SKILL.md
@@ -15,19 +15,40 @@ description: 現在のセッションで、独立したタスクからなる実�
 
 **継続実行:** タスクの合間に人間パートナーへ確認を取るために止まらない。計画の全タスクを止まらずに実行する。止まってよい理由は、解決できないBLOCKED状態、真に進行を妨げる曖昧さ、または全タスク完了のみ。「続けてよいですか？」という確認や進捗サマリーは相手の時間の無駄になる — 彼らは計画の実行を依頼したのだから、実行せよ。
 
+## 規模ゲート: 既定はインライン実装（2026-08-18 実測に基づく）
+
+計画があっても、**規模が閾値未満ならこのスキルを使わずインラインで実装するのが既定**である。SDDの実装subagent自体は安いが、派遣往復によるコントローラーの肥大とタスクごとのレビューゲートが固定費として乗る（実測: 1計画あたり$40〜90相当 + 本体ループ肥大。実装subagentは大型セッション総額の6〜25%に過ぎなかった）。
+
+**SDDを発動する条件（いずれか1つで発動）:**
+
+1. **予想変更が約15ファイル超、または約1,000行超**
+2. **計画の独立タスクが6個以上**
+3. 実装と並行して**長いデバッグ・実機e2e往復**が見込まれる（調査churnがコンテキストを食う）
+4. **並列実行**したい独立タスク群がある
+
+どれにも該当しなければインラインで実装する。その場合も最終レビュー1本（moores-code-review）は省略しない。worktree隔離が必要なだけならworktree + インラインでよく、SDDの理由にはならない。
+
+**閾値の根拠（両Mac 130+セッションのtranscript実測、2026-08-18）:** インライン実装は編集約20ファイル・読み書き合計約45ファイルまでcompaction発生ゼロで完走している（25〜32ファイルも読み込みが少なければ可）。編集25〜30ファイル超または長いデバッグ往復を伴うと高頻度でcompactionし、文脈喪失は「完了済みタスクの再派遣」級の最も高くつく失敗につながる。15ファイルはこの実測限界に対する安全マージンである。
+
+**途中切替:** インラインで始めて、半分に達する前にコンテキスト残量が3割を切ったら、そこで止めて残りのタスクをこのスキル（subagent派遣）に切り替える。進捗台帳（下記）に切替点を記録する。
+
 ## 使用場面
 
 ```dot
 digraph when_to_use {
     "Have implementation plan?" [shape=diamond];
+    "Over size gate? (>~15 files / >~1000 lines / 6+ tasks / long debug loop)" [shape=diamond];
     "Tasks mostly independent?" [shape=diamond];
-    "Stay in this session?" [shape=diamond];
     "subagent-driven-development" [shape=box];
     "executing-plans" [shape=box];
     "Manual execution or brainstorm first" [shape=box];
+    "Inline implementation + final review" [shape=box];
+    "Stay in this session?" [shape=diamond];
 
-    "Have implementation plan?" -> "Tasks mostly independent?" [label="yes"];
+    "Have implementation plan?" -> "Over size gate? (>~15 files / >~1000 lines / 6+ tasks / long debug loop)" [label="yes"];
     "Have implementation plan?" -> "Manual execution or brainstorm first" [label="no"];
+    "Over size gate? (>~15 files / >~1000 lines / 6+ tasks / long debug loop)" -> "Tasks mostly independent?" [label="yes"];
+    "Over size gate? (>~15 files / >~1000 lines / 6+ tasks / long debug loop)" -> "Inline implementation + final review" [label="no - below gate"];
     "Tasks mostly independent?" -> "Stay in this session?" [label="yes"];
     "Tasks mostly independent?" -> "Manual execution or brainstorm first" [label="no - tightly coupled"];
     "Stay in this session?" -> "subagent-driven-development" [label="yes"];


### PR DESCRIPTION
## 概要

subagent-driven-development スキルに規模ゲートを追加し、**閾値未満の計画はインライン実装を既定**とする。~/.agents 側スキル(コミット 386c38c)で導入した変更の moorestech 版移植(PR #1158/#1160 の委譲既定化と同じ実測に基づく一連の変更)。

## 根拠(両Mac 130+セッションの transcript 実測、2026-08-18)

- SDD の固定費は implementer ではなく派遣監督とタスクレビュー(1計画あたり $40〜90 相当 + 本体ループ肥大)。implementer は大型セッション総額の 6〜25% に過ぎない
- インライン実装は編集約20ファイル・読み書き合計約45ファイルまで compaction 発生ゼロで完走している

## 変更内容

- **規模ゲート節を新設**: SDD 発動条件は (1) 約15ファイル超 or 約1,000行超 (2) 独立タスク6個以上 (3) 長いデバッグ・実機往復 (4) 並列実行希望 — のいずれか。該当しなければインライン + 最終 moores-code-review 1本
- **途中切替の規定**: インラインで始めてコンテキスト残3割を切ったら SDD へ切替、進捗台帳に記録
- **使用場面フローチャートに規模ゲート分岐を追加**

moorestech 翻案は最終レビューの参照を moores-code-review にした1点のみで、他は逐語移植。

🤖 Generated with [Claude Code](https://claude.com/claude-code)