### PR TITLE
チャレンジHUDの背景サイズを約1/2へ縮小

### DIFF
--- a/moorestech_web/webui/src/app/tokens.css
+++ b/moorestech_web/webui/src/app/tokens.css
@@ -99,16 +99,16 @@
   --panel-action-button-hover-mix: 22%;
   /* HUD面の安全帯。フェード帯を超える余白で、チャレンジHUDの面幅導出とも共有する */
   /* HUD face safe area: padding wider than the fade band, shared with the challenge HUD's width derivation */
-  --hud-panel-padding: 20px;
+  --hud-panel-padding: 14px;
   /* 常駐チャレンジHUDは左上へ固定し、本文と罫線の幅を分離する */
   /* Keep the resident challenge HUD top-left with independent content and rule widths */
   --challenge-hud-left: 24px;
   --challenge-hud-top: 24px;
   /* 面幅は本文の折返し幅にGamePanel hud variantの安全帯paddingを左右分足して導く */
   /* Derive the face width from the text-wrap width plus the hud variant's safe-area padding on each side */
-  --challenge-hud-content-width: 520px;
+  --challenge-hud-content-width: 250px;
   --challenge-hud-width: calc(var(--challenge-hud-content-width) + var(--hud-panel-padding) * 2);
-  --challenge-hud-rule-width: 176px;
+  --challenge-hud-rule-width: 88px;
   --challenge-hud-label-font-size: 12px;
   --challenge-hud-objective-font-size: 14px;
   --challenge-hud-label-rule-gap: 5px;


### PR DESCRIPTION
## 変更内容
常駐チャレンジHUD（目標UI）の面（背景）が過大だったため、約1/2のサイズへ縮小した。

`moorestech_web/webui/src/app/tokens.css`:
- `--challenge-hud-content-width`: 520px → 250px
- `--hud-panel-padding`: 20px → 14px
- `--challenge-hud-rule-width`: 176px → 88px

面幅は `content-width + padding * 2` で導出されるため、560px → 278px（約1/2）になる。

## 補足
- `--hud-panel-padding` はフェード帯 `--panel-edge-fade: 12px` を超える必要があるため14pxで止めた（10pxだと本文がフェード領域に食い込む）。
- `--hud-panel-padding` の利用は `GamePanel variant="hud"` のみで、その唯一の利用者が本HUD。他UIへの波及なし。
- `hudVariantDesign.test.ts` 通過確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)