### PR TITLE
fix(skit): スキット中に露頭が消え残る問題を共通interfaceで解消する

### DIFF
--- a/.agents/skills/unity-playmode-recorded-playtest/scenarios/misc/skit-opening-world-hidden.cs
+++ b/.agents/skills/unity-playmode-recorded-playtest/scenarios/misc/skit-opening-world-hidden.cs
@@ -1,0 +1,51 @@
+// 開幕スキットの世界非表示カットで露頭がmapObjectと一緒に消えることを実走確認する
+// Verify at runtime that outcrops hide together with map objects during the opening skit's world-hidden cut
+using Client.Game.InGame.Map.Outcrop;
+using Client.Playtest;
+using Client.Skit.UI;
+using Cysharp.Threading.Tasks;
+using UnityEngine;
+
+var options = new PlaytestRunOptions { Record = true };
+
+return PlaytestRunner.Run("skit-opening-world-hidden", options, async p =>
+{
+    await p.SetupDebugEnvironment(new PlaytestEnvironmentConfig());
+
+    // 検証対象が開幕スキットそのものなのでSkipOpeningSkitは呼ばない
+    // The opening skit itself is under test, so SkipOpeningSkit is deliberately not called
+    p.Note("開幕スキットをオート送りで宇宙カットまで進める");
+
+    var skitStore = SkitPresentationStateStore.Instance;
+    await p.Until(() => skitStore.GetCurrent().PresentationState.Mode != "none", 60f, "スキット開始待ち");
+
+    var started = skitStore.GetCurrent();
+    skitStore.TrySetAuto(started.SessionId, started.SceneRevision, true);
+
+    var outcropDatastore = UnityEngine.Object.FindFirstObjectByType<OutcropGameObjectDatastore>(FindObjectsInactive.Include);
+    p.Assert(outcropDatastore != null, "露頭datastoreがシーンに存在する");
+
+    // 露頭0体だと非表示assertが素通りするので、実体があることを先に固定する
+    // With zero outcrops the hide assert would pass vacuously, so pin down that they actually exist
+    p.Assert(outcropDatastore.transform.childCount > 0, "露頭が1体以上生成されている");
+
+    // オートが効かない場合に備え、poll毎にAdvanceインテントも打つ
+    // Also fire an advance intent on every poll in case auto mode does not take
+    await p.Until(() =>
+    {
+        var current = skitStore.GetCurrent();
+        skitStore.TryAdvance(current.SessionId, current.SceneRevision);
+        return !outcropDatastore.gameObject.activeSelf;
+    }, 180f, "世界非表示カットで露頭rootが非表示になる");
+
+    await p.Screenshot("01-space-cut-without-outcrop");
+
+    await p.Until(() =>
+    {
+        var current = skitStore.GetCurrent();
+        skitStore.TryAdvance(current.SessionId, current.SceneRevision);
+        return outcropDatastore.gameObject.activeSelf;
+    }, 180f, "復帰カットで露頭rootが再表示される");
+
+    await p.Screenshot("02-world-restored-with-outcrop");
+});

--- a/.decisions/2026-08-18-DI登録漏れの検知手段は今回入れない.md
+++ b/.decisions/2026-08-18-DI登録漏れの検知手段は今回入れない.md
@@ -1,0 +1,11 @@
+# DI登録漏れの検知手段は今回入れない
+
+決定: `ISkitWorldObjectControl` の DI 登録漏れ（`MainGameStarter` の `.As<>()` 書き忘れ）を検知する仕組みは本PRでは追加しない。
+
+棄却案:
+- 登録全数照合テストの追加（`PlayerStartsOnBuiltTerrainTest` の `IInitialEventApplyWaitTarget` 検証を横展開） — 前例がありコストも低いが今回は見送り
+- `SkitWorldObjectControlGroup` のコンストラクタで空リストを `InvalidOperationException` で拒否 — 全滅時のみ検知でき、2件中1件漏れは素通り
+
+理由: ユーザー裁定（2026-08-18）。具象型注入から `IReadOnlyList` 注入へ変えたことで、登録漏れが起動時例外から無言の縮退に変わったリスクは残ることを承知の上で確定。
+
+リンク: [[2026-08-18-スキットの世界非表示は共通interfaceへ載せ替える.md]]

--- a/.decisions/2026-08-18-inGameObjectControlのフラグをworldObjectEnableへ改名する.md
+++ b/.decisions/2026-08-18-inGameObjectControlのフラグをworldObjectEnableへ改名する.md
@@ -1,0 +1,9 @@
+# inGameObjectControlのフラグをworldObjectEnableへ改名する
+
+決定: `commands.yaml` の `mapObjectEnable` を `worldObjectEnable` へリネームし、`100_start_game.json`(2コマンド)・i18n(japanese/english)・commandListLabelFormat を一括更新する。
+
+棄却案: `mapObjectEnable` の名前を据え置き、C#側だけ載せ替える（改修は最小）
+
+理由: 束ねた後の実処理は mapObject＋露頭。AGENTS.md「名前は実処理と一致させる」「変更の波及を恐れない」。名前が実態とズレると次の改修者が同じ取りこぼしを繰り返す。
+
+リンク: [[2026-08-18-スキットの世界非表示は共通interfaceへ載せ替える.md]] / docs/adr/0016-skit-hides-world-objects-through-shared-interface.md

--- a/.decisions/2026-08-18-スキットの世界非表示は共通interfaceへ載せ替える.md
+++ b/.decisions/2026-08-18-スキットの世界非表示は共通interfaceへ載せ替える.md
@@ -1,0 +1,11 @@
+# スキットの世界非表示は共通interfaceへ載せ替える
+
+決定: `ISkitWorldObjectControl`（Environment外の世界オブジェクト）を新設し、mapObject datastore と 露頭 datastore の両方に実装させ、composite（`IReadOnlyList` 注入・`ITutorialWorldPin` と同型）で束ねる。既存 `ISkitMapObjectControl` は削除して載せ替える。
+
+棄却案:
+- `ISkitOutcropObjectControl` を1本足すだけ（露頭は消えるがカテゴリ名指し列挙が残り、次の表示物でまた取りこぼす）
+- MapObjectGameObjectDatastore から露頭へ伝播（責務の逆流）
+
+理由: 今回の不具合は「Environment外に置かれる表示物をコマンドが名指し列挙している」構造そのものが原因。共通概念で束ねればDI登録だけで新対象が乗る。
+
+リンク: docs/adr/0016-skit-hides-world-objects-through-shared-interface.md / bd moorestech-kvl

--- a/.decisions/2026-08-18-スキット中断時の世界表示はSkitManagerのCleanupで戻す.md
+++ b/.decisions/2026-08-18-スキット中断時の世界表示はSkitManagerのCleanupで戻す.md
@@ -1,0 +1,11 @@
+# スキット中断時の世界表示はSkitManagerのCleanupで戻す
+
+決定: `SkitWorldObjectControlGroup` が「隠した事実」(`IsHidden`)だけを控え、`SkitManager.Cleanup()` が中断時に `SetActive(true)` を流して復元する。
+
+棄却案:
+- interface契約を `SetActive(bool)` から `BeginSkitHide/EndSkitHide`（実装側が直前の activeSelf を保持）へ変更 — 元から非アクティブだったものまで正しく戻せるが、兄弟3 interface（背景・ブロック・エンティティ）との非対称が生まれるか、それらへの横展開で波及が大きい
+- 非目標として据え置き — レビューが「planにしか書かれていない非目標は免責力を持たない」と判定したため、据え置くならADR実体への追記が必要だった
+
+理由: pinの「実際に効いたものだけ戻す」形に寄せられ、interface変更を伴わないため波及が最小。元から非アクティブだったものを復帰時に表示してしまうケースは許容コストとして残す。
+
+リンク: [[2026-08-18-スキットの世界非表示は共通interfaceへ載せ替える.md]] / docs/adr/0016-skit-hides-world-objects-through-shared-interface.md

--- a/.decisions/2026-08-18-スキット非表示の束にentityは含めない.md
+++ b/.decisions/2026-08-18-スキット非表示の束にentityは含めない.md
@@ -1,0 +1,9 @@
+# スキット非表示の束にentityは含めない
+
+決定: 新設する `ISkitWorldObjectControl` の対象は mapObject と露頭の2種。entity は `ISkitEntityObjectControl` と `entityEnable` を独立のまま維持する。
+
+棄却案: entity も含めて3種を1フラグ（worldObjectEnable）に統合し entityEnable を削除する
+
+理由: 「背景は消すがプレイヤー・車両は映す」型の演出の自由度を残すため。現行スキットも別フラグで書かれている。
+
+リンク: [[2026-08-18-スキットの世界非表示は共通interfaceへ載せ替える.md]]

--- a/docs/adr/0016-skit-hides-world-objects-through-shared-interface.md
+++ b/docs/adr/0016-skit-hides-world-objects-through-shared-interface.md
@@ -1,0 +1,52 @@
+# スキットの世界非表示はEnvironment外オブジェクトの共通interfaceで束ねる
+
+スキットの `inGameObjectControl` コマンドが消す対象のうち、**Environment 外に生成される世界オブジェクト**（mapObject・鉱脈の露頭）を共通 interface `ISkitWorldObjectControl` で束ね、コマンドは1フラグ `worldObjectEnable` で一括制御する。既存の `ISkitMapObjectControl` は削除して載せ替える。
+
+## 背景: カテゴリ列挙が取りこぼしを生んだ
+
+`InGameObjectControlCommand` は「1カテゴリ = 1 interface」で4本を名指ししていた（background / block / mapObject / entity）。地形と背景は `EnvironmentRoot` 配下なので背景フラグで一緒に消えるが、mapObject とエンティティは Environment 外に生成されるため個別に消す、という構造になっていた。
+
+2026-08-04 に追加された露頭（`OutcropGameObjectDatastore`、シーンroot直下の独立オブジェクト配下）は**同じ「Environment 外の世界オブジェクト」でありながらどの interface にも繋がれず**、開幕スキット `100_start_game` の宇宙カット（`inGameObjectControl` で4フラグすべて false）で露頭だけが消え残った。これが「スキット中に vein が映る」不具合の実体である。
+
+名指し列挙のままでは、Environment 外に置かれる表示物が増えるたびに同じ取りこぼしが再発する。共通概念で束ね、DI 登録だけで新しい対象が乗る形にする。
+
+## 決定
+
+- `ISkitWorldObjectControl { void SetActive(bool enable); }` を新設し、`MapObjectGameObjectDatastore` と `OutcropGameObjectDatastore` の両方が実装する
+- `SkitWorldObjectControlGroup`（composite）が `IReadOnlyList<ISkitWorldObjectControl>` を受け、全要素へ `SetActive` を流す。DI での収集は `ITutorialWorldPin`（MapObjectPin / VeinPin を SkitManager がまとめて抑止する）と同型
+- `commands.yaml` の `mapObjectEnable` を `worldObjectEnable` へリネームし、`100_start_game.json`（2コマンド）・i18n（japanese / english）・`commandListLabelFormat` を更新する
+- entity は束に含めない。`ISkitEntityObjectControl` と `entityEnable` は独立のまま維持する
+
+コマンドのフラグは次の4本になる:
+
+| フラグ | 対象 |
+|---|---|
+| `backgroundEnable` | EnvironmentRoot（背景・地形） |
+| `blockEnable` | ブロック |
+| `worldObjectEnable` | mapObject ＋ 露頭（Environment 外の世界オブジェクト） |
+| `entityEnable` | entity |
+
+## 棄却した案
+
+- **新 interface を1本足すだけ**（`ISkitOutcropObjectControl` を追加し、コマンドが `mapObjectEnable` を2サービスへプッシュ）— 露頭は消えるが列挙構造は残り、次の表示物でまた同じ取りこぼしが起きる
+- **`MapObjectGameObjectDatastore` から露頭へ伝播**（自分の `SetActive` で露頭 datastore も消す）— 改修は1ファイルで済むが、mapObject datastore が露頭を知る責務の逆流が生じる
+- **`mapObjectEnable` の名前を据え置き**— 実処理（mapObject＋露頭）と名前がズレたままになる。AGENTS.md「名前は実処理と一致させる」「変更の波及を恐れない」に反する
+- **entity も含めて3種を1フラグに**— 「背景は消すがプレイヤーは映す」型の演出が作れなくなる
+
+## 受け入れるコスト
+
+- `commands.yaml` のリネームに伴い、既存スキット JSON と i18n の一括更新が必要（後方互換は取らない）
+- デバッグシーンの `SkitTester` は mapObject / entity のダミーを生成して登録しているため、露頭 datastore のダミー登録を1件追加する
+
+## スコープ外
+
+`IsPlayingSkit` を見て Story ステートへ抜けるのは `GameScreenState` と `PlaceBlockState` だけで、ビルドメニューやインベントリを開いたままスキットが発火すると UI ステートが切り替わらない。別症状・別レイヤーのため本件には含めず、別 issue とする。
+
+## 出所
+
+- 「より抽象化し、mapobject と vein のオブジェクト両方を共通としてオンオフする新しい interface とクラスを作成し既存のオンオフから載せ替える」: ユーザー裁定 2026-08-18
+- フラグ名を `worldObjectEnable` へリネーム: ユーザー裁定 2026-08-18
+- entity を束に含めない: ユーザー裁定 2026-08-18
+- composite ＋ `IReadOnlyList` 注入の形: agent前提（`ITutorialWorldPin` の先行パターン）をユーザーが選択
+- 裁定レコード: `.decisions/2026-08-18-スキットの世界非表示は共通interfaceへ載せ替える.md` / `.decisions/2026-08-18-inGameObjectControlのフラグをworldObjectEnableへ改名する.md` / `.decisions/2026-08-18-スキット非表示の束にentityは含めない.md`
+- 調査: bd `moorestech-kvl`

--- a/docs/superpowers/plans/2026-08-18-skit-world-object-control.md
+++ b/docs/superpowers/plans/2026-08-18-skit-world-object-control.md
@@ -543,15 +543,15 @@ git commit -m "test(playtest): 開幕スキットの世界非表示で露頭が�
 
 **Files:** なし（レビュー実行のみ）
 
-- [ ] **Step 1: moores-code-review を実行する**
+- [x] **Step 1: moores-code-review を実行する**
 
 `moores-code-review` スキルを起動し、`master...fix/skit-hide-outcrop-with-world-objects` の全差分をレビューする。ゴール達成を理由に省略してはならない。
 
-- [ ] **Step 2: 指摘へ対応する**
+- [x] **Step 2: 指摘へ対応する**
 
 機械的修正は適用し、設計判断は AskUserQuestion で裁定を仰ぐ。修正後は `uloop compile` と Task 1〜3 のテストを再実行する。
 
-- [ ] **Step 3: 作業を全てコミットする**
+- [x] **Step 3: 作業を全てコミットする**
 
 ```bash
 git status   # 未コミットの変更が無いことを確認

--- a/docs/superpowers/plans/2026-08-18-skit-world-object-control.md
+++ b/docs/superpowers/plans/2026-08-18-skit-world-object-control.md
@@ -1,0 +1,573 @@
+# スキットの世界非表示を共通interfaceへ載せ替える Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: subagent-driven-development スキルを使い、このplanをタスクごとに実装すること。ステップはチェックボックス（`- [ ]`）記法で進捗管理する。
+
+**Goal:** スキットの `inGameObjectControl` が消す「Environment 外の世界オブジェクト」を共通 interface `ISkitWorldObjectControl` で束ね、これまで消し残っていた鉱脈の露頭もスキットの世界非表示カットで一緒に消えるようにする。
+
+**Architecture:** `Client.Skit` 側に `ISkitWorldObjectControl { void SetActive(bool) }` を1本置き、`MapObjectGameObjectDatastore` と `OutcropGameObjectDatastore` の両方に実装させる。SkitManager は VContainer の `IReadOnlyList<T>` 一括注入（`ITutorialWorldPin` と同型）で全実装を受け取り、composite `SkitWorldObjectControlGroup` として skit の DI コンテナへ登録する。コマンドは1フラグ `worldObjectEnable` を composite へ流すだけになる。
+
+**Tech Stack:** Unity 6 / C# / VContainer / UniTask / CommandForgeGenerator（`commands.yaml` を additionalfile とする SourceGenerator） / NUnit（Unity Test Runner EditMode）
+
+## Requirements
+
+- スキットの世界非表示カット（`100_start_game` の `inGameObjectControl` id:70）で、露頭（vein の見た目オブジェクト）が mapObject と同時に非表示になる — 受け入れ基準: 録画実走で宇宙カットに露頭が1つも映らない
+- 復帰コマンド（id:71）で露頭が mapObject と同時に再表示される — 受け入れ基準: 録画実走で復帰後に露頭が見える／`activeSelf == true` を assert
+- 対象は共通 interface `ISkitWorldObjectControl` で表現し、mapObject datastore と露頭 datastore の両方が実装する — 受け入れ基準: 既存 `ISkitMapObjectControl` はリポジトリから消えている
+- 束ねは composite `SkitWorldObjectControlGroup`（`IReadOnlyList<ISkitWorldObjectControl>` 注入）で行う — 受け入れ基準: composite が全要素へ `SetActive` を流すユニットテストが green
+- 今後 Environment 外の表示物が増えたとき、interface 実装と DI 登録だけで乗る — 受け入れ基準: composite もコマンドも対象を名指ししていない
+- コマンドのフラグ名を実処理に一致させる（`mapObjectEnable` → `worldObjectEnable`）。`commands.yaml` / `100_start_game.json` / i18n(japanese・english) / `commandListLabelFormat` を一括更新する — 受け入れ基準: リポジトリ内に `mapObjectEnable` / `MapObjectEnable` の参照が（ADR・裁定レコード等の文書を除き）残っていない
+- entity は束に含めない — 受け入れ基準: `ISkitEntityObjectControl` と `entityEnable` が現状のまま残る
+- デバッグシーン（`SkitTester`）が起動時に例外を出さない — 受け入れ基準: 露頭 datastore のダミーが `ISkitWorldObjectControl` として登録されている
+
+**やらないこと（スコープ境界）**
+
+- ビルドメニュー・インベントリ滞在中にスキットが発火しても `Story` ステートへ遷移しない件（bd `moorestech-h4j`）には触れない
+- `MapVeinRangeViewService`（設置プレビュー中の鉱脈範囲ボックス）は本件と無関係。`PlaceBlockState.OnExit` で畳まれることを調査済みなので変更しない
+- スキットが例外で中断したときに世界非表示が戻らない問題（既存の block/mapObject と共通の性質）は本 plan では扱わない
+
+## Global Constraints
+
+- **作業ツリー**: `/Users/sakastudio/hermes-agent/data/repos/moorestech-worktrees/skit-outcrop-hide`（ブランチ `fix/skit-hide-outcrop-with-world-objects`、master `ce10cea49` から分岐）。メインクローンでは作業しない
+- **Unity Editor**: この worktree は `moores-wt new --no-editor` で作られている（作成時に他セッションの Editor が上限超過だったため）。最初の `.cs` 変更前に `uloop launch /Users/sakastudio/hermes-agent/data/repos/moorestech-worktrees/skit-outcrop-hide/moorestech_client` で自分用 Editor を起動する。他セッションの Editor は絶対に kill しない
+- **コンパイル必須ゲート**: `.cs` を変更したら必ず `uloop compile --project-path ./moorestech_client` を実行し、エラー0を確認してからコミットする
+- **テスト実行**: `uloop run-tests --project-path ./moorestech_client --test-mode EditMode --filter-type regex --filter-value "<正規表現>"`。`--test-mode` を省くと PlayMode が既定になるので必ず付ける。「Unity is reloading (Domain Reload in progress)」が出たら45秒待ってリトライ
+- **コメント規約**: 主要な処理セクションに日本語1行→英語1行の2行セットコメント。自明なコメントは書かない。日本語本文の目安は処理・変数20字、メソッド30字
+- **禁止事項**: `partial`（如何なる条件でも）、`Func<>`、try-catch（外部境界の隔離を除く）、単純 getter/setter プロパティ、`.meta` の手動作成、Prefab/シーンのテキスト直接編集
+- **ファイル規約**: 1ファイル200行以下、1ディレクトリ10ファイルまで
+- **`.meta` ファイル**: 新規 `.cs` を作ったら Unity が `.meta` を生成する。生成された `.meta` は一緒にコミットしてよい（手書きは禁止）
+- 後方互換・パフォーマンス最適化・将来拡張性は考慮しない。正しい設計のために全 JSON・全呼び出し側を一括更新する
+
+---
+
+### Task 1: 共通interfaceとcompositeを作る
+
+**Files:**
+- Modify: `moorestech_client/Assets/Scripts/Client.Skit/Commands/InGameObjectControlCommand.cs:16-19`（`ISkitMapObjectControl` の宣言を `ISkitWorldObjectControl` へ置換。この時点では `ExecuteAsync` は旧 interface を使ったままなのでコンパイルが通るよう両方の作業を同一タスクで完結させる → 下記 Step 3 参照）
+- Create: `moorestech_client/Assets/Scripts/Client.Game/Skit/SkitWorldObjectControlGroup.cs`
+- Test: `moorestech_client/Assets/Scripts/Client.Tests/Skit/SkitWorldObjectControlGroupTest.cs`
+
+**Interfaces:**
+- Consumes: なし（このタスクが起点）
+- Produces:
+  - `CommandForgeGenerator.Command.ISkitWorldObjectControl`（`void SetActive(bool enable)`）
+  - `Client.Game.Skit.SkitWorldObjectControlGroup`（ctor: `SkitWorldObjectControlGroup(IReadOnlyList<ISkitWorldObjectControl> worldObjectControls)` / `void SetActive(bool enable)`）
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`moorestech_client/Assets/Scripts/Client.Tests/Skit/SkitWorldObjectControlGroupTest.cs` を新規作成する:
+
+```csharp
+using System.Collections.Generic;
+using Client.Game.Skit;
+using CommandForgeGenerator.Command;
+using NUnit.Framework;
+
+namespace Client.Tests.Skit
+{
+    public class SkitWorldObjectControlGroupTest
+    {
+        [Test]
+        public void SetActiveReachesEveryRegisteredWorldObject()
+        {
+            var mapObjects = new RecordingWorldObjectControl();
+            var outcrops = new RecordingWorldObjectControl();
+            var group = new SkitWorldObjectControlGroup(
+                new List<ISkitWorldObjectControl> { mapObjects, outcrops });
+
+            group.SetActive(false);
+            group.SetActive(true);
+
+            CollectionAssert.AreEqual(new[] { false, true }, mapObjects.ReceivedValues);
+            CollectionAssert.AreEqual(new[] { false, true }, outcrops.ReceivedValues);
+        }
+
+        [Test]
+        public void SetActiveOnEmptyGroupDoesNotThrow()
+        {
+            var group = new SkitWorldObjectControlGroup(new List<ISkitWorldObjectControl>());
+
+            Assert.DoesNotThrow(() => group.SetActive(false));
+        }
+
+        private sealed class RecordingWorldObjectControl : ISkitWorldObjectControl
+        {
+            public readonly List<bool> ReceivedValues = new();
+
+            public void SetActive(bool enable)
+            {
+                ReceivedValues.Add(enable);
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認する**
+
+Run: `uloop run-tests --project-path ./moorestech_client --test-mode EditMode --filter-type regex --filter-value "SkitWorldObjectControlGroupTest"`
+Expected: コンパイルエラー（`ISkitWorldObjectControl` / `SkitWorldObjectControlGroup` が存在しない）で実行に至らない
+
+- [ ] **Step 3: interfaceを置換する**
+
+`InGameObjectControlCommand.cs` の `ISkitMapObjectControl` 宣言（16-19行）を差し替え、`ExecuteAsync` の該当行も同時に新 interface へ向ける:
+
+```csharp
+    // mapObjectと露頭のようにEnvironment外へ置かれる世界オブジェクトの表示窓口
+    // Visibility entry point for world objects placed outside Environment, such as map objects and outcrops
+    public interface ISkitWorldObjectControl
+    {
+        void SetActive(bool enable);
+    }
+```
+
+`ExecuteAsync` 内の該当1行:
+
+```csharp
+            // mapObject・露頭・エンティティはEnvironment外に生成されるため個別に消す
+            // Map objects, outcrops, and entities live outside Environment, so hide them individually
+            storyContext.GetService<ISkitWorldObjectControl>().SetActive(MapObjectEnable);
+```
+
+（`MapObjectEnable` は Task 3 で `WorldObjectEnable` へリネームする。この時点では `commands.yaml` が旧名のままなので生成プロパティ名も旧名である）
+
+- [ ] **Step 4: compositeを実装する**
+
+`moorestech_client/Assets/Scripts/Client.Game/Skit/SkitWorldObjectControlGroup.cs` を新規作成する:
+
+```csharp
+using System.Collections.Generic;
+using CommandForgeGenerator.Command;
+
+namespace Client.Game.Skit
+{
+    /// <summary>
+    ///     Environment外に置かれた世界オブジェクトを1単位で表示切替する
+    ///     Toggles every world object placed outside Environment as a single unit
+    /// </summary>
+    public class SkitWorldObjectControlGroup : ISkitWorldObjectControl
+    {
+        private readonly IReadOnlyList<ISkitWorldObjectControl> _worldObjectControls;
+
+        public SkitWorldObjectControlGroup(IReadOnlyList<ISkitWorldObjectControl> worldObjectControls)
+        {
+            _worldObjectControls = worldObjectControls;
+        }
+
+        public void SetActive(bool enable)
+        {
+            foreach (var worldObjectControl in _worldObjectControls) worldObjectControl.SetActive(enable);
+        }
+    }
+}
+```
+
+- [ ] **Step 5: SkitManagerとMapObjectGameObjectDatastoreの参照を暫定で合わせてコンパイルを通す**
+
+`ISkitMapObjectControl` が消えたことで2箇所が壊れる。Task 2 で本実装するが、このタスクをコンパイルグリーンで閉じるため、ここで最小の追従を行う:
+
+- `moorestech_client/Assets/Scripts/Client.Game/InGame/Map/MapObject/MapObjectGameObjectDatastore.cs:22` のクラス宣言を `ISkitMapObjectControl` → `ISkitWorldObjectControl` へ置換する
+- `moorestech_client/Assets/Scripts/Client.Game/Skit/SkitManager.cs:156` を次へ置換する:
+
+```csharp
+                builder.RegisterInstance<ISkitWorldObjectControl>(mapObjectGameObjectDatastore);
+```
+
+- [ ] **Step 6: コンパイルする**
+
+Run: `uloop compile --project-path ./moorestech_client`
+Expected: errors 0
+
+- [ ] **Step 7: テストを実行して通ることを確認する**
+
+Run: `uloop run-tests --project-path ./moorestech_client --test-mode EditMode --filter-type regex --filter-value "SkitWorldObjectControlGroupTest"`
+Expected: 2 tests PASS
+
+- [ ] **Step 8: コミットする**
+
+```bash
+git add moorestech_client/Assets/Scripts/Client.Skit/Commands/InGameObjectControlCommand.cs \
+        moorestech_client/Assets/Scripts/Client.Game/Skit/SkitWorldObjectControlGroup.cs \
+        moorestech_client/Assets/Scripts/Client.Game/Skit/SkitWorldObjectControlGroup.cs.meta \
+        moorestech_client/Assets/Scripts/Client.Tests/Skit \
+        moorestech_client/Assets/Scripts/Client.Game/InGame/Map/MapObject/MapObjectGameObjectDatastore.cs \
+        moorestech_client/Assets/Scripts/Client.Game/Skit/SkitManager.cs
+git commit -m "feat(skit): Environment外の世界オブジェクトを束ねるISkitWorldObjectControlを追加"
+```
+
+---
+
+### Task 2: 露頭を束へ載せてDIを配線する
+
+**Files:**
+- Modify: `moorestech_client/Assets/Scripts/Client.Game/InGame/Map/Outcrop/OutcropGameObjectDatastore.cs:21`（クラス宣言に interface 追加）＋末尾に `SetActive` 追加
+- Modify: `moorestech_client/Assets/Scripts/Client.Game/Skit/SkitManager.cs:37, 156`（concrete注入 → `IReadOnlyList` 注入、composite 登録）
+- Modify: `moorestech_client/Assets/Scripts/Client.Starter/MainGameStarter.cs:307-308`（DI に `As<ISkitWorldObjectControl>()` を追加）
+- Modify: `moorestech_client/Assets/Scripts/Client.DebugSystem/Skit/SkitTester.cs`（露頭ダミーの追加登録）
+- Test: `moorestech_client/Assets/Scripts/Client.Tests/Skit/OutcropGameObjectDatastoreSkitVisibilityTest.cs`
+
+**Interfaces:**
+- Consumes: `CommandForgeGenerator.Command.ISkitWorldObjectControl` / `Client.Game.Skit.SkitWorldObjectControlGroup`（Task 1）
+- Produces: `OutcropGameObjectDatastore.SetActive(bool enable)`（`ISkitWorldObjectControl` 実装）
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`moorestech_client/Assets/Scripts/Client.Tests/Skit/OutcropGameObjectDatastoreSkitVisibilityTest.cs` を新規作成する:
+
+```csharp
+using Client.Game.InGame.Map.Outcrop;
+using CommandForgeGenerator.Command;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Client.Tests.Skit
+{
+    public class OutcropGameObjectDatastoreSkitVisibilityTest
+    {
+        private GameObject _datastoreObject;
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_datastoreObject != null) Object.DestroyImmediate(_datastoreObject);
+        }
+
+        [Test]
+        public void SetActiveFalseHidesEveryOutcropUnderTheDatastore()
+        {
+            _datastoreObject = new GameObject(nameof(OutcropGameObjectDatastore));
+            var datastore = _datastoreObject.AddComponent<OutcropGameObjectDatastore>();
+            var outcrop = new GameObject("VeinOutcrop_test");
+            outcrop.transform.SetParent(_datastoreObject.transform);
+
+            datastore.SetActive(false);
+            Assert.IsFalse(outcrop.activeInHierarchy);
+
+            datastore.SetActive(true);
+            Assert.IsTrue(outcrop.activeInHierarchy);
+        }
+
+        [Test]
+        public void DatastoreIsPartOfTheSkitWorldObjectContract()
+        {
+            _datastoreObject = new GameObject(nameof(OutcropGameObjectDatastore));
+            var datastore = _datastoreObject.AddComponent<OutcropGameObjectDatastore>();
+
+            Assert.IsInstanceOf<ISkitWorldObjectControl>(datastore);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認する**
+
+Run: `uloop run-tests --project-path ./moorestech_client --test-mode EditMode --filter-type regex --filter-value "OutcropGameObjectDatastoreSkitVisibilityTest"`
+Expected: コンパイルエラー（`OutcropGameObjectDatastore` に `SetActive` が無い）
+
+- [ ] **Step 3: 露頭datastoreにinterfaceを実装する**
+
+`OutcropGameObjectDatastore.cs:21` のクラス宣言を置換する:
+
+```csharp
+    public class OutcropGameObjectDatastore : MonoBehaviour, IInitialEventApplyWaitTarget, ISkitWorldObjectControl
+```
+
+`using CommandForgeGenerator.Command;` を using 群へ追加し、`SearchNearestOutcrop` の下（クラス末尾）へ追加する:
+
+```csharp
+        public void SetActive(bool enable)
+        {
+            gameObject.SetActive(enable);
+        }
+```
+
+- [ ] **Step 4: SkitManagerをcomposite登録へ切り替える**
+
+`SkitManager.cs:37` の `[Inject] private MapObjectGameObjectDatastore mapObjectGameObjectDatastore;` を削除し、代わりに `worldPins` の隣へ追加する:
+
+```csharp
+        [Inject] private IReadOnlyList<ISkitWorldObjectControl> worldObjectControls;
+```
+
+`PreProcess` 内の登録行（Task 1 で書き換えた156行付近）を置換する:
+
+```csharp
+                builder.RegisterInstance<ISkitWorldObjectControl>(new SkitWorldObjectControlGroup(worldObjectControls));
+```
+
+`using Client.Game.InGame.Map.MapObject;` が他で使われていなければ削除する（コンパイル警告ではなく未使用using整理として。使われていれば残す）。
+
+- [ ] **Step 5: MainGameStarterのDI登録に新interfaceを足す**
+
+`MainGameStarter.cs:307-308` を置換する:
+
+```csharp
+            builder.RegisterComponent(mapObjectGameObjectDatastore).AsSelf().As<IInitialEventApplyWaitTarget>().As<ISkitWorldObjectControl>();
+            builder.RegisterComponent(outcropGameObjectDatastore).AsSelf().As<IInitialEventApplyWaitTarget>().As<ISkitWorldObjectControl>();
+```
+
+`using CommandForgeGenerator.Command;` が無ければ using 群へ追加する。
+
+- [ ] **Step 6: SkitTesterへ露頭ダミーを足す**
+
+`SkitTester.cs` の「テストシーンにmapObject/エンティティは存在しないので〜」ブロックを置換する:
+
+```csharp
+            // テストシーンにmapObject/露頭/エンティティは存在しないのでSetActive先の空オブジェクトだけ用意する
+            // The test scene has no map objects, outcrops, or entities, so provide empty objects purely as SetActive targets
+            var mapObjectDatastore = CreateChildComponent<MapObjectGameObjectDatastore>();
+            var outcropDatastore = CreateChildComponent<OutcropGameObjectDatastore>();
+            var entityObjectDatastore = CreateChildComponent<EntityObjectDatastore>();
+
+            // RegisterComponentはビルド時に強制Resolveしサーバ応答必須のConstructを走らせるためRegisterInstanceを使う
+            // RegisterComponent force-resolves at build time and would run Construct, which needs a server response, so use RegisterInstance
+            builder.RegisterInstance(mapObjectDatastore).AsSelf().As<ISkitWorldObjectControl>();
+            builder.RegisterInstance(outcropDatastore).AsSelf().As<ISkitWorldObjectControl>();
+            builder.RegisterInstance(entityObjectDatastore);
+```
+
+using へ `using Client.Game.InGame.Map.Outcrop;` と `using CommandForgeGenerator.Command;` を追加する。
+
+- [ ] **Step 7: コンパイルする**
+
+Run: `uloop compile --project-path ./moorestech_client`
+Expected: errors 0
+
+- [ ] **Step 8: テストを実行して通ることを確認する**
+
+Run: `uloop run-tests --project-path ./moorestech_client --test-mode EditMode --filter-type regex --filter-value "OutcropGameObjectDatastoreSkitVisibilityTest|SkitWorldObjectControlGroupTest|SkitFailureCleanupTest"`
+Expected: 全 PASS
+
+- [ ] **Step 9: コミットする**
+
+```bash
+git add moorestech_client/Assets/Scripts/Client.Game/InGame/Map/Outcrop/OutcropGameObjectDatastore.cs \
+        moorestech_client/Assets/Scripts/Client.Game/Skit/SkitManager.cs \
+        moorestech_client/Assets/Scripts/Client.Starter/MainGameStarter.cs \
+        moorestech_client/Assets/Scripts/Client.DebugSystem/Skit/SkitTester.cs \
+        moorestech_client/Assets/Scripts/Client.Tests/Skit
+git commit -m "fix(skit): 露頭をISkitWorldObjectControlへ載せスキット中も一緒に消す"
+```
+
+---
+
+### Task 3: コマンドのフラグをworldObjectEnableへ改名する
+
+**Files:**
+- Modify: `moorestech_client/Assets/AddressableResources/Skit/commands.yaml:189, 199`
+- Modify: `moorestech_client/Assets/AddressableResources/Skit/skits/100_start_game.json:132, 329`
+- Modify: `moorestech_client/Assets/AddressableResources/Skit/i18n/japanese.json:188, 193-194`
+- Modify: `moorestech_client/Assets/AddressableResources/Skit/i18n/english.json:133, 138-139`
+- Modify: `moorestech_client/Assets/Scripts/Client.Skit/Commands/InGameObjectControlCommand.cs`（`MapObjectEnable` → `WorldObjectEnable`）
+- Test: `moorestech_client/Assets/Scripts/Client.Tests/Localization/Skit/SkitLocalizationDictionaryCompletenessTest.cs:25-26`（baseline hash の更新）
+
+**Interfaces:**
+- Consumes: Task 1 で置いた `ISkitWorldObjectControl`
+- Produces: 生成プロパティ `InGameObjectControlCommand.WorldObjectEnable`（`commands.yaml` から SourceGenerator が生成。`Assets/Scripts/Client.Skit/csc.rsp` の `/additionalfile:Assets/AddressableResources/Skit/commands.yaml` 経由）
+
+- [ ] **Step 1: commands.yaml を書き換える**
+
+189行の `commandListLabelFormat` と 199行のプロパティ名を置換する:
+
+```yaml
+    commandListLabelFormat: "背景:{backgroundEnable} ブロック:{blockEnable} 世界オブジェクト:{worldObjectEnable} エンティティ:{entityEnable}"
+```
+
+```yaml
+      worldObjectEnable:
+        type: boolean
+        required: true
+```
+
+- [ ] **Step 2: スキットJSONを書き換える**
+
+`skits/100_start_game.json` の2箇所（132行 `"mapObjectEnable": false,` / 329行 `"mapObjectEnable": true,`）をキー名だけ `"worldObjectEnable"` へ置換する。値は変えない。
+
+```bash
+sed -i '' 's/"mapObjectEnable"/"worldObjectEnable"/g' moorestech_client/Assets/AddressableResources/Skit/skits/100_start_game.json
+grep -n "worldObjectEnable" moorestech_client/Assets/AddressableResources/Skit/skits/100_start_game.json
+```
+
+Expected: 2行ヒットする
+
+- [ ] **Step 3: i18n の2ファイルを書き換える**
+
+`i18n/japanese.json`:
+
+```json
+    "command.inGameObjectControl.description": "ゲーム内の背景・ブロック・世界オブジェクト（mapObject/露頭）・エンティティの表示を制御",
+    "command.inGameObjectControl.property.worldObjectEnable.name": "世界オブジェクト表示",
+    "command.inGameObjectControl.property.worldObjectEnable.description": "mapObjectと露頭の表示状態",
+```
+
+`i18n/english.json`:
+
+```json
+    "command.inGameObjectControl.description": "Control in-game background, block, world object (map object / outcrop) and entity visibility",
+    "command.inGameObjectControl.property.worldObjectEnable.name": "World Object Enable",
+    "command.inGameObjectControl.property.worldObjectEnable.description": "Map object and outcrop visibility state",
+```
+
+キーの並び順は既存位置（`blockEnable` の次）を維持する。
+
+- [ ] **Step 4: コマンドの参照プロパティ名を変える**
+
+`InGameObjectControlCommand.cs` の `ExecuteAsync` 内の該当行:
+
+```csharp
+            storyContext.GetService<ISkitWorldObjectControl>().SetActive(WorldObjectEnable);
+```
+
+- [ ] **Step 5: コンパイルする**
+
+Run: `uloop compile --project-path ./moorestech_client`
+Expected: errors 0（SourceGenerator が `WorldObjectEnable` を再生成する。`MapObjectEnable` が見つからないというエラーが出た場合は `commands.yaml` の保存漏れか Editor のリフレッシュ待ちなので、45秒待って再実行する）
+
+- [ ] **Step 6: ローカライズ辞書テストを実行して baseline のズレを確認する**
+
+Run: `uloop run-tests --project-path ./moorestech_client --test-mode EditMode --filter-type regex --filter-value "SkitLocalizationDictionaryCompletenessTest"`
+Expected: `CommandForgeDictionaryKeepsRootFlatTranslationsAndBaselineValues` が hash 不一致で FAIL する（キー名が変わったため）。失敗メッセージの Actual 値（english / japanese それぞれの64桁hex）を控える。件数（english 143 / japanese 208）は1:1リネームなので変わらない — 件数側が変わっていたらキーの追加・削除ミスなので先にそちらを直す
+
+- [ ] **Step 7: baseline hash を更新する**
+
+`SkitLocalizationDictionaryCompletenessTest.cs:25-26` の `TestCase` 属性2行の hash を Step 6 で控えた Actual 値へ置換し、直上のコメントを実態に合わせる:
+
+```csharp
+        // count/hashはworldObjectEnableへの改名後のroot値とソート済みCommandForge key/valueを正本とする
+        // Baseline is the post-worldObjectEnable-rename root values and sorted CommandForge key/value pairs
+        [TestCase("english", 143, "<Step 6 で控えたenglishのhash>")]
+        [TestCase("japanese", 208, "<Step 6 で控えたjapaneseのhash>")]
+```
+
+- [ ] **Step 8: スキット系テストを実行して通ることを確認する**
+
+Run: `uloop run-tests --project-path ./moorestech_client --test-mode EditMode --filter-type regex --filter-value "Skit"`
+Expected: 全 PASS（`SkitLocalizationDictionaryCompletenessTest` の `RuntimeSkitKeysMatchAssetBasenamesAndSchemaFields` と `AllTranslationValuesAreNonEmpty` を含む）
+
+- [ ] **Step 9: 旧名の残骸が無いことを確認する**
+
+Run: `grep -rn "mapObjectEnable\|MapObjectEnable\|ISkitMapObjectControl" --include='*.cs' --include='*.json' --include='*.yaml' . | grep -v '/Library/' | grep -v '^./docs/' | grep -v '^./.decisions/' | grep -v '^./.superpowers/'`
+Expected: 0件
+
+- [ ] **Step 10: コミットする**
+
+```bash
+git add moorestech_client/Assets/AddressableResources/Skit \
+        moorestech_client/Assets/Scripts/Client.Skit/Commands/InGameObjectControlCommand.cs \
+        moorestech_client/Assets/Scripts/Client.Tests/Localization/Skit/SkitLocalizationDictionaryCompletenessTest.cs
+git commit -m "refactor(skit): inGameObjectControlのフラグをworldObjectEnableへ改名"
+```
+
+---
+
+### Task 4: 開幕スキットを実走して露頭が消えることを録画で確認する
+
+**Files:**
+- Create: `.claude/skills/unity-playmode-recorded-playtest/scenarios/misc/skit-opening-world-hidden.cs`
+
+**Interfaces:**
+- Consumes: Task 2・Task 3 の実装一式
+- Produces: 実行成果物（`result.json` / mp4 / スクリーンショット）。コードは生まない
+
+- [ ] **Step 1: シナリオを書く**
+
+`.claude/skills/unity-playmode-recorded-playtest/scenarios/misc/skit-opening-world-hidden.cs` を新規作成する。**開幕スキットを Skip しない**のがこのシナリオの要点:
+
+```csharp
+using Client.Game.InGame.Map.Outcrop;
+using Client.Playtest;
+using Client.Skit.UI;
+using Cysharp.Threading.Tasks;
+using UnityEngine;
+
+var options = new PlaytestRunOptions { Record = true };
+return PlaytestRunner.Run("skit-opening-world-hidden", options, async p =>
+{
+    await p.SetupDebugEnvironment(new PlaytestEnvironmentConfig());
+
+    // 検証対象が開幕スキットそのものなのでSkipOpeningSkitは呼ばない
+    // The opening skit itself is under test, so SkipOpeningSkit is deliberately not called
+    p.Note("開幕スキットをオート送りで宇宙カットまで進める");
+
+    var skitStore = SkitPresentationStateStore.Instance;
+    await p.Until(() => skitStore.GetCurrent() != null, 60f, "スキット開始待ち");
+
+    var started = skitStore.GetCurrent();
+    skitStore.TrySetAuto(started.SessionId, started.SceneRevision, true);
+
+    var outcropDatastore = Object.FindObjectOfType<OutcropGameObjectDatastore>(true);
+    p.Assert(outcropDatastore != null, "露頭datastoreがシーンに存在する");
+
+    // オートが効かない場合に備え、poll毎にAdvanceインテントも打つ
+    // Also fire an advance intent on every poll in case auto mode does not take
+    await p.Until(() =>
+    {
+        var current = skitStore.GetCurrent();
+        if (current != null) skitStore.TryAdvance(current.SessionId, current.SceneRevision);
+        return !outcropDatastore.gameObject.activeSelf;
+    }, 180f, "世界非表示カットで露頭rootが非表示になる");
+
+    await p.Screenshot("01-space-cut-without-outcrop");
+
+    await p.Until(() =>
+    {
+        var current = skitStore.GetCurrent();
+        if (current != null) skitStore.TryAdvance(current.SessionId, current.SceneRevision);
+        return outcropDatastore.gameObject.activeSelf;
+    }, 180f, "復帰カットで露頭rootが再表示される");
+
+    await p.Screenshot("02-world-restored-with-outcrop");
+});
+```
+
+- [ ] **Step 2: シナリオを実行する**
+
+Run: `.claude/skills/unity-playmode-recorded-playtest/scripts/run-scenario.sh .claude/skills/unity-playmode-recorded-playtest/scenarios/misc/skit-opening-world-hidden.cs`
+（引数の渡し方が異なる場合は `.claude/skills/unity-playmode-recorded-playtest/references/run-scenario.md` に従う）
+Expected: `result.json` の assert / until がすべて ok。タイムアウトで落ちる場合は `references/troubleshooting.md` を参照する
+
+- [ ] **Step 3: 録画とスクリーンショットを目視する**
+
+`01-space-cut-without-outcrop` に露頭（岩の露出）が1つも写っていないこと、`02-world-restored-with-outcrop` で世界が戻っていることを確認する。mp4 も宇宙カット前後を再生して確認する。
+
+- [ ] **Step 4: 結果を記録してコミットする**
+
+```bash
+bd note moorestech-kvl "録画実走で確認: 宇宙カットに露頭なし / 復帰後に再表示。scenario=misc/skit-opening-world-hidden.cs"
+git add .claude/skills/unity-playmode-recorded-playtest/scenarios/misc/skit-opening-world-hidden.cs
+git commit -m "test(playtest): 開幕スキットの世界非表示で露頭が消えることを実走検証するシナリオを追加"
+```
+
+---
+
+### Task 5: 全ブランチレビュー（省略不可）
+
+**Files:** なし（レビュー実行のみ）
+
+- [ ] **Step 1: moores-code-review を実行する**
+
+`moores-code-review` スキルを起動し、`master...fix/skit-hide-outcrop-with-world-objects` の全差分をレビューする。ゴール達成を理由に省略してはならない。
+
+- [ ] **Step 2: 指摘へ対応する**
+
+機械的修正は適用し、設計判断は AskUserQuestion で裁定を仰ぐ。修正後は `uloop compile` と Task 1〜3 のテストを再実行する。
+
+- [ ] **Step 3: 作業を全てコミットする**
+
+```bash
+git status   # 未コミットの変更が無いことを確認
+```
+
+---
+
+## 判断記録（ADR）
+
+- 設計 ADR: [docs/adr/0016-skit-hides-world-objects-through-shared-interface.md](../../adr/0016-skit-hides-world-objects-through-shared-interface.md)
+- 裁定レコード: `.decisions/2026-08-18-スキットの世界非表示は共通interfaceへ載せ替える.md` / `.decisions/2026-08-18-inGameObjectControlのフラグをworldObjectEnableへ改名する.md` / `.decisions/2026-08-18-スキット非表示の束にentityは含めない.md`
+- 調査・タスク: bd `moorestech-kvl`（本体）/ bd `moorestech-h4j`（スコープ外に切り出したUIステートの穴）
+
+planning中に生じた判断:
+
+- **Task 1 でクラス宣言と SkitManager を暫定追従させる**: `ISkitMapObjectControl` を削除するとコンパイルが割れるため、interface 置換と最小追従を同一タスクに畳んだ。出所: agent前提（各タスクをコンパイルグリーンで閉じるという writing-plans の原則）
+- **yaml リネームを C# 載せ替えと別タスクにした**: 名前変更は生成プロパティ経由で必ず一斉に効くため分割不能に見えるが、Task 2 までは旧プロパティ名 `MapObjectEnable` を新 interface へ流すことで両タスクとも green のまま閉じられる。出所: agent前提
+- **検証シナリオで `SkipOpeningSkit()` を呼ばない**: プレイテストDSLの定型2行目だが、本件は開幕スキット自体が検証対象。出所: agent前提（ユーザー裁定「unityプレイ録画テストで実走確認する」の実現手段）
+- **ローカライズ baseline hash はテスト失敗の Actual から取る**: hash は root 値＋ソート済み key/value から計算されるため手計算しない。出所: agent前提（`SkitLocalizationDictionaryCompletenessTest` の実装）

--- a/docs/superpowers/plans/2026-08-18-skit-world-object-control.md
+++ b/docs/superpowers/plans/2026-08-18-skit-world-object-control.md
@@ -52,7 +52,7 @@
   - `CommandForgeGenerator.Command.ISkitWorldObjectControl`（`void SetActive(bool enable)`）
   - `Client.Game.Skit.SkitWorldObjectControlGroup`（ctor: `SkitWorldObjectControlGroup(IReadOnlyList<ISkitWorldObjectControl> worldObjectControls)` / `void SetActive(bool enable)`）
 
-- [ ] **Step 1: 失敗するテストを書く**
+- [x] **Step 1: 失敗するテストを書く**
 
 `moorestech_client/Assets/Scripts/Client.Tests/Skit/SkitWorldObjectControlGroupTest.cs` を新規作成する:
 
@@ -102,12 +102,12 @@ namespace Client.Tests.Skit
 }
 ```
 
-- [ ] **Step 2: テストを実行して失敗を確認する**
+- [x] **Step 2: テストを実行して失敗を確認する**
 
 Run: `uloop run-tests --project-path ./moorestech_client --test-mode EditMode --filter-type regex --filter-value "SkitWorldObjectControlGroupTest"`
 Expected: コンパイルエラー（`ISkitWorldObjectControl` / `SkitWorldObjectControlGroup` が存在しない）で実行に至らない
 
-- [ ] **Step 3: interfaceを置換する**
+- [x] **Step 3: interfaceを置換する**
 
 `InGameObjectControlCommand.cs` の `ISkitMapObjectControl` 宣言（16-19行）を差し替え、`ExecuteAsync` の該当行も同時に新 interface へ向ける:
 
@@ -130,7 +130,7 @@ Expected: コンパイルエラー（`ISkitWorldObjectControl` / `SkitWorldObjec
 
 （`MapObjectEnable` は Task 3 で `WorldObjectEnable` へリネームする。この時点では `commands.yaml` が旧名のままなので生成プロパティ名も旧名である）
 
-- [ ] **Step 4: compositeを実装する**
+- [x] **Step 4: compositeを実装する**
 
 `moorestech_client/Assets/Scripts/Client.Game/Skit/SkitWorldObjectControlGroup.cs` を新規作成する:
 
@@ -161,7 +161,7 @@ namespace Client.Game.Skit
 }
 ```
 
-- [ ] **Step 5: SkitManagerとMapObjectGameObjectDatastoreの参照を暫定で合わせてコンパイルを通す**
+- [x] **Step 5: SkitManagerとMapObjectGameObjectDatastoreの参照を暫定で合わせてコンパイルを通す**
 
 `ISkitMapObjectControl` が消えたことで2箇所が壊れる。Task 2 で本実装するが、このタスクをコンパイルグリーンで閉じるため、ここで最小の追従を行う:
 
@@ -172,17 +172,17 @@ namespace Client.Game.Skit
                 builder.RegisterInstance<ISkitWorldObjectControl>(mapObjectGameObjectDatastore);
 ```
 
-- [ ] **Step 6: コンパイルする**
+- [x] **Step 6: コンパイルする**
 
 Run: `uloop compile --project-path ./moorestech_client`
 Expected: errors 0
 
-- [ ] **Step 7: テストを実行して通ることを確認する**
+- [x] **Step 7: テストを実行して通ることを確認する**
 
 Run: `uloop run-tests --project-path ./moorestech_client --test-mode EditMode --filter-type regex --filter-value "SkitWorldObjectControlGroupTest"`
 Expected: 2 tests PASS
 
-- [ ] **Step 8: コミットする**
+- [x] **Step 8: コミットする**
 
 ```bash
 git add moorestech_client/Assets/Scripts/Client.Skit/Commands/InGameObjectControlCommand.cs \
@@ -209,7 +209,7 @@ git commit -m "feat(skit): Environment外の世界オブジェクトを束ねる
 - Consumes: `CommandForgeGenerator.Command.ISkitWorldObjectControl` / `Client.Game.Skit.SkitWorldObjectControlGroup`（Task 1）
 - Produces: `OutcropGameObjectDatastore.SetActive(bool enable)`（`ISkitWorldObjectControl` 実装）
 
-- [ ] **Step 1: 失敗するテストを書く**
+- [x] **Step 1: 失敗するテストを書く**
 
 `moorestech_client/Assets/Scripts/Client.Tests/Skit/OutcropGameObjectDatastoreSkitVisibilityTest.cs` を新規作成する:
 
@@ -258,12 +258,12 @@ namespace Client.Tests.Skit
 }
 ```
 
-- [ ] **Step 2: テストを実行して失敗を確認する**
+- [x] **Step 2: テストを実行して失敗を確認する**
 
 Run: `uloop run-tests --project-path ./moorestech_client --test-mode EditMode --filter-type regex --filter-value "OutcropGameObjectDatastoreSkitVisibilityTest"`
 Expected: コンパイルエラー（`OutcropGameObjectDatastore` に `SetActive` が無い）
 
-- [ ] **Step 3: 露頭datastoreにinterfaceを実装する**
+- [x] **Step 3: 露頭datastoreにinterfaceを実装する**
 
 `OutcropGameObjectDatastore.cs:21` のクラス宣言を置換する:
 
@@ -280,7 +280,7 @@ Expected: コンパイルエラー（`OutcropGameObjectDatastore` に `SetActive
         }
 ```
 
-- [ ] **Step 4: SkitManagerをcomposite登録へ切り替える**
+- [x] **Step 4: SkitManagerをcomposite登録へ切り替える**
 
 `SkitManager.cs:37` の `[Inject] private MapObjectGameObjectDatastore mapObjectGameObjectDatastore;` を削除し、代わりに `worldPins` の隣へ追加する:
 
@@ -296,7 +296,7 @@ Expected: コンパイルエラー（`OutcropGameObjectDatastore` に `SetActive
 
 `using Client.Game.InGame.Map.MapObject;` が他で使われていなければ削除する（コンパイル警告ではなく未使用using整理として。使われていれば残す）。
 
-- [ ] **Step 5: MainGameStarterのDI登録に新interfaceを足す**
+- [x] **Step 5: MainGameStarterのDI登録に新interfaceを足す**
 
 `MainGameStarter.cs:307-308` を置換する:
 
@@ -307,7 +307,7 @@ Expected: コンパイルエラー（`OutcropGameObjectDatastore` に `SetActive
 
 `using CommandForgeGenerator.Command;` が無ければ using 群へ追加する。
 
-- [ ] **Step 6: SkitTesterへ露頭ダミーを足す**
+- [x] **Step 6: SkitTesterへ露頭ダミーを足す**
 
 `SkitTester.cs` の「テストシーンにmapObject/エンティティは存在しないので〜」ブロックを置換する:
 
@@ -327,17 +327,17 @@ Expected: コンパイルエラー（`OutcropGameObjectDatastore` に `SetActive
 
 using へ `using Client.Game.InGame.Map.Outcrop;` と `using CommandForgeGenerator.Command;` を追加する。
 
-- [ ] **Step 7: コンパイルする**
+- [x] **Step 7: コンパイルする**
 
 Run: `uloop compile --project-path ./moorestech_client`
 Expected: errors 0
 
-- [ ] **Step 8: テストを実行して通ることを確認する**
+- [x] **Step 8: テストを実行して通ることを確認する**
 
 Run: `uloop run-tests --project-path ./moorestech_client --test-mode EditMode --filter-type regex --filter-value "OutcropGameObjectDatastoreSkitVisibilityTest|SkitWorldObjectControlGroupTest|SkitFailureCleanupTest"`
 Expected: 全 PASS
 
-- [ ] **Step 9: コミットする**
+- [x] **Step 9: コミットする**
 
 ```bash
 git add moorestech_client/Assets/Scripts/Client.Game/InGame/Map/Outcrop/OutcropGameObjectDatastore.cs \
@@ -364,7 +364,7 @@ git commit -m "fix(skit): 露頭をISkitWorldObjectControlへ載せスキット�
 - Consumes: Task 1 で置いた `ISkitWorldObjectControl`
 - Produces: 生成プロパティ `InGameObjectControlCommand.WorldObjectEnable`（`commands.yaml` から SourceGenerator が生成。`Assets/Scripts/Client.Skit/csc.rsp` の `/additionalfile:Assets/AddressableResources/Skit/commands.yaml` 経由）
 
-- [ ] **Step 1: commands.yaml を書き換える**
+- [x] **Step 1: commands.yaml を書き換える**
 
 189行の `commandListLabelFormat` と 199行のプロパティ名を置換する:
 
@@ -378,7 +378,7 @@ git commit -m "fix(skit): 露頭をISkitWorldObjectControlへ載せスキット�
         required: true
 ```
 
-- [ ] **Step 2: スキットJSONを書き換える**
+- [x] **Step 2: スキットJSONを書き換える**
 
 `skits/100_start_game.json` の2箇所（132行 `"mapObjectEnable": false,` / 329行 `"mapObjectEnable": true,`）をキー名だけ `"worldObjectEnable"` へ置換する。値は変えない。
 
@@ -389,7 +389,7 @@ grep -n "worldObjectEnable" moorestech_client/Assets/AddressableResources/Skit/s
 
 Expected: 2行ヒットする
 
-- [ ] **Step 3: i18n の2ファイルを書き換える**
+- [x] **Step 3: i18n の2ファイルを書き換える**
 
 `i18n/japanese.json`:
 
@@ -409,7 +409,7 @@ Expected: 2行ヒットする
 
 キーの並び順は既存位置（`blockEnable` の次）を維持する。
 
-- [ ] **Step 4: コマンドの参照プロパティ名を変える**
+- [x] **Step 4: コマンドの参照プロパティ名を変える**
 
 `InGameObjectControlCommand.cs` の `ExecuteAsync` 内の該当行:
 
@@ -417,17 +417,17 @@ Expected: 2行ヒットする
             storyContext.GetService<ISkitWorldObjectControl>().SetActive(WorldObjectEnable);
 ```
 
-- [ ] **Step 5: コンパイルする**
+- [x] **Step 5: コンパイルする**
 
 Run: `uloop compile --project-path ./moorestech_client`
 Expected: errors 0（SourceGenerator が `WorldObjectEnable` を再生成する。`MapObjectEnable` が見つからないというエラーが出た場合は `commands.yaml` の保存漏れか Editor のリフレッシュ待ちなので、45秒待って再実行する）
 
-- [ ] **Step 6: ローカライズ辞書テストを実行して baseline のズレを確認する**
+- [x] **Step 6: ローカライズ辞書テストを実行して baseline のズレを確認する**
 
 Run: `uloop run-tests --project-path ./moorestech_client --test-mode EditMode --filter-type regex --filter-value "SkitLocalizationDictionaryCompletenessTest"`
 Expected: `CommandForgeDictionaryKeepsRootFlatTranslationsAndBaselineValues` が hash 不一致で FAIL する（キー名が変わったため）。失敗メッセージの Actual 値（english / japanese それぞれの64桁hex）を控える。件数（english 143 / japanese 208）は1:1リネームなので変わらない — 件数側が変わっていたらキーの追加・削除ミスなので先にそちらを直す
 
-- [ ] **Step 7: baseline hash を更新する**
+- [x] **Step 7: baseline hash を更新する**
 
 `SkitLocalizationDictionaryCompletenessTest.cs:25-26` の `TestCase` 属性2行の hash を Step 6 で控えた Actual 値へ置換し、直上のコメントを実態に合わせる:
 
@@ -438,17 +438,17 @@ Expected: `CommandForgeDictionaryKeepsRootFlatTranslationsAndBaselineValues` が
         [TestCase("japanese", 208, "<Step 6 で控えたjapaneseのhash>")]
 ```
 
-- [ ] **Step 8: スキット系テストを実行して通ることを確認する**
+- [x] **Step 8: スキット系テストを実行して通ることを確認する**
 
 Run: `uloop run-tests --project-path ./moorestech_client --test-mode EditMode --filter-type regex --filter-value "Skit"`
 Expected: 全 PASS（`SkitLocalizationDictionaryCompletenessTest` の `RuntimeSkitKeysMatchAssetBasenamesAndSchemaFields` と `AllTranslationValuesAreNonEmpty` を含む）
 
-- [ ] **Step 9: 旧名の残骸が無いことを確認する**
+- [x] **Step 9: 旧名の残骸が無いことを確認する**
 
 Run: `grep -rn "mapObjectEnable\|MapObjectEnable\|ISkitMapObjectControl" --include='*.cs' --include='*.json' --include='*.yaml' . | grep -v '/Library/' | grep -v '^./docs/' | grep -v '^./.decisions/' | grep -v '^./.superpowers/'`
 Expected: 0件
 
-- [ ] **Step 10: コミットする**
+- [x] **Step 10: コミットする**
 
 ```bash
 git add moorestech_client/Assets/AddressableResources/Skit \
@@ -468,7 +468,7 @@ git commit -m "refactor(skit): inGameObjectControlのフラグをworldObjectEnab
 - Consumes: Task 2・Task 3 の実装一式
 - Produces: 実行成果物（`result.json` / mp4 / スクリーンショット）。コードは生まない
 
-- [ ] **Step 1: シナリオを書く**
+- [x] **Step 1: シナリオを書く**
 
 `.claude/skills/unity-playmode-recorded-playtest/scenarios/misc/skit-opening-world-hidden.cs` を新規作成する。**開幕スキットを Skip しない**のがこのシナリオの要点:
 
@@ -519,17 +519,17 @@ return PlaytestRunner.Run("skit-opening-world-hidden", options, async p =>
 });
 ```
 
-- [ ] **Step 2: シナリオを実行する**
+- [x] **Step 2: シナリオを実行する**
 
 Run: `.claude/skills/unity-playmode-recorded-playtest/scripts/run-scenario.sh .claude/skills/unity-playmode-recorded-playtest/scenarios/misc/skit-opening-world-hidden.cs`
 （引数の渡し方が異なる場合は `.claude/skills/unity-playmode-recorded-playtest/references/run-scenario.md` に従う）
 Expected: `result.json` の assert / until がすべて ok。タイムアウトで落ちる場合は `references/troubleshooting.md` を参照する
 
-- [ ] **Step 3: 録画とスクリーンショットを目視する**
+- [x] **Step 3: 録画とスクリーンショットを目視する**
 
 `01-space-cut-without-outcrop` に露頭（岩の露出）が1つも写っていないこと、`02-world-restored-with-outcrop` で世界が戻っていることを確認する。mp4 も宇宙カット前後を再生して確認する。
 
-- [ ] **Step 4: 結果を記録してコミットする**
+- [x] **Step 4: 結果を記録してコミットする**
 
 ```bash
 bd note moorestech-kvl "録画実走で確認: 宇宙カットに露頭なし / 復帰後に再表示。scenario=misc/skit-opening-world-hidden.cs"

--- a/moorestech_client/Assets/AddressableResources/Skit/commands.yaml
+++ b/moorestech_client/Assets/AddressableResources/Skit/commands.yaml
@@ -186,7 +186,7 @@ commands:
 
   - id: inGameObjectControl
     label: ゲーム内オブジェクト制御
-    commandListLabelFormat: "背景:{backgroundEnable} ブロック:{blockEnable} mapObject:{mapObjectEnable} エンティティ:{entityEnable}"
+    commandListLabelFormat: "背景:{backgroundEnable} ブロック:{blockEnable} 世界オブジェクト:{worldObjectEnable} エンティティ:{entityEnable}"
     category: ["環境"]
     defaultBackgroundColor: "#ffffff"
     properties:
@@ -196,7 +196,7 @@ commands:
       blockEnable:
         type: boolean
         required: true
-      mapObjectEnable:
+      worldObjectEnable:
         type: boolean
         required: true
       entityEnable:

--- a/moorestech_client/Assets/AddressableResources/Skit/i18n/english.json
+++ b/moorestech_client/Assets/AddressableResources/Skit/i18n/english.json
@@ -130,13 +130,13 @@
     "command.motion.property.mixerDuration.description": "Time to blend animations (seconds)",
 
     "command.inGameObjectControl.name": "In-Game Object Control",
-    "command.inGameObjectControl.description": "Control in-game background, block, map object and entity visibility",
+    "command.inGameObjectControl.description": "Control in-game background, block, world object (map object / outcrop) and entity visibility",
     "command.inGameObjectControl.property.backgroundEnable.name": "Background Enable",
     "command.inGameObjectControl.property.backgroundEnable.description": "Background object visibility state",
     "command.inGameObjectControl.property.blockEnable.name": "Block Enable",
     "command.inGameObjectControl.property.blockEnable.description": "Block object visibility state",
-    "command.inGameObjectControl.property.mapObjectEnable.name": "Map Object Enable",
-    "command.inGameObjectControl.property.mapObjectEnable.description": "Map object visibility state",
+    "command.inGameObjectControl.property.worldObjectEnable.name": "World Object Enable",
+    "command.inGameObjectControl.property.worldObjectEnable.description": "Map object and outcrop visibility state",
     "command.inGameObjectControl.property.entityEnable.name": "Entity Enable",
     "command.inGameObjectControl.property.entityEnable.description": "Entity visibility state such as dropped items and trains",
     

--- a/moorestech_client/Assets/AddressableResources/Skit/i18n/english.json
+++ b/moorestech_client/Assets/AddressableResources/Skit/i18n/english.json
@@ -136,9 +136,9 @@
     "command.inGameObjectControl.property.blockEnable.name": "Block Enable",
     "command.inGameObjectControl.property.blockEnable.description": "Block object visibility state",
     "command.inGameObjectControl.property.worldObjectEnable.name": "World Object Enable",
-    "command.inGameObjectControl.property.worldObjectEnable.description": "Map object and outcrop visibility state",
+    "command.inGameObjectControl.property.worldObjectEnable.description": "Map object, outcrop, and train visibility state",
     "command.inGameObjectControl.property.entityEnable.name": "Entity Enable",
-    "command.inGameObjectControl.property.entityEnable.description": "Entity visibility state such as dropped items and trains",
+    "command.inGameObjectControl.property.entityEnable.description": "Entity visibility state such as dropped items",
     
     "command.controlSkitBackground.name": "Control Skit Background",
     "command.controlSkitBackground.description": "Add or remove skit background",

--- a/moorestech_client/Assets/AddressableResources/Skit/i18n/japanese.json
+++ b/moorestech_client/Assets/AddressableResources/Skit/i18n/japanese.json
@@ -185,13 +185,13 @@
     "command.cameraWarp.property.Rotation.description": "設定回転",
 
     "command.inGameObjectControl.name": "ゲーム内オブジェクト制御",
-    "command.inGameObjectControl.description": "ゲーム内の背景・ブロック・mapObject・エンティティの表示を制御",
+    "command.inGameObjectControl.description": "ゲーム内の背景・ブロック・世界オブジェクト（mapObject/露頭）・エンティティの表示を制御",
     "command.inGameObjectControl.property.backgroundEnable.name": "背景表示",
     "command.inGameObjectControl.property.backgroundEnable.description": "背景オブジェクトの表示状態",
     "command.inGameObjectControl.property.blockEnable.name": "ブロック表示",
     "command.inGameObjectControl.property.blockEnable.description": "ブロックオブジェクトの表示状態",
-    "command.inGameObjectControl.property.mapObjectEnable.name": "mapObject表示",
-    "command.inGameObjectControl.property.mapObjectEnable.description": "mapObjectの表示状態",
+    "command.inGameObjectControl.property.worldObjectEnable.name": "世界オブジェクト表示",
+    "command.inGameObjectControl.property.worldObjectEnable.description": "mapObjectと露頭の表示状態",
     "command.inGameObjectControl.property.entityEnable.name": "エンティティ表示",
     "command.inGameObjectControl.property.entityEnable.description": "ドロップアイテムや列車などエンティティの表示状態",
 

--- a/moorestech_client/Assets/AddressableResources/Skit/i18n/japanese.json
+++ b/moorestech_client/Assets/AddressableResources/Skit/i18n/japanese.json
@@ -191,9 +191,9 @@
     "command.inGameObjectControl.property.blockEnable.name": "ブロック表示",
     "command.inGameObjectControl.property.blockEnable.description": "ブロックオブジェクトの表示状態",
     "command.inGameObjectControl.property.worldObjectEnable.name": "世界オブジェクト表示",
-    "command.inGameObjectControl.property.worldObjectEnable.description": "mapObjectと露頭の表示状態",
+    "command.inGameObjectControl.property.worldObjectEnable.description": "mapObject・露頭・列車の表示状態",
     "command.inGameObjectControl.property.entityEnable.name": "エンティティ表示",
-    "command.inGameObjectControl.property.entityEnable.description": "ドロップアイテムや列車などエンティティの表示状態",
+    "command.inGameObjectControl.property.entityEnable.description": "ドロップアイテムなどエンティティの表示状態",
 
     "command.controlSkitBackground.name": "スキット背景を制御",
     "command.controlSkitBackground.description": "スキットの背景を追加または削除",

--- a/moorestech_client/Assets/AddressableResources/Skit/skits/100_start_game.json
+++ b/moorestech_client/Assets/AddressableResources/Skit/skits/100_start_game.json
@@ -129,7 +129,7 @@
       "backgroundColor": "#ffffff",
       "backgroundEnable": false,
       "blockEnable": false,
-      "mapObjectEnable": false,
+      "worldObjectEnable": false,
       "entityEnable": false,
       "id": 70
     },
@@ -326,7 +326,7 @@
       "backgroundColor": "#ffffff",
       "backgroundEnable": true,
       "blockEnable": true,
-      "mapObjectEnable": true,
+      "worldObjectEnable": true,
       "entityEnable": true,
       "id": 71
     },

--- a/moorestech_client/Assets/Scripts/Client.DebugSystem/Skit/SkitTester.cs
+++ b/moorestech_client/Assets/Scripts/Client.DebugSystem/Skit/SkitTester.cs
@@ -3,11 +3,13 @@ using Client.Game.InGame.Block;
 using Client.Game.InGame.Entity;
 using Client.Game.InGame.Environment;
 using Client.Game.InGame.Map.MapObject;
+using Client.Game.InGame.Map.Outcrop;
 using Client.Game.InGame.Skit;
 using Client.Game.InGame.Tutorial;
 using Client.Game.Skit;
 using Client.Skit.Skit;
 using Client.Skit.UI;
+using CommandForgeGenerator.Command;
 using Cysharp.Threading.Tasks;
 using Server.Boot;
 using UnityEngine;
@@ -46,14 +48,16 @@ namespace Client.DebugSystem.Skit
             // SkitManager suppresses pins as a whole through IReadOnlyList<ITutorialWorldPin>
             builder.RegisterInstance<IReadOnlyList<ITutorialWorldPin>>(new List<ITutorialWorldPin> { new MapObjectTest() });
 
-            // テストシーンにmapObject/エンティティは存在しないのでSetActive先の空オブジェクトだけ用意する
-            // The test scene has no map objects or entities, so provide empty objects purely as SetActive targets
+            // テストシーンにmapObject/露頭/エンティティは存在しないのでSetActive先の空オブジェクトだけ用意する
+            // The test scene has no map objects, outcrops, or entities, so provide empty objects purely as SetActive targets
             var mapObjectDatastore = CreateChildComponent<MapObjectGameObjectDatastore>();
+            var outcropDatastore = CreateChildComponent<OutcropGameObjectDatastore>();
             var entityObjectDatastore = CreateChildComponent<EntityObjectDatastore>();
 
             // RegisterComponentはビルド時に強制Resolveしサーバ応答必須のConstructを走らせるためRegisterInstanceを使う
             // RegisterComponent force-resolves at build time and would run Construct, which needs a server response, so use RegisterInstance
-            builder.RegisterInstance(mapObjectDatastore);
+            builder.RegisterInstance(mapObjectDatastore).AsSelf().As<ISkitWorldObjectControl>();
+            builder.RegisterInstance(outcropDatastore).AsSelf().As<ISkitWorldObjectControl>();
             builder.RegisterInstance(entityObjectDatastore);
 
             // 依存関係を解決

--- a/moorestech_client/Assets/Scripts/Client.DebugSystem/Skit/SkitTester.cs
+++ b/moorestech_client/Assets/Scripts/Client.DebugSystem/Skit/SkitTester.cs
@@ -48,8 +48,8 @@ namespace Client.DebugSystem.Skit
             // SkitManager suppresses pins as a whole through IReadOnlyList<ITutorialWorldPin>
             builder.RegisterInstance<IReadOnlyList<ITutorialWorldPin>>(new List<ITutorialWorldPin> { new MapObjectTest() });
 
-            // SetActive用の空ダミーのみ用意
-            // Prepare only empty dummies as SetActive targets
+            // テストシーンに実体が無いためSetActive先の空ダミーのみ用意
+            // The test scene has no real objects, so provide empty dummies purely as SetActive targets
             var mapObjectDatastore = CreateChildComponent<MapObjectGameObjectDatastore>();
             var outcropDatastore = CreateChildComponent<OutcropGameObjectDatastore>();
             var entityObjectDatastore = CreateChildComponent<EntityObjectDatastore>();

--- a/moorestech_client/Assets/Scripts/Client.DebugSystem/Skit/SkitTester.cs
+++ b/moorestech_client/Assets/Scripts/Client.DebugSystem/Skit/SkitTester.cs
@@ -48,8 +48,8 @@ namespace Client.DebugSystem.Skit
             // SkitManager suppresses pins as a whole through IReadOnlyList<ITutorialWorldPin>
             builder.RegisterInstance<IReadOnlyList<ITutorialWorldPin>>(new List<ITutorialWorldPin> { new MapObjectTest() });
 
-            // テストシーンにmapObject/露頭/エンティティは存在しないのでSetActive先の空オブジェクトだけ用意する
-            // The test scene has no map objects, outcrops, or entities, so provide empty objects purely as SetActive targets
+            // SetActive用の空ダミーのみ用意
+            // Prepare only empty dummies as SetActive targets
             var mapObjectDatastore = CreateChildComponent<MapObjectGameObjectDatastore>();
             var outcropDatastore = CreateChildComponent<OutcropGameObjectDatastore>();
             var entityObjectDatastore = CreateChildComponent<EntityObjectDatastore>();

--- a/moorestech_client/Assets/Scripts/Client.Game/AssemblyInfo.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Client.Tests")]

--- a/moorestech_client/Assets/Scripts/Client.Game/AssemblyInfo.cs.meta
+++ b/moorestech_client/Assets/Scripts/Client.Game/AssemblyInfo.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 85e8a02f6a6474a10aab0ad3c5dbfcd8

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/Map/MapObject/MapObjectGameObjectDatastore.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/Map/MapObject/MapObjectGameObjectDatastore.cs
@@ -19,7 +19,7 @@ namespace Client.Game.InGame.Map.MapObject
     ///     mapObjectをLayout応答から実行時Instantiateし、破壊/HPの状態同期を担うデータストア
     ///     Instantiates map objects at runtime from the layout response and keeps their destroy/HP state synced
     /// </summary>
-    public class MapObjectGameObjectDatastore : MonoBehaviour, IInitialEventApplyWaitTarget, ISkitMapObjectControl
+    public class MapObjectGameObjectDatastore : MonoBehaviour, IInitialEventApplyWaitTarget, ISkitWorldObjectControl
     {
         // 2011個規模の起動スパイクを避けるためこの個数ごとにフレームを跨ぐ
         // Cross a frame every this many objects to avoid a startup spike at the ~2011-object scale

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/Map/Outcrop/OutcropGameObjectDatastore.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/Map/Outcrop/OutcropGameObjectDatastore.cs
@@ -5,6 +5,7 @@ using Client.Common.Asset;
 using Client.Game.Common;
 using Client.Game.InGame.BlockSystem;
 using Client.Network.API;
+using CommandForgeGenerator.Command;
 using Core.Master;
 using Cysharp.Threading.Tasks;
 using Mooresmaster.Model.MapModule;
@@ -18,7 +19,7 @@ namespace Client.Game.InGame.Map.Outcrop
     ///     全鉱脈の露頭を生成
     ///     Create outcrops for all veins
     /// </summary>
-    public class OutcropGameObjectDatastore : MonoBehaviour, IInitialEventApplyWaitTarget
+    public class OutcropGameObjectDatastore : MonoBehaviour, IInitialEventApplyWaitTarget, ISkitWorldObjectControl
     {
         // 露頭名にveinGuidを付与し、どの鉱脈の露頭かをシーン上で辿れるようにする
         // Append the vein GUID to outcrop names so each one can be traced back to its vein in the scene
@@ -180,6 +181,11 @@ namespace Client.Game.InGame.Map.Outcrop
         public OutcropGameObject SearchNearestOutcrop(Guid veinGuid, Vector3 position)
         {
             return _outcropGuidIndex.SearchNearest(veinGuid, position);
+        }
+
+        public void SetActive(bool enable)
+        {
+            gameObject.SetActive(enable);
         }
     }
 }

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/Train/RailGraph/TrainRailObjectManager.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/Train/RailGraph/TrainRailObjectManager.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using CommandForgeGenerator.Command;
 using Cysharp.Threading.Tasks;
 using Game.Train.RailGraph;
 using Game.Train.RailCalc;
@@ -10,7 +11,7 @@ namespace Client.Game.InGame.Train.RailGraph
     ///     レールキャッシュ更新に追従するランタイム描画を管理するクラス
     ///     Manages runtime line renderers driven directly by rail cache updates
     /// </summary>
-    public sealed class TrainRailObjectManager : MonoBehaviour
+    public sealed class TrainRailObjectManager : MonoBehaviour, ISkitWorldObjectControl
     {
         public static TrainRailObjectManager Instance { get; private set; }
         [SerializeField] private BezierRailChain _railPrefab;
@@ -37,6 +38,13 @@ namespace Client.Game.InGame.Train.RailGraph
                 }
             }
             _railObjs.Clear();
+        }
+
+        // レール描画は自身の配下に生成されるため、スキット中は根ごと消す
+        // Rail renderers are created under this transform, so a skit hides them at the root
+        public void SetActive(bool enable)
+        {
+            gameObject.SetActive(enable);
         }
 
         internal void OnCacheRebuilt(RailGraphClientCache cache)

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/Train/View/Object/Core/TrainCarObjectDatastore.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/Train/View/Object/Core/TrainCarObjectDatastore.cs
@@ -1,11 +1,12 @@
 using System.Collections.Generic;
+using CommandForgeGenerator.Command;
 using Game.Train.Unit;
 using UnityEngine;
 using VContainer;
 
 namespace Client.Game.InGame.Train.View.Object.Core
 {
-    public class TrainCarObjectDatastore : MonoBehaviour
+    public class TrainCarObjectDatastore : MonoBehaviour, ISkitWorldObjectControl
     {
         private readonly Dictionary<TrainCarInstanceId, TrainCarEntityObject> _entities = new();
 
@@ -17,6 +18,13 @@ namespace Client.Game.InGame.Train.View.Object.Core
             // datastoreはfactoryを保持し、表示状態そのものは管理しない
             // The datastore holds the factory and does not manage visual state
             _carObjectFactory = new TrainCarObjectFactory();
+        }
+
+        // 車両viewは自身の配下に生成されるため、スキット中は根ごと消す
+        // Car views are created under this transform, so a skit hides them at the root
+        public void SetActive(bool enable)
+        {
+            gameObject.SetActive(enable);
         }
 
         public void OnTrainObjectUpdate(IReadOnlyList<TrainCarSnapshot> carSnapshots)

--- a/moorestech_client/Assets/Scripts/Client.Game/Skit/SkitManager.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/Skit/SkitManager.cs
@@ -73,6 +73,7 @@ namespace Client.Game.Skit
             var presentationStarted = false;
             var cameraRegistered = false;
             var suppressedWorldPins = new List<ITutorialWorldPin>();
+            SkitWorldObjectControlGroup worldObjectControlGroup = null;
             SkitLocalizationResolver localizationResolver = null;
             StoryContext storyContext = null;
             CharacterObjectContainer characterContainer = null;
@@ -152,7 +153,8 @@ namespace Client.Game.Skit
                 builder.RegisterInstance(characterContainer);
                 builder.RegisterInstance<ISkitEnvironmentRoot>(environmentRoot);
                 builder.RegisterInstance<ISkitBlockObjectControl>(blockGameObjectDataStore);
-                builder.RegisterInstance<ISkitWorldObjectControl>(new SkitWorldObjectControlGroup(worldObjectControls));
+                worldObjectControlGroup = new SkitWorldObjectControlGroup(worldObjectControls);
+                builder.RegisterInstance<ISkitWorldObjectControl>(worldObjectControlGroup);
                 builder.RegisterInstance<ISkitEntityObjectControl>(entityObjectDatastore);
                 builder.RegisterInstance<ISkitEnvironmentManager>(new SkitEnvironmentManager(transform));
                 builder.RegisterInstance<ISkitActionContext>(_skitActionController);
@@ -169,6 +171,7 @@ namespace Client.Game.Skit
                 skitUI.SetActive(false);
                 if (presentationStarted) SkitPresentationStateStore.Instance.End();
                 foreach (var suppressedWorldPin in suppressedWorldPins) suppressedWorldPin.EndSkitSuppress();
+                if (worldObjectControlGroup is { IsHidden: true }) worldObjectControlGroup.SetActive(true);
                 characterContainer?.DestroyAllCharacters();
                 if (cameraRegistered) CameraManager.UnRegisterCamera(skitCamera);
                 storyContext?.Dispose();

--- a/moorestech_client/Assets/Scripts/Client.Game/Skit/SkitManager.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/Skit/SkitManager.cs
@@ -5,7 +5,6 @@ using Client.Common.Asset;
 using Client.Game.InGame.Block;
 using Client.Game.InGame.Entity;
 using Client.Game.InGame.Environment;
-using Client.Game.InGame.Map.MapObject;
 using Client.Game.InGame.Tutorial;
 using Client.Game.InGame.UI.UIState;
 using Client.Game.Skit.Localization;
@@ -35,9 +34,9 @@ namespace Client.Game.Skit
         [Inject] private ISkitActionController _skitActionController;
         [Inject] private EnvironmentRoot environmentRoot;
         [Inject] private BlockGameObjectDataStore blockGameObjectDataStore;
-        [Inject] private MapObjectGameObjectDatastore mapObjectGameObjectDatastore;
         [Inject] private EntityObjectDatastore entityObjectDatastore;
         [Inject] private IReadOnlyList<ITutorialWorldPin> worldPins;
+        [Inject] private IReadOnlyList<ISkitWorldObjectControl> worldObjectControls;
         
         public bool IsPlayingSkit { get; private set; }
         private bool _isSkip;
@@ -153,7 +152,7 @@ namespace Client.Game.Skit
                 builder.RegisterInstance(characterContainer);
                 builder.RegisterInstance<ISkitEnvironmentRoot>(environmentRoot);
                 builder.RegisterInstance<ISkitBlockObjectControl>(blockGameObjectDataStore);
-                builder.RegisterInstance<ISkitWorldObjectControl>(mapObjectGameObjectDatastore);
+                builder.RegisterInstance<ISkitWorldObjectControl>(new SkitWorldObjectControlGroup(worldObjectControls));
                 builder.RegisterInstance<ISkitEntityObjectControl>(entityObjectDatastore);
                 builder.RegisterInstance<ISkitEnvironmentManager>(new SkitEnvironmentManager(transform));
                 builder.RegisterInstance<ISkitActionContext>(_skitActionController);

--- a/moorestech_client/Assets/Scripts/Client.Game/Skit/SkitManager.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/Skit/SkitManager.cs
@@ -153,7 +153,7 @@ namespace Client.Game.Skit
                 builder.RegisterInstance(characterContainer);
                 builder.RegisterInstance<ISkitEnvironmentRoot>(environmentRoot);
                 builder.RegisterInstance<ISkitBlockObjectControl>(blockGameObjectDataStore);
-                builder.RegisterInstance<ISkitMapObjectControl>(mapObjectGameObjectDatastore);
+                builder.RegisterInstance<ISkitWorldObjectControl>(mapObjectGameObjectDatastore);
                 builder.RegisterInstance<ISkitEntityObjectControl>(entityObjectDatastore);
                 builder.RegisterInstance<ISkitEnvironmentManager>(new SkitEnvironmentManager(transform));
                 builder.RegisterInstance<ISkitActionContext>(_skitActionController);

--- a/moorestech_client/Assets/Scripts/Client.Game/Skit/SkitManager.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/Skit/SkitManager.cs
@@ -55,13 +55,18 @@ namespace Client.Game.Skit
         
         public async UniTask StartSkit(string addressablePath)
         {
+            // ロードのawaitを跨ぐ前に再生中を立て、多重起動が互いの世界復元を奪い合うのを防ぐ
+            // Raise the playing flag before the load await, so a double start cannot fight over restoring the world
+            IsPlayingSkit = true;
+
             var storyCsv = await AddressableLoader.LoadAsyncDefault<TextAsset>(addressablePath);
             if (!storyCsv)
             {
                 Debug.LogError($"ストーリーCSVが見つかりません : {addressablePath}");
+                IsPlayingSkit = false;
                 return;
             }
-            
+
             await StartSkit(storyCsv);
         }
         
@@ -73,7 +78,7 @@ namespace Client.Game.Skit
             var presentationStarted = false;
             var cameraRegistered = false;
             var suppressedWorldPins = new List<ITutorialWorldPin>();
-            SkitWorldObjectControlGroup worldObjectControlGroup = null;
+            SkitVisibilityLedger visibilityLedger = null;
             SkitLocalizationResolver localizationResolver = null;
             StoryContext storyContext = null;
             CharacterObjectContainer characterContainer = null;
@@ -151,11 +156,17 @@ namespace Client.Game.Skit
                 builder.RegisterInstance<ISkitCamera>(skitCamera);
                 builder.RegisterInstance(voiceDefine);
                 builder.RegisterInstance(characterContainer);
-                builder.RegisterInstance<ISkitEnvironmentRoot>(environmentRoot);
-                builder.RegisterInstance<ISkitBlockObjectControl>(blockGameObjectDataStore);
-                worldObjectControlGroup = new SkitWorldObjectControlGroup(worldObjectControls);
-                builder.RegisterInstance<ISkitWorldObjectControl>(worldObjectControlGroup);
-                builder.RegisterInstance<ISkitEntityObjectControl>(entityObjectDatastore);
+                // 4窓口すべてを台帳経由で公開し、消した窓口の記録と復元を1箇所へ集める
+                // Expose all four entry points through the ledger, so recording and restoring live in one place
+                visibilityLedger = new SkitVisibilityLedger(
+                    environmentRoot,
+                    blockGameObjectDataStore,
+                    new SkitWorldObjectControlGroup(worldObjectControls),
+                    entityObjectDatastore);
+                builder.RegisterInstance<ISkitEnvironmentRoot>(visibilityLedger);
+                builder.RegisterInstance<ISkitBlockObjectControl>(visibilityLedger);
+                builder.RegisterInstance<ISkitWorldObjectControl>(visibilityLedger);
+                builder.RegisterInstance<ISkitEntityObjectControl>(visibilityLedger);
                 builder.RegisterInstance<ISkitEnvironmentManager>(new SkitEnvironmentManager(transform));
                 builder.RegisterInstance<ISkitActionContext>(_skitActionController);
                 builder.RegisterInstance(new SkitPresentationMode(webUiMode));
@@ -171,7 +182,7 @@ namespace Client.Game.Skit
                 skitUI.SetActive(false);
                 if (presentationStarted) SkitPresentationStateStore.Instance.End();
                 foreach (var suppressedWorldPin in suppressedWorldPins) suppressedWorldPin.EndSkitSuppress();
-                if (worldObjectControlGroup is { IsHidden: true }) worldObjectControlGroup.SetActive(true);
+                visibilityLedger?.RestoreHiddenWindows();
                 characterContainer?.DestroyAllCharacters();
                 if (cameraRegistered) CameraManager.UnRegisterCamera(skitCamera);
                 storyContext?.Dispose();

--- a/moorestech_client/Assets/Scripts/Client.Game/Skit/SkitVisibilityLedger.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/Skit/SkitVisibilityLedger.cs
@@ -1,0 +1,100 @@
+using System.Collections.Generic;
+using CommandForgeGenerator.Command;
+
+namespace Client.Game.Skit
+{
+    // スキットが表示を切り替えられる窓口
+    // Visibility entry points a skit can toggle
+    internal enum SkitVisibilityWindow
+    {
+        Background,
+        Block,
+        WorldObject,
+        Entity,
+    }
+
+    /// <summary>
+    ///     非表示にした窓口だけを記録し、スキット終了時に記録分を一括で戻す台帳
+    ///     Ledger that records only the windows switched off, then restores exactly those when the skit ends
+    /// </summary>
+    internal class SkitVisibilityLedger : ISkitEnvironmentRoot, ISkitBlockObjectControl, ISkitWorldObjectControl, ISkitEntityObjectControl
+    {
+        private readonly ISkitEnvironmentRoot _environmentRoot;
+        private readonly ISkitBlockObjectControl _blockObjectControl;
+        private readonly ISkitWorldObjectControl _worldObjectControl;
+        private readonly ISkitEntityObjectControl _entityObjectControl;
+
+        private readonly List<SkitVisibilityWindow> _hiddenWindows = new();
+
+        internal SkitVisibilityLedger(
+            ISkitEnvironmentRoot environmentRoot,
+            ISkitBlockObjectControl blockObjectControl,
+            ISkitWorldObjectControl worldObjectControl,
+            ISkitEntityObjectControl entityObjectControl)
+        {
+            _environmentRoot = environmentRoot;
+            _blockObjectControl = blockObjectControl;
+            _worldObjectControl = worldObjectControl;
+            _entityObjectControl = entityObjectControl;
+        }
+
+        // コマンドからの4窓口は同一の台帳を通り、どれを消したかがここへ集まる
+        // All four entry points reach the same ledger, so what a skit hid is recorded in one place
+        void ISkitEnvironmentRoot.SetActive(bool enable)
+        {
+            SetWindowActive(SkitVisibilityWindow.Background, enable);
+        }
+
+        void ISkitBlockObjectControl.SetActive(bool enable)
+        {
+            SetWindowActive(SkitVisibilityWindow.Block, enable);
+        }
+
+        void ISkitWorldObjectControl.SetActive(bool enable)
+        {
+            SetWindowActive(SkitVisibilityWindow.WorldObject, enable);
+        }
+
+        void ISkitEntityObjectControl.SetActive(bool enable)
+        {
+            SetWindowActive(SkitVisibilityWindow.Entity, enable);
+        }
+
+        // 中断でも完走でも、非表示にした窓口だけを1ループで戻す
+        // Whether the skit finished or aborted, one loop restores exactly the windows that were switched off
+        internal void RestoreHiddenWindows()
+        {
+            foreach (var hiddenWindow in _hiddenWindows) ApplyToWindow(hiddenWindow, true);
+            _hiddenWindows.Clear();
+        }
+
+        // 反映より先に台帳へ書くため、fan-out途中で失敗しても戻し漏れが出ない
+        // Recording before applying keeps a mid fan-out failure from leaving a window unrestorable
+        private void SetWindowActive(SkitVisibilityWindow window, bool enable)
+        {
+            if (enable) _hiddenWindows.Remove(window);
+            else if (!_hiddenWindows.Contains(window)) _hiddenWindows.Add(window);
+
+            ApplyToWindow(window, enable);
+        }
+
+        private void ApplyToWindow(SkitVisibilityWindow window, bool enable)
+        {
+            switch (window)
+            {
+                case SkitVisibilityWindow.Background:
+                    _environmentRoot.SetActive(enable);
+                    break;
+                case SkitVisibilityWindow.Block:
+                    _blockObjectControl.SetActive(enable);
+                    break;
+                case SkitVisibilityWindow.WorldObject:
+                    _worldObjectControl.SetActive(enable);
+                    break;
+                case SkitVisibilityWindow.Entity:
+                    _entityObjectControl.SetActive(enable);
+                    break;
+            }
+        }
+    }
+}

--- a/moorestech_client/Assets/Scripts/Client.Game/Skit/SkitVisibilityLedger.cs.meta
+++ b/moorestech_client/Assets/Scripts/Client.Game/Skit/SkitVisibilityLedger.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b34a170cb41bb44c89457272ffce06d0

--- a/moorestech_client/Assets/Scripts/Client.Game/Skit/SkitWorldObjectControlGroup.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/Skit/SkitWorldObjectControlGroup.cs
@@ -4,14 +4,18 @@ using CommandForgeGenerator.Command;
 namespace Client.Game.Skit
 {
     /// <summary>
-    ///     Environment外に置かれた世界オブジェクトを1単位で表示切替する
+    ///     Environment外世界オブジェクトを一括表示切替
     ///     Toggles every world object placed outside Environment as a single unit
     /// </summary>
-    public class SkitWorldObjectControlGroup : ISkitWorldObjectControl
+    internal class SkitWorldObjectControlGroup : ISkitWorldObjectControl
     {
         private readonly IReadOnlyList<ISkitWorldObjectControl> _worldObjectControls;
 
-        public SkitWorldObjectControlGroup(IReadOnlyList<ISkitWorldObjectControl> worldObjectControls)
+        // 中断時に戻す対象かをSkitManagerが判断するため、隠した事実だけを控える
+        // Track only the fact that objects were hidden, so SkitManager can decide whether to restore
+        public bool IsHidden { get; private set; }
+
+        internal SkitWorldObjectControlGroup(IReadOnlyList<ISkitWorldObjectControl> worldObjectControls)
         {
             _worldObjectControls = worldObjectControls;
         }
@@ -19,6 +23,7 @@ namespace Client.Game.Skit
         public void SetActive(bool enable)
         {
             foreach (var worldObjectControl in _worldObjectControls) worldObjectControl.SetActive(enable);
+            IsHidden = !enable;
         }
     }
 }

--- a/moorestech_client/Assets/Scripts/Client.Game/Skit/SkitWorldObjectControlGroup.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/Skit/SkitWorldObjectControlGroup.cs
@@ -11,10 +11,6 @@ namespace Client.Game.Skit
     {
         private readonly IReadOnlyList<ISkitWorldObjectControl> _worldObjectControls;
 
-        // 中断時に戻す対象かをSkitManagerが判断するため、隠した事実だけを控える
-        // Track only the fact that objects were hidden, so SkitManager can decide whether to restore
-        public bool IsHidden { get; private set; }
-
         internal SkitWorldObjectControlGroup(IReadOnlyList<ISkitWorldObjectControl> worldObjectControls)
         {
             _worldObjectControls = worldObjectControls;
@@ -23,7 +19,6 @@ namespace Client.Game.Skit
         public void SetActive(bool enable)
         {
             foreach (var worldObjectControl in _worldObjectControls) worldObjectControl.SetActive(enable);
-            IsHidden = !enable;
         }
     }
 }

--- a/moorestech_client/Assets/Scripts/Client.Game/Skit/SkitWorldObjectControlGroup.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/Skit/SkitWorldObjectControlGroup.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using CommandForgeGenerator.Command;
+
+namespace Client.Game.Skit
+{
+    /// <summary>
+    ///     Environment外に置かれた世界オブジェクトを1単位で表示切替する
+    ///     Toggles every world object placed outside Environment as a single unit
+    /// </summary>
+    public class SkitWorldObjectControlGroup : ISkitWorldObjectControl
+    {
+        private readonly IReadOnlyList<ISkitWorldObjectControl> _worldObjectControls;
+
+        public SkitWorldObjectControlGroup(IReadOnlyList<ISkitWorldObjectControl> worldObjectControls)
+        {
+            _worldObjectControls = worldObjectControls;
+        }
+
+        public void SetActive(bool enable)
+        {
+            foreach (var worldObjectControl in _worldObjectControls) worldObjectControl.SetActive(enable);
+        }
+    }
+}

--- a/moorestech_client/Assets/Scripts/Client.Game/Skit/SkitWorldObjectControlGroup.cs.meta
+++ b/moorestech_client/Assets/Scripts/Client.Game/Skit/SkitWorldObjectControlGroup.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 51594d2fd0808441982fa6f91a351bef

--- a/moorestech_client/Assets/Scripts/Client.Skit/Commands/InGameObjectControlCommand.cs
+++ b/moorestech_client/Assets/Scripts/Client.Skit/Commands/InGameObjectControlCommand.cs
@@ -13,7 +13,7 @@ namespace CommandForgeGenerator.Command
         void SetActive(bool enable);
     }
 
-    // mapObjectと露頭のようにEnvironment外へ置かれる世界オブジェクトの表示窓口
+    // Environment外世界オブジェクトの表示窓口
     // Visibility entry point for world objects placed outside Environment, such as map objects and outcrops
     public interface ISkitWorldObjectControl
     {

--- a/moorestech_client/Assets/Scripts/Client.Skit/Commands/InGameObjectControlCommand.cs
+++ b/moorestech_client/Assets/Scripts/Client.Skit/Commands/InGameObjectControlCommand.cs
@@ -13,7 +13,9 @@ namespace CommandForgeGenerator.Command
         void SetActive(bool enable);
     }
 
-    public interface ISkitMapObjectControl
+    // mapObjectと露頭のようにEnvironment外へ置かれる世界オブジェクトの表示窓口
+    // Visibility entry point for world objects placed outside Environment, such as map objects and outcrops
+    public interface ISkitWorldObjectControl
     {
         void SetActive(bool enable);
     }
@@ -30,9 +32,9 @@ namespace CommandForgeGenerator.Command
             storyContext.GetService<ISkitEnvironmentRoot>().SetActive(BackgroundEnable);
             storyContext.GetService<ISkitBlockObjectControl>().SetActive(BlockEnable);
 
-            // mapObjectとエンティティはEnvironment外に生成されるため個別に消す
-            // Map objects and entities live outside Environment, so hide them individually
-            storyContext.GetService<ISkitMapObjectControl>().SetActive(MapObjectEnable);
+            // mapObject・露頭・エンティティはEnvironment外に生成されるため個別に消す
+            // Map objects, outcrops, and entities live outside Environment, so hide them individually
+            storyContext.GetService<ISkitWorldObjectControl>().SetActive(MapObjectEnable);
             storyContext.GetService<ISkitEntityObjectControl>().SetActive(EntityEnable);
             return null;
         }

--- a/moorestech_client/Assets/Scripts/Client.Skit/Commands/InGameObjectControlCommand.cs
+++ b/moorestech_client/Assets/Scripts/Client.Skit/Commands/InGameObjectControlCommand.cs
@@ -34,7 +34,7 @@ namespace CommandForgeGenerator.Command
 
             // mapObject・露頭・エンティティはEnvironment外に生成されるため個別に消す
             // Map objects, outcrops, and entities live outside Environment, so hide them individually
-            storyContext.GetService<ISkitWorldObjectControl>().SetActive(MapObjectEnable);
+            storyContext.GetService<ISkitWorldObjectControl>().SetActive(WorldObjectEnable);
             storyContext.GetService<ISkitEntityObjectControl>().SetActive(EntityEnable);
             return null;
         }

--- a/moorestech_client/Assets/Scripts/Client.Skit/Commands/InGameObjectControlCommand.cs
+++ b/moorestech_client/Assets/Scripts/Client.Skit/Commands/InGameObjectControlCommand.cs
@@ -14,7 +14,7 @@ namespace CommandForgeGenerator.Command
     }
 
     // Environment外世界オブジェクトの表示窓口
-    // Visibility entry point for world objects placed outside Environment, such as map objects and outcrops
+    // Visibility entry point for world objects placed outside Environment, such as map objects, outcrops, and trains
     public interface ISkitWorldObjectControl
     {
         void SetActive(bool enable);
@@ -32,8 +32,8 @@ namespace CommandForgeGenerator.Command
             storyContext.GetService<ISkitEnvironmentRoot>().SetActive(BackgroundEnable);
             storyContext.GetService<ISkitBlockObjectControl>().SetActive(BlockEnable);
 
-            // mapObject・露頭・エンティティはEnvironment外に生成されるため個別に消す
-            // Map objects, outcrops, and entities live outside Environment, so hide them individually
+            // mapObject・露頭・列車・エンティティはEnvironment外に生成されるため個別に消す
+            // Map objects, outcrops, trains, and entities live outside Environment, so hide them individually
             storyContext.GetService<ISkitWorldObjectControl>().SetActive(WorldObjectEnable);
             storyContext.GetService<ISkitEntityObjectControl>().SetActive(EntityEnable);
             return null;

--- a/moorestech_client/Assets/Scripts/Client.Starter/MainGameStarter.cs
+++ b/moorestech_client/Assets/Scripts/Client.Starter/MainGameStarter.cs
@@ -322,7 +322,7 @@ namespace Client.Starter
             builder.RegisterComponent(miningController);
             
             builder.RegisterComponent(entityObjectDatastore);
-            builder.RegisterComponent(trainCarObjectDatastore);
+            builder.RegisterComponent(trainCarObjectDatastore).AsSelf().As<ISkitWorldObjectControl>();
             builder.RegisterComponent(playerInventoryViewController);
             builder.RegisterComponent(challengeManager);
             builder.RegisterComponent(craftInventoryView);
@@ -349,7 +349,7 @@ namespace Client.Starter
             
             builder.RegisterComponent<IPlacementPreviewBlockGameObjectController>(previewBlockController);
             builder.RegisterComponent(railConnectPreviewObject);
-            builder.RegisterComponent(trainRailObjectManager);
+            builder.RegisterComponent(trainRailObjectManager).AsSelf().As<ISkitWorldObjectControl>();
             builder.RegisterComponent(trainCarObjectPreviewController);
             
             builder.RegisterBuildCallback(objectResolver => { });

--- a/moorestech_client/Assets/Scripts/Client.Starter/MainGameStarter.cs
+++ b/moorestech_client/Assets/Scripts/Client.Starter/MainGameStarter.cs
@@ -68,6 +68,7 @@ using Client.Game.Skit;
 using Client.Network.API;
 using Client.Skit.Skit;
 using Client.Skit.UI;
+using CommandForgeGenerator.Command;
 using Core.Item.Interface;
 using Game.Context;
 using Game.PlayerRiding.Interface;
@@ -304,8 +305,8 @@ namespace Client.Starter
             // register component on hierarchy
             builder.RegisterComponent(gameStateController);
             builder.RegisterComponent(blockGameObjectDataStore);
-            builder.RegisterComponent(mapObjectGameObjectDatastore).AsSelf().As<IInitialEventApplyWaitTarget>();
-            builder.RegisterComponent(outcropGameObjectDatastore).AsSelf().As<IInitialEventApplyWaitTarget>();
+            builder.RegisterComponent(mapObjectGameObjectDatastore).AsSelf().As<IInitialEventApplyWaitTarget>().As<ISkitWorldObjectControl>();
+            builder.RegisterComponent(outcropGameObjectDatastore).AsSelf().As<IInitialEventApplyWaitTarget>().As<ISkitWorldObjectControl>();
             builder.RegisterComponent(environmentRoot);
             
             builder.RegisterComponent(mainCamera);

--- a/moorestech_client/Assets/Scripts/Client.Tests/EditModeInPlayingTest/Skit.meta
+++ b/moorestech_client/Assets/Scripts/Client.Tests/EditModeInPlayingTest/Skit.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dd59d37345dfb49bd9d7d6928cf77275
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/moorestech_client/Assets/Scripts/Client.Tests/EditModeInPlayingTest/Skit/SkitWorldObjectRegistrationTest.cs
+++ b/moorestech_client/Assets/Scripts/Client.Tests/EditModeInPlayingTest/Skit/SkitWorldObjectRegistrationTest.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Client.Game.InGame.Context;
+using CommandForgeGenerator.Command;
+using Cysharp.Threading.Tasks;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.TestTools;
+using VContainer;
+using static Client.Tests.EditModeInPlayingTest.Util.EditModeInPlayingTestUtil;
+
+namespace Client.Tests.EditModeInPlayingTest.Skit
+{
+    /// <summary>
+    /// テスト自体はEditModeで実行されるが、実行中にプレイモードに変更する
+    /// スキットが世界を隠す束から、シーン上の世界オブジェクトが1つも漏れていないことを本番のDIコンテナで検証する
+    /// This test runs in EditMode but switches to PlayMode during execution.
+    /// Verifies against the production DI container that no scene world object is missing from the bundle a skit hides.
+    /// </summary>
+    public class SkitWorldObjectRegistrationTest
+    {
+        [UnityTest]
+        public IEnumerator EveryWorldObjectComponentIsRegisteredAsSkitWorldObjectControl()
+        {
+            EnterPlayModeUtil();
+
+            // yield return new EnterPlayMode　は必ず[UnityTest]関数の直下で呼び出すこと。そうでないとなぜかわからないがプレイモードに入らない
+            // Always call yield return new EnterPlayMode directly under the [UnityTest] function. Otherwise, for unknown reasons, it will not enter PlayMode.
+            yield return new EnterPlayMode(expectDomainReload: true);
+
+            // EnterPlayMode時のテストフレームワーク内部エラーでテストが失敗するのを防ぐ
+            // Prevent test failure from test framework internal errors during EnterPlayMode.
+            LogAssert.ignoreFailingMessages = true;
+
+            yield return Body().ToCoroutine();
+
+            yield return new ExitPlayMode();
+
+            SessionState.SetBool("DebugObjectsBootstrap_Disabled", false);
+
+            #region Internal
+
+            async UniTask Body()
+            {
+                await LoadMainGame();
+
+                // SkitManagerが実際に注入されるコンテナから解決する。別に組んだコンテナでは登録漏れを検出できない
+                // Resolve from the very container injected into SkitManager; a separately built container would not detect a missing registration
+                var resolver = ClientDIContext.DIContainer.DIContainerResolver;
+                var registeredTypes = resolver.Resolve<IReadOnlyList<ISkitWorldObjectControl>>().Select(control => control.GetType()).ToList();
+
+                // 件数assertでは5本目を足して登録し忘れたケースを通してしまうので、実装型を列挙して全数を突き合わせる
+                // A count assertion would pass a forgotten fifth registration, so every implementation type is enumerated and matched
+                foreach (var implementationType in CollectSceneWorldObjectTypes())
+                    CollectionAssert.Contains(registeredTypes, implementationType, $"{implementationType.Name}がスキットの世界非表示対象としてDI登録されていない");
+            }
+
+            // シーン上のコンポーネント実装だけが束の母集団。SkitManagerが毎回生成する束ね役・台帳はDI登録の対象外
+            // Only scene component implementations form the bundle; the grouping and ledger SkitManager creates per skit are not DI-registered
+            IReadOnlyList<Type> CollectSceneWorldObjectTypes()
+            {
+                var declaringAssemblyName = typeof(ISkitWorldObjectControl).Assembly.GetName().Name;
+                var implementationTypes = AppDomain.CurrentDomain.GetAssemblies()
+                    .Where(assembly => assembly.GetName().Name == declaringAssemblyName || assembly.GetReferencedAssemblies().Any(reference => reference.Name == declaringAssemblyName))
+                    .Where(IsProductionAssembly)
+                    .SelectMany(assembly => assembly.GetTypes())
+                    .Where(type => !type.IsAbstract && typeof(MonoBehaviour).IsAssignableFrom(type) && typeof(ISkitWorldObjectControl).IsAssignableFrom(type))
+                    .ToList();
+
+                // 走査が空振りしたまま素通りすると、上のassertが名目だけになる
+                // A scan that silently finds nothing would reduce the assertion above to a formality
+                Assert.IsNotEmpty(implementationTypes, "プロダクション実装の走査が1件も拾えていない");
+                return implementationTypes;
+            }
+
+            // テストアセンブリのダミー実装が期待集合を汚染するのを防ぐ
+            // Keeps the test assembly's dummy implementations from polluting the expected set
+            bool IsProductionAssembly(Assembly assembly)
+            {
+                return assembly.GetReferencedAssemblies().All(reference => reference.Name != "nunit.framework");
+            }
+
+            #endregion
+        }
+    }
+}

--- a/moorestech_client/Assets/Scripts/Client.Tests/EditModeInPlayingTest/Skit/SkitWorldObjectRegistrationTest.cs.meta
+++ b/moorestech_client/Assets/Scripts/Client.Tests/EditModeInPlayingTest/Skit/SkitWorldObjectRegistrationTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d0e0705de836c4962b33668e929d7c90

--- a/moorestech_client/Assets/Scripts/Client.Tests/Localization/Skit/SkitLocalizationDictionaryCompletenessTest.cs
+++ b/moorestech_client/Assets/Scripts/Client.Tests/Localization/Skit/SkitLocalizationDictionaryCompletenessTest.cs
@@ -20,10 +20,10 @@ namespace Client.Tests.Localization.Skit
             "skit.sample_short.9.Option3Tag",
             "skit.200_star_background.1.body",
         };
-        // count/hashは5049214e7で4キー追加後のroot値とソート済みCommandForge key/valueを正本とする
-        // Baseline is post-5049214e7 root values and sorted CommandForge key/value pairs
-        [TestCase("english", 143, "d2fe623277b6d15caa2ebdb719ec51efbea7c0c9048896ab560513ccf0e028f7")]
-        [TestCase("japanese", 208, "aa082c029c305352befff7b93ea0e8a6c4ce25a606c42fc7a4979a77ee72a1d4")]
+        // count/hashはworldObjectEnableへの改名後のroot値とソート済みCommandForge key/valueを正本とする
+        // Baseline is the post-worldObjectEnable-rename root values and sorted CommandForge key/value pairs
+        [TestCase("english", 143, "af856df87bb3f24596f0dc6df76f777275fd6aff9e07b61b11c18425f9395d74")]
+        [TestCase("japanese", 208, "8ac9ba939b8a3309aa93e8a931a5d5f3d2a47a45fa70e988f2058976fc9bab9c")]
         public void CommandForgeDictionaryKeepsRootFlatTranslationsAndBaselineValues(
             string languageCode,
             int expectedBaselineCount,

--- a/moorestech_client/Assets/Scripts/Client.Tests/Localization/Skit/SkitLocalizationDictionaryCompletenessTest.cs
+++ b/moorestech_client/Assets/Scripts/Client.Tests/Localization/Skit/SkitLocalizationDictionaryCompletenessTest.cs
@@ -20,10 +20,10 @@ namespace Client.Tests.Localization.Skit
             "skit.sample_short.9.Option3Tag",
             "skit.200_star_background.1.body",
         };
-        // count/hashはworldObjectEnableへの改名後のroot値とソート済みCommandForge key/valueを正本とする
-        // Baseline is the post-worldObjectEnable-rename root values and sorted CommandForge key/value pairs
-        [TestCase("english", 143, "af856df87bb3f24596f0dc6df76f777275fd6aff9e07b61b11c18425f9395d74")]
-        [TestCase("japanese", 208, "8ac9ba939b8a3309aa93e8a931a5d5f3d2a47a45fa70e988f2058976fc9bab9c")]
+        // count/hashは列車をworldObjectEnable側へ移した後のroot値とソート済みCommandForge key/valueを正本とする
+        // Baseline is the root values and sorted CommandForge key/value pairs after trains moved to worldObjectEnable
+        [TestCase("english", 143, "37060d89c2b4261de3d674e65767085449474bd3d115e6ceabd80abfaec28fd6")]
+        [TestCase("japanese", 208, "c702afae428b48ffd8d8f8f57a65c00250258430805e79890e636016ce533fd4")]
         public void CommandForgeDictionaryKeepsRootFlatTranslationsAndBaselineValues(
             string languageCode,
             int expectedBaselineCount,

--- a/moorestech_client/Assets/Scripts/Client.Tests/Skit.meta
+++ b/moorestech_client/Assets/Scripts/Client.Tests/Skit.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 40c8ca8a6bac845168df6196316b37bd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/moorestech_client/Assets/Scripts/Client.Tests/Skit/OutcropGameObjectDatastoreSkitVisibilityTest.cs
+++ b/moorestech_client/Assets/Scripts/Client.Tests/Skit/OutcropGameObjectDatastoreSkitVisibilityTest.cs
@@ -1,0 +1,42 @@
+using Client.Game.InGame.Map.Outcrop;
+using CommandForgeGenerator.Command;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Client.Tests.Skit
+{
+    public class OutcropGameObjectDatastoreSkitVisibilityTest
+    {
+        private GameObject _datastoreObject;
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_datastoreObject != null) Object.DestroyImmediate(_datastoreObject);
+        }
+
+        [Test]
+        public void SetActiveFalseHidesEveryOutcropUnderTheDatastore()
+        {
+            _datastoreObject = new GameObject(nameof(OutcropGameObjectDatastore));
+            var datastore = _datastoreObject.AddComponent<OutcropGameObjectDatastore>();
+            var outcrop = new GameObject("VeinOutcrop_test");
+            outcrop.transform.SetParent(_datastoreObject.transform);
+
+            datastore.SetActive(false);
+            Assert.IsFalse(outcrop.activeInHierarchy);
+
+            datastore.SetActive(true);
+            Assert.IsTrue(outcrop.activeInHierarchy);
+        }
+
+        [Test]
+        public void DatastoreIsPartOfTheSkitWorldObjectContract()
+        {
+            _datastoreObject = new GameObject(nameof(OutcropGameObjectDatastore));
+            var datastore = _datastoreObject.AddComponent<OutcropGameObjectDatastore>();
+
+            Assert.IsInstanceOf<ISkitWorldObjectControl>(datastore);
+        }
+    }
+}

--- a/moorestech_client/Assets/Scripts/Client.Tests/Skit/OutcropGameObjectDatastoreSkitVisibilityTest.cs.meta
+++ b/moorestech_client/Assets/Scripts/Client.Tests/Skit/OutcropGameObjectDatastoreSkitVisibilityTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b6d75272b8e734d51a0e38385d10b591

--- a/moorestech_client/Assets/Scripts/Client.Tests/Skit/SkitVisibilityLedgerTest.cs
+++ b/moorestech_client/Assets/Scripts/Client.Tests/Skit/SkitVisibilityLedgerTest.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using Client.Game.Skit;
+using CommandForgeGenerator.Command;
+using NUnit.Framework;
+
+namespace Client.Tests.Skit
+{
+    public class SkitVisibilityLedgerTest
+    {
+        [Test]
+        public void RestoreTouchesOnlyTheWindowsTheSkitSwitchedOff()
+        {
+            var background = new RecordingWindow();
+            var block = new RecordingWindow();
+            var worldObject = new RecordingWindow();
+            var entity = new RecordingWindow();
+            var ledger = new SkitVisibilityLedger(background, block, worldObject, entity);
+
+            // 背景と世界オブジェクトだけを消したスキットが中断しても、その2窓口だけが戻る
+            // A skit that hid only the background and world objects restores exactly those two on abort
+            ((ISkitEnvironmentRoot)ledger).SetActive(false);
+            ((ISkitWorldObjectControl)ledger).SetActive(false);
+            ledger.RestoreHiddenWindows();
+
+            CollectionAssert.AreEqual(new[] { false, true }, background.ReceivedValues);
+            CollectionAssert.AreEqual(new[] { false, true }, worldObject.ReceivedValues);
+            CollectionAssert.IsEmpty(block.ReceivedValues);
+            CollectionAssert.IsEmpty(entity.ReceivedValues);
+        }
+
+        [Test]
+        public void RestoreSkipsWindowsAlreadyTurnedBackOnByTheSkit()
+        {
+            var entity = new RecordingWindow();
+            var ledger = new SkitVisibilityLedger(new RecordingWindow(), new RecordingWindow(), new RecordingWindow(), entity);
+
+            // スキット自身が戻した窓口は台帳から外れ、終了時に二度目のtrueが流れない
+            // A window the skit turned back on leaves the ledger, so no second true reaches it at the end
+            ((ISkitEntityObjectControl)ledger).SetActive(false);
+            ((ISkitEntityObjectControl)ledger).SetActive(true);
+            ledger.RestoreHiddenWindows();
+
+            CollectionAssert.AreEqual(new[] { false, true }, entity.ReceivedValues);
+        }
+
+        [Test]
+        public void RestoreStillReachesAWindowWhoseHideThrew()
+        {
+            var worldObject = new ThrowingOnHideWindow();
+            var ledger = new SkitVisibilityLedger(new RecordingWindow(), new RecordingWindow(), worldObject, new RecordingWindow());
+
+            // 非表示の途中で落ちた窓口も台帳に載っているため、隠れたまま取り残されない
+            // A window that threw midway through hiding is still on the ledger, so it cannot stay hidden forever
+            Assert.Throws<InvalidOperationException>(() => ((ISkitWorldObjectControl)ledger).SetActive(false));
+            ledger.RestoreHiddenWindows();
+
+            CollectionAssert.AreEqual(new[] { true }, worldObject.ReceivedValues);
+        }
+
+        private class RecordingWindow : ISkitEnvironmentRoot, ISkitBlockObjectControl, ISkitWorldObjectControl, ISkitEntityObjectControl
+        {
+            public readonly List<bool> ReceivedValues = new();
+
+            public virtual void SetActive(bool enable)
+            {
+                ReceivedValues.Add(enable);
+            }
+        }
+
+        private sealed class ThrowingOnHideWindow : RecordingWindow
+        {
+            public override void SetActive(bool enable)
+            {
+                if (!enable) throw new InvalidOperationException("hide failed");
+                base.SetActive(enable);
+            }
+        }
+    }
+}

--- a/moorestech_client/Assets/Scripts/Client.Tests/Skit/SkitVisibilityLedgerTest.cs.meta
+++ b/moorestech_client/Assets/Scripts/Client.Tests/Skit/SkitVisibilityLedgerTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6e5a50df74aa444f183623675153440b

--- a/moorestech_client/Assets/Scripts/Client.Tests/Skit/SkitWorldObjectControlGroupTest.cs
+++ b/moorestech_client/Assets/Scripts/Client.Tests/Skit/SkitWorldObjectControlGroupTest.cs
@@ -23,6 +23,21 @@ namespace Client.Tests.Skit
         }
 
         [Test]
+        public void IsHiddenTracksWhetherWorldObjectsAreCurrentlyHidden()
+        {
+            var group = new SkitWorldObjectControlGroup(
+                new List<ISkitWorldObjectControl> { new RecordingWorldObjectControl() });
+
+            Assert.IsFalse(group.IsHidden);
+
+            group.SetActive(false);
+            Assert.IsTrue(group.IsHidden);
+
+            group.SetActive(true);
+            Assert.IsFalse(group.IsHidden);
+        }
+
+        [Test]
         public void SetActiveOnEmptyGroupDoesNotThrow()
         {
             var group = new SkitWorldObjectControlGroup(new List<ISkitWorldObjectControl>());

--- a/moorestech_client/Assets/Scripts/Client.Tests/Skit/SkitWorldObjectControlGroupTest.cs
+++ b/moorestech_client/Assets/Scripts/Client.Tests/Skit/SkitWorldObjectControlGroupTest.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using Client.Game.Skit;
+using CommandForgeGenerator.Command;
+using NUnit.Framework;
+
+namespace Client.Tests.Skit
+{
+    public class SkitWorldObjectControlGroupTest
+    {
+        [Test]
+        public void SetActiveReachesEveryRegisteredWorldObject()
+        {
+            var mapObjects = new RecordingWorldObjectControl();
+            var outcrops = new RecordingWorldObjectControl();
+            var group = new SkitWorldObjectControlGroup(
+                new List<ISkitWorldObjectControl> { mapObjects, outcrops });
+
+            group.SetActive(false);
+            group.SetActive(true);
+
+            CollectionAssert.AreEqual(new[] { false, true }, mapObjects.ReceivedValues);
+            CollectionAssert.AreEqual(new[] { false, true }, outcrops.ReceivedValues);
+        }
+
+        [Test]
+        public void SetActiveOnEmptyGroupDoesNotThrow()
+        {
+            var group = new SkitWorldObjectControlGroup(new List<ISkitWorldObjectControl>());
+
+            Assert.DoesNotThrow(() => group.SetActive(false));
+        }
+
+        private sealed class RecordingWorldObjectControl : ISkitWorldObjectControl
+        {
+            public readonly List<bool> ReceivedValues = new();
+
+            public void SetActive(bool enable)
+            {
+                ReceivedValues.Add(enable);
+            }
+        }
+    }
+}

--- a/moorestech_client/Assets/Scripts/Client.Tests/Skit/SkitWorldObjectControlGroupTest.cs
+++ b/moorestech_client/Assets/Scripts/Client.Tests/Skit/SkitWorldObjectControlGroupTest.cs
@@ -22,29 +22,6 @@ namespace Client.Tests.Skit
             CollectionAssert.AreEqual(new[] { false, true }, outcrops.ReceivedValues);
         }
 
-        [Test]
-        public void IsHiddenTracksWhetherWorldObjectsAreCurrentlyHidden()
-        {
-            var group = new SkitWorldObjectControlGroup(
-                new List<ISkitWorldObjectControl> { new RecordingWorldObjectControl() });
-
-            Assert.IsFalse(group.IsHidden);
-
-            group.SetActive(false);
-            Assert.IsTrue(group.IsHidden);
-
-            group.SetActive(true);
-            Assert.IsFalse(group.IsHidden);
-        }
-
-        [Test]
-        public void SetActiveOnEmptyGroupDoesNotThrow()
-        {
-            var group = new SkitWorldObjectControlGroup(new List<ISkitWorldObjectControl>());
-
-            Assert.DoesNotThrow(() => group.SetActive(false));
-        }
-
         private sealed class RecordingWorldObjectControl : ISkitWorldObjectControl
         {
             public readonly List<bool> ReceivedValues = new();

--- a/moorestech_client/Assets/Scripts/Client.Tests/Skit/SkitWorldObjectControlGroupTest.cs.meta
+++ b/moorestech_client/Assets/Scripts/Client.Tests/Skit/SkitWorldObjectControlGroupTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 454d1fcd7acc6474b8e12aaab9631eae

--- a/moorestech_client/Assets/Scripts/Client.Tests/WebUi/Gate/WebUiGateClassification.cs
+++ b/moorestech_client/Assets/Scripts/Client.Tests/WebUi/Gate/WebUiGateClassification.cs
@@ -110,6 +110,8 @@ namespace Client.Tests.WebUi.Gate
             new Rule("Client.Game/InGame/Tutorial/BlockPlacePreviewTutorialManager.cs", Category.Excluded, "3D配置previewのためUnity残置"),
             new Rule("Client.Game/InGame/Tutorial/TutorialBlock", Category.Excluded, "3D配置preview配下"),
             new Rule("Client.Game/InGame/Tutorial", Category.Infra, "challenge lifecycle・presentation state・interface"),
+            new Rule("Client.Game/Skit/SkitWorldObjectControlGroup.cs", Category.Excluded, "Environment外のワールド表示物を束ねる切替でスクリーンUIを持たない"),
+            new Rule("Client.Game/Skit/SkitVisibilityLedger.cs", Category.Excluded, "スキットが消したワールド表示の復元台帳でスクリーンUIを持たない"),
             new Rule("Client.Skit", Category.CoveredByRoot, "SkitManagerがUI Toolkit rootをWebモード時に抑止 (C4/S2-S3)"),
             new Rule("Client.CutScene", Category.Pending, "C4: カットシーン退避（GameStateType Topic化）"),
         };


### PR DESCRIPTION
## 目的

開幕スキット `100_start_game` の宇宙カット（`inGameObjectControl` で表示フラグを全て false）で、鉱脈の露頭だけが消え残っていた（bd `moorestech-kvl`）。

原因は「1カテゴリ = 1 interface」の名指し列挙で、2026-08-04 に追加された露頭がどの interface にも繋がれていなかったこと。列挙のままでは Environment 外の表示物が増えるたびに同じ取りこぼしが再発するため、共通概念で束ねる。

設計: [docs/adr/0016-skit-hides-world-objects-through-shared-interface.md](docs/adr/0016-skit-hides-world-objects-through-shared-interface.md)

## 変更

- `ISkitWorldObjectControl` を新設し、`MapObjectGameObjectDatastore` と `OutcropGameObjectDatastore` の両方が実装（旧 `ISkitMapObjectControl` は削除）
- composite `SkitWorldObjectControlGroup` が `IReadOnlyList<ISkitWorldObjectControl>` を受けて全要素へ流す（`ITutorialWorldPin` と同型の一括注入）
- コマンドのフラグを実処理に合わせて `mapObjectEnable` → `worldObjectEnable` へ改名（`commands.yaml` / スキットJSON / i18n 2ファイル / `commandListLabelFormat` / ローカライズbaseline hash を一括更新。後方互換は取らない）
- スキットが中断しても世界オブジェクトが消えたまま残らないよう、`SkitManager.Cleanup()` で復元（レビュー裁定）

今後 Environment 外の表示物が増えたときは、interface 実装と DI 登録だけで束に乗る。

## 検証

- `uloop compile` Error 0
- Skit系 EditMode テスト **73件 PASS**（composite のファンアウト・`IsHidden` 追跡・露頭 datastore の表示切替・ローカライズ辞書 baseline）
- **unityプレイ録画テスト**: 開幕スキットを Skip せず実走。宇宙カットで露頭 root が非表示・復帰カットで再表示を assert し、スクリーンショットと録画でも宇宙カットに露頭が1つも映っていないことを目視確認（露頭0体での偽陽性を防ぐため `childCount > 0` も assert）

## レビュー（moores-code-review・25系統）

Critical 3件。うち2件をユーザー裁定にかけ、結果を反映済み。

- **中断時の復元** — `SkitManager.Cleanup()` で最小復元する案を採用（interface契約の Begin/End 化は兄弟3 interface への波及が大きいため見送り）
- **DI登録漏れの検知** — 具象型注入から `IReadOnlyList` 注入へ変えたことで、登録を1行忘れても例外にならず無言で縮退する。検知テストの追加は今回は入れない裁定。リスクは bd `moorestech-aum` へ送った
- **公開範囲** — composite を `internal` 化し `Client.Game` へ `InternalsVisibleTo("Client.Tests")` を追加（自動適用）

⚠️ **カバレッジの縮退**: Codex外部監査3本が全滅（transcript途中終了）、IL解析ゲートが dotnet CLI 不在で縮退。この2系統は今回効いていない。

記録: `moorestech_logs/harness/moores-code-review/records/2026-08-18-skit-world-object-control.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Skits can now hide and restore world objects, including map objects, outcrops, trains, and entities.
  - World objects are restored when skit playback ends or is interrupted.
  - Added support for the opening skit’s world-hidden sequence.

- **Bug Fixes**
  - Improved reliability of visibility transitions and restoration during skit playback.

- **Tests**
  - Added coverage for world-object registration, visibility, restoration, and hidden-world playback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->