### PR TITLE
fix(dev-hooks): poll-guardの検知を全ツールへ一般化し時間窓判定に変更

### DIFF
--- a/.dev-hooks/README.md
+++ b/.dev-hooks/README.md
@@ -17,7 +17,7 @@
   decisions-format-check.mjs     # .decisions/レコードの書式検査（違反はexit 2で差し戻し）
   beads-prime.mjs                # Beads台帳(bd)の概況と役割分担ルールをSessionStartで注入
   beads-guard.mjs                # 破壊的bd/doltコマンドの物理拒否とpublic誤送信ガード（PreToolUse）
-  poll-guard.mjs                 # 同一Bashコマンド3連続＝ポーリングを拒否し正しい待ち方を再注入（PreToolUse 全ツール。Claudeのみ登録 — リセット判定に全ツールイベントが要るため）
+  poll-guard.mjs                 # 同一ツール呼び出しの反復＝ポーリングを拒否し正しい待ち方を再注入（PreToolUse 全ツール。Claudeのみ登録 — リセット判定に全ツールイベントが要るため）
   beads-sync-watch.mjs           # Dolt同期障害の復旧誘導＋claim/createへのセッション出自刻印（PostToolUse）
   beads-learn-capture.mjs        # 応答末尾の「LEARN: 一行」をbd noteへ自動保存（Claude Stop）
   logs-sync.mjs                  # Claude/Codex生JSONLをprivateの../moorestech_logsへ退避（Stop/SessionEnd等）
@@ -89,3 +89,12 @@ echo '{"tool_name":"Edit","tool_input":{"file_path":"Foo.cs","new_string":"publi
 ```
 
 一致すれば `hookSpecificOutput.additionalContext` を含む JSON が出力される。
+
+poll-guard は同じ入力を3回流すと3回目で exit 2 になる（ツール名は Bash 以外でも同じ）。
+
+```bash
+for i in 1 2 3; do
+  echo '{"session_id":"T","transcript_path":"/x/t.jsonl","tool_name":"ListAgents","tool_input":{}}' \
+    | node .dev-hooks/poll-guard.mjs; echo "exit=$?"
+done
+```

--- a/.dev-hooks/poll-guard.mjs
+++ b/.dev-hooks/poll-guard.mjs
@@ -22,7 +22,11 @@
 // Detection: deny when a tool-name+arguments fingerprint occurs THRESHOLD times within the last
 // WINDOW non-resetting calls; the window is cleared after a deny and by any side-effecting tool.
 //
-// 所有する状態: ~/.cache/claude-poll-guard/<session>__<transcript basename>(JSON {window,last})。
+// 所有する状態: ~/.cache/claude-poll-guard/<自スクリプトpathの短縮hash>__<session>__<transcript basename>
+// (JSON {window,last})。鍵に自分のpathを混ぜるのは、同じ内容の写し(ユーザー全体hookとproject hook)が
+// 両方登録された環境で1回のツール呼びを二重に数え、閾値より早くdenyしてしまうのを防ぐため。
+// The key includes this script's own path so a user-level and a project-level copy of the same hook
+// do not both count one tool call into the same window and deny before the threshold.
 // 鍵にtranscriptを含めるのは、並列subagentがhook入力で親と同一session_idを共有するため
 // (cmux-connector側で実測)。session単独鍵だと並列エージェント間でカウンタが相互汚染する。
 // State: keyed by session + transcript basename because parallel subagents share the parent's
@@ -34,6 +38,7 @@
 import { readFileSync, writeFileSync, mkdirSync, readdirSync, statSync, unlinkSync, rmSync, existsSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { homedir } from "node:os";
+import { fileURLToPath } from "node:url";
 import { join, basename } from "node:path";
 
 const THRESHOLD = 3;
@@ -63,7 +68,8 @@ if (!session || !tool) process.exit(0);
 const home = homedir();
 if (!home) process.exit(0);
 const stateDir = join(home, ".cache", "claude-poll-guard");
-const key = `${session}__${basename(transcript)}`.replace(/[\/\\]/g, "_");
+const scope = createHash("sha1").update(fileURLToPath(import.meta.url)).digest("hex").slice(0, 8);
+const key = `${scope}__${session}__${basename(transcript)}`.replace(/[\/\\]/g, "_");
 const stateFile = join(stateDir, key);
 
 // 副作用のあるツールが来たら窓ごと破棄する(実作業が進んだので反復の意味が変わる)

--- a/.dev-hooks/poll-guard.mjs
+++ b/.dev-hooks/poll-guard.mjs
@@ -1,23 +1,27 @@
 #!/usr/bin/env node
-// ポーリング連打ガード: 同一Bashコマンドの連続実行を拒否し、正しい待ち方を再注入する
-// Poll guard: denies consecutive identical Bash commands and re-injects the correct way to wait.
+// ポーリング連打ガード: 同一ツール呼び出しの反復を拒否し、正しい待ち方を再注入する
+// Poll guard: denies repeated identical tool calls and re-injects the correct way to wait.
 //
-// 目的: サブエージェント完了待ちを `ls` 等の同一コマンド連打でポーリングする退行を機械的に
-// 止める(2026-08-15にcmux-connector側セッションで数十回のlsポーリングが実際に起きた。
-// 指示文言だけでは防げなかったのでdenyで構造的に遮断する。cmux-connectorのpoll-guard.shと
-// 同一ロジックのNode移植 — このrepoはmac/windows共通でnode前提のため)。
-// Why: mechanically stop the regression of polling for subagent completion by repeating the
-// same command; instructions alone did not prevent it. Node port of cmux-connector's
-// poll-guard.sh because this repo's hooks are node-based for mac/windows parity.
+// 目的: サブエージェント/バックグラウンド完了待ちを同一呼び出しの連打で見張る退行を機械的に止める。
+// 初版はBashコマンドの完全一致連続だけを見ていたが、それでは実際の退行を1件も止められなかった
+// (2026-08-17のセッションで ListAgents 593回・最長380回連続・間隔中央値3秒のポーリングが素通り。
+// Bash以外は判定対象外で、さらに非Bashツールが来るとカウンタを消していたため、間にListAgentsを
+// 挟んだBashの18回反復も検知できなかった)。よって判定は全ツールへ一般化し、リセットは副作用の
+// あるツールだけに限定する。指示文言では防げないためdenyで構造的に遮断する。
+// Why: instructions alone never stopped the regression — the Bash-only version let 593 ListAgents
+// polls (380 consecutive, ~3s apart) through and its "any non-Bash tool resets" rule also erased
+// the streak of 18 repeated Bash polls. Detection is now tool-agnostic and only side-effecting
+// tools clear the streak.
 //
-// 判定: 他ツール呼び出しを挟まず直前と完全一致するBashコマンドがTHRESHOLD回連続したらdeny。
-// deny後はカウンタを0に戻す(恒久ブロックにしない — 主目的は指示の再注入で、一時的失敗の
-// 正当な再試行を殺さないため)。Bash以外のツールが挟まればリセットされるため、テスト→修正→
-// テストの反復は誤検知しない。意図的な反復は1コマンド内のfor/untilで書けば通る。
-// Detection: deny when an identical Bash command repeats THRESHOLD times with no other tool
-// in between; the counter resets after a deny and on any non-Bash tool call.
+// 判定: ツール名＋引数の指紋が、直近WINDOW件の非リセット呼び出しの中でTHRESHOLD回に達したらdeny。
+// 交互ポーリング(ls → ListAgents → ls …)も窓内の出現回数で拾える。deny後は窓を空にする
+// (恒久ブロックにしない — 主目的は指示の再注入で、正当な反復や一時的失敗の再試行を殺さないため)。
+// Edit/Write/Agent等の副作用ツールが挟まれば窓ごとリセットされるため、実作業の反復は誤検知しない。
+// 意図的な反復は1呼び出し内のfor/untilループで書けば通る。
+// Detection: deny when a tool-name+arguments fingerprint occurs THRESHOLD times within the last
+// WINDOW non-resetting calls; the window is cleared after a deny and by any side-effecting tool.
 //
-// 所有する状態: ~/.cache/claude-poll-guard/<session>__<transcript basename>(JSON {count,prev})。
+// 所有する状態: ~/.cache/claude-poll-guard/<session>__<transcript basename>(JSON {window,last})。
 // 鍵にtranscriptを含めるのは、並列subagentがhook入力で親と同一session_idを共有するため
 // (cmux-connector側で実測)。session単独鍵だと並列エージェント間でカウンタが相互汚染する。
 // State: keyed by session + transcript basename because parallel subagents share the parent's
@@ -27,13 +31,16 @@
 // Every failure path exits 0 silently (fail open, same philosophy as beads-guard).
 
 import { readFileSync, writeFileSync, mkdirSync, readdirSync, statSync, unlinkSync, rmSync, existsSync } from "node:fs";
+import { createHash } from "node:crypto";
 import { homedir } from "node:os";
 import { join, basename } from "node:path";
 
 const THRESHOLD = 3;
-// Claudeは"Bash"、Codexのシェル系ツール名も同列に扱う(Codex側はhooks.json未登録のうちは不発)
-// "Bash" for Claude; Codex shell tool names accepted for future wiring.
-const BASH_TOOLS = /^(Bash|shell|local_shell|exec|exec_command)$/;
+const WINDOW = 24;
+// 副作用のあるツールだけが窓をリセットする(読み取り専用ツールを挟んだ偽装ポーリングを通さないため)
+// Only side-effecting tools reset the window, so read-only calls cannot launder a poll loop.
+const RESETTING_TOOLS =
+  /^(Edit|Write|MultiEdit|NotebookEdit|apply_patch|Agent|Task|TaskCreate|TaskUpdate|SendMessage|AskUserQuestion|ExitPlanMode|Workflow|Artifact|EnterWorktree|ExitWorktree)$/;
 
 let input = {};
 try {
@@ -45,9 +52,6 @@ try {
 const session = typeof input?.session_id === "string" ? input.session_id : "";
 const transcript = typeof input?.transcript_path === "string" ? input.transcript_path : "";
 const tool = typeof input?.tool_name === "string" ? input.tool_name : "";
-// Claudeはtool_input.command、Codexのexecツールはtool_input.cmd
-// Claude carries the command in tool_input.command; Codex's exec tool uses tool_input.cmd.
-const rawCmd = input?.tool_input?.command ?? input?.tool_input?.cmd;
 if (!session || !tool) process.exit(0);
 
 const home = homedir();
@@ -56,18 +60,34 @@ const stateDir = join(home, ".cache", "claude-poll-guard");
 const key = `${session}__${basename(transcript)}`.replace(/[\/\\]/g, "_");
 const stateFile = join(stateDir, key);
 
-// Bash以外のツールが挟まったら連続カウントをリセット
-// Any non-Bash tool call resets the streak.
-if (!BASH_TOOLS.test(tool)) {
+// 副作用のあるツールが来たら窓ごと破棄する(実作業が進んだので反復の意味が変わる)
+// A side-effecting tool discards the window: real work advanced, so repeats mean something else.
+if (RESETTING_TOOLS.test(tool)) {
   try {
     rmSync(stateFile, { force: true });
   } catch {}
   process.exit(0);
 }
-if (typeof rawCmd !== "string" || rawCmd === "") process.exit(0);
+
+// キー順を固定して指紋化する(同じ引数がオブジェクトの並び順違いで別物にならないように)
+// Canonicalize key order so identical arguments cannot hash differently.
+function canonical(value) {
+  if (value === null || typeof value !== "object") return JSON.stringify(value) ?? "null";
+  if (Array.isArray(value)) return "[" + value.map(canonical).join(",") + "]";
+  return (
+    "{" +
+    Object.keys(value)
+      .sort()
+      .map((k) => JSON.stringify(k) + ":" + canonical(value[k]))
+      .join(",") +
+    "}"
+  );
+}
+
+const fingerprint = createHash("sha1").update(tool + "|" + canonical(input?.tool_input ?? {})).digest("hex").slice(0, 16);
 
 try {
-  // dir作成と古いstateの掃除はstate新規作成時(エージェントの初回Bash)だけ払う
+  // dir作成と古いstateの掃除はstate新規作成時(エージェントの初回ツール呼び)だけ払う
   // Pay for mkdir + stale-state cleanup only when creating this agent's state file.
   if (!existsSync(stateFile)) {
     mkdirSync(stateDir, { recursive: true });
@@ -80,29 +100,29 @@ try {
     }
   }
 
-  let count = 0;
-  let prev = "";
+  let window = [];
   try {
     const st = JSON.parse(readFileSync(stateFile, "utf8"));
-    if (Number.isInteger(st?.count) && st.count >= 0) count = st.count;
-    if (typeof st?.prev === "string") prev = st.prev;
+    if (Array.isArray(st?.window)) window = st.window.filter((f) => typeof f === "string");
   } catch {}
 
-  count = rawCmd === prev ? count + 1 : 1;
+  window.push(fingerprint);
+  if (window.length > WINDOW) window = window.slice(-WINDOW);
+  const hits = window.filter((f) => f === fingerprint).length;
   // 書き込み失敗はcatchでexit 0に落ちる = denyまで進まない(fail open)
   // A write failure lands in the outer catch and exits 0, never reaching the deny.
-  writeFileSync(stateFile, JSON.stringify({ count, prev: rawCmd }));
+  writeFileSync(stateFile, JSON.stringify({ window, last: tool }));
 
-  if (count >= THRESHOLD) {
-    writeFileSync(stateFile, JSON.stringify({ count: 0, prev: rawCmd }));
+  if (hits >= THRESHOLD) {
+    writeFileSync(stateFile, JSON.stringify({ window: [], last: tool }));
     console.error(
-      `poll-guard: 同一Bashコマンドが${count}回連続しています(ポーリングと判定して拒否。` +
-        "カウンタはリセット済みで、次の同一コマンドは通る)。サブエージェント/バックグラウンド" +
-        "タスクの完了待ちなら、ポーリングせずにターンを終了してtask-notificationを待つこと。" +
-        "状態の出現をどうしても監視する必要があるなら、Monitorツールにuntilループを1本だけ" +
-        "渡すこと(例: until [ -f <path> ]; do sleep 5; done)。意図的な反復(flake確認・" +
-        "一時的失敗の再試行等)やMonitorが無い環境では、1回のBash呼び出し内でfor/untilループ" +
-        "として書くこと。"
+      `poll-guard: 同一の ${tool} 呼び出し(引数まで一致)が直近${window.length}件中${hits}回出現しています` +
+        "(ポーリングと判定して拒否。窓はリセット済みで、次の同一呼び出しは通る)。サブエージェント/" +
+        "バックグラウンドタスクの完了待ちなら、ポーリングせずにターンを終了してtask-notificationを" +
+        "待つこと(ListAgents・TaskGet・BashOutput・成果物ファイルのlsを含め、待つための反復呼び出しは" +
+        "すべて対象)。状態の出現をどうしても監視する必要があるなら、Monitorツールにuntilループを1本" +
+        "だけ渡すこと(例: until [ -f <path> ]; do sleep 5; done)。意図的な反復(flake確認・一時的失敗の" +
+        "再試行等)やMonitorが無い環境では、1回のBash呼び出し内でfor/untilループとして書くこと。"
     );
     process.exit(2);
   }

--- a/.dev-hooks/poll-guard.mjs
+++ b/.dev-hooks/poll-guard.mjs
@@ -13,7 +13,8 @@
 // the streak of 18 repeated Bash polls. Detection is now tool-agnostic and only side-effecting
 // tools clear the streak.
 //
-// 判定: ツール名＋引数の指紋が、直近WINDOW件の非リセット呼び出しの中でTHRESHOLD回に達したらdeny。
+// 判定: ツール名＋引数の指紋が、直近WINDOW件かつWINDOW_SECONDS秒内の非リセット呼び出しの中で
+// THRESHOLD回に達したらdeny。時間窓があるので、分単位で離れた正当な同一呼び出しは積み上がらない。
 // 交互ポーリング(ls → ListAgents → ls …)も窓内の出現回数で拾える。deny後は窓を空にする
 // (恒久ブロックにしない — 主目的は指示の再注入で、正当な反復や一時的失敗の再試行を殺さないため)。
 // Edit/Write/Agent等の副作用ツールが挟まれば窓ごとリセットされるため、実作業の反復は誤検知しない。
@@ -37,10 +38,15 @@ import { join, basename } from "node:path";
 
 const THRESHOLD = 3;
 const WINDOW = 24;
-// 副作用のあるツールだけが窓をリセットする(読み取り専用ツールを挟んだ偽装ポーリングを通さないため)
-// Only side-effecting tools reset the window, so read-only calls cannot launder a poll loop.
+// 3秒間隔のポーリングは窓に残り、分単位で離れた正当な同一呼び出しは残らない長さにする
+// Long enough to hold a 3-second poll loop, short enough to forget legitimate minute-apart repeats.
+const WINDOW_SECONDS = 300;
+// 実作業を進めるツールだけが窓をリセットする(読み取り専用ツールを挟んだ偽装ポーリングを通さないため)
+// Only tools that advance real work reset the window, so read-only calls cannot launder a poll loop.
+// SendMessageは除外する — 同文の「終わった?」をsubagentへ反復送るのは実在のポーリング形態だから。
+// SendMessage is excluded: repeating the same "are you done?" to a subagent is itself a poll loop.
 const RESETTING_TOOLS =
-  /^(Edit|Write|MultiEdit|NotebookEdit|apply_patch|Agent|Task|TaskCreate|TaskUpdate|SendMessage|AskUserQuestion|ExitPlanMode|Workflow|Artifact|EnterWorktree|ExitWorktree)$/;
+  /^(Edit|Write|MultiEdit|NotebookEdit|apply_patch|Agent|TaskCreate|TaskUpdate|AskUserQuestion|ExitPlanMode|Workflow|Artifact|EnterWorktree|ExitWorktree)$/;
 
 let input = {};
 try {
@@ -100,21 +106,26 @@ try {
     }
   }
 
+  const now = Date.now();
   let window = [];
   try {
     const st = JSON.parse(readFileSync(stateFile, "utf8"));
-    if (Array.isArray(st?.window)) window = st.window.filter((f) => typeof f === "string");
+    if (Array.isArray(st?.window)) {
+      window = st.window.filter(
+        (e) => typeof e?.fp === "string" && Number.isFinite(e?.at) && now - e.at <= WINDOW_SECONDS * 1000
+      );
+    }
   } catch {}
 
-  window.push(fingerprint);
+  window.push({ fp: fingerprint, at: now });
   if (window.length > WINDOW) window = window.slice(-WINDOW);
-  const hits = window.filter((f) => f === fingerprint).length;
+  const hits = window.filter((e) => e.fp === fingerprint).length;
+  const denied = hits >= THRESHOLD;
   // 書き込み失敗はcatchでexit 0に落ちる = denyまで進まない(fail open)
   // A write failure lands in the outer catch and exits 0, never reaching the deny.
-  writeFileSync(stateFile, JSON.stringify({ window, last: tool }));
+  writeFileSync(stateFile, JSON.stringify({ window: denied ? [] : window, last: tool }));
 
-  if (hits >= THRESHOLD) {
-    writeFileSync(stateFile, JSON.stringify({ window: [], last: tool }));
+  if (denied) {
     console.error(
       `poll-guard: 同一の ${tool} 呼び出し(引数まで一致)が直近${window.length}件中${hits}回出現しています` +
         "(ポーリングと判定して拒否。窓はリセット済みで、次の同一呼び出しは通る)。サブエージェント/" +

--- a/.dev-hooks/poll-guard.mjs
+++ b/.dev-hooks/poll-guard.mjs
@@ -38,15 +38,15 @@ import { join, basename } from "node:path";
 
 const THRESHOLD = 3;
 const WINDOW = 24;
-// 3秒間隔のポーリングは窓に残り、分単位で離れた正当な同一呼び出しは残らない長さにする
-// Long enough to hold a 3-second poll loop, short enough to forget legitimate minute-apart repeats.
-const WINDOW_SECONDS = 300;
+// sleepを挟む遅いポーリング(間隔15分未満)まで捕まえる長さにする。短くすると素通りする穴になる
+// Long enough to catch slow sleep-based polling (under 15 min apart); shorter values become a bypass.
+const WINDOW_SECONDS = 1800;
 // 実作業を進めるツールだけが窓をリセットする(読み取り専用ツールを挟んだ偽装ポーリングを通さないため)
 // Only tools that advance real work reset the window, so read-only calls cannot launder a poll loop.
 // SendMessageは除外する — 同文の「終わった?」をsubagentへ反復送るのは実在のポーリング形態だから。
 // SendMessage is excluded: repeating the same "are you done?" to a subagent is itself a poll loop.
 const RESETTING_TOOLS =
-  /^(Edit|Write|MultiEdit|NotebookEdit|apply_patch|Agent|TaskCreate|TaskUpdate|AskUserQuestion|ExitPlanMode|Workflow|Artifact|EnterWorktree|ExitWorktree)$/;
+  /^(Edit|Write|MultiEdit|NotebookEdit|apply_patch|Agent|Task|TaskCreate|TaskUpdate|AskUserQuestion|ExitPlanMode|Workflow|Artifact|EnterWorktree|ExitWorktree)$/;
 
 let input = {};
 try {


### PR DESCRIPTION
## Summary
- poll-guard hook の検知対象を Bash 限定から全ツールへ一般化し、リセットするのは副作用のあるツール（Edit/Write/Agent等）だけに限定した
- 判定ロジックを「直前と完全一致の連続」から「直近24件かつ1800秒の窓での同一指紋の出現回数がTHRESHOLD(3)回」へ変更
- state の鍵に自スクリプトpathのhashを混ぜて、ユーザー全体hookとproject hookの二重登録による二重カウントを防止

## 動機
旧実装はBash以外を判定対象外にしたうえ、非Bashツールが来るとカウンタを消していたため、2026-08-17のセッションで ListAgents 593回（最長380回連続・間隔中央値3秒）のポーリングが素通りし、間にListAgentsを挟んだBash 18回反復も検知できなかった。関連Beadsタスク: moorestech-2xm

## 変更ファイル
- `.dev-hooks/poll-guard.mjs` (+123 -44)
- `.dev-hooks/README.md` (+11 -1)

.cs変更ゼロ、Web関連の変更ゼロ（スクリーンショット添付は対象外）。

## 検証済み
- 同一ListAgents×3で3回目に exit 2
- 引数が違えば4連続でも通る
- ls⇄ListAgentsの交互ポーリングも窓で捕捉して exit 2
- 間にEditが挟まれば窓がリセットされ通る

（moores-code-review は今回未実施）

Generated with [Claude Code](https://claude.com/claude-code)