### PR TITLE
feat(env): 鉱脈ビジュアルに資源種別ごとのマテリアルバリエーションを追加

### DIFF
--- a/moorestech_client/Assets/AddressableAssetsData/AssetGroups/Vanilla Asset Group.asset
+++ b/moorestech_client/Assets/AddressableAssetsData/AssetGroups/Vanilla Asset Group.asset
@@ -250,6 +250,11 @@ MonoBehaviour:
     m_ReadOnly: 0
     m_SerializedLabels: []
     FlaggedDuringContentUpdateRestriction: 0
+  - m_GUID: 19d78660b83304b7393b0f7aebc2fb03
+    m_Address: Vanilla/Environment/Vein/Item/VeinPrefab_Copper
+    m_ReadOnly: 0
+    m_SerializedLabels: []
+    FlaggedDuringContentUpdateRestriction: 0
   - m_GUID: 1a76de895924b4f4f9377d554d2dd050
     m_Address: Vanilla/Environment/Tree/Savanna/Bush3
     m_ReadOnly: 0
@@ -287,6 +292,11 @@ MonoBehaviour:
     FlaggedDuringContentUpdateRestriction: 0
   - m_GUID: 1cf601f7c10835f4790932aad2abdb25
     m_Address: Vanilla/Block/Old/IC chip assembler
+    m_ReadOnly: 0
+    m_SerializedLabels: []
+    FlaggedDuringContentUpdateRestriction: 0
+  - m_GUID: 1df27d00e9d6b46ea8535b047020338c
+    m_Address: Vanilla/Environment/Vein/Item/VeinPrefab_Iron
     m_ReadOnly: 0
     m_SerializedLabels: []
     FlaggedDuringContentUpdateRestriction: 0
@@ -622,6 +632,11 @@ MonoBehaviour:
     FlaggedDuringContentUpdateRestriction: 0
   - m_GUID: 457461b7f513b4ad0b0f975784351904
     m_Address: Vanilla/Environment/Plant/MesaDesert/Brittlebush_1
+    m_ReadOnly: 0
+    m_SerializedLabels: []
+    FlaggedDuringContentUpdateRestriction: 0
+  - m_GUID: 45bd1c42410764c4baff0d3becb83757
+    m_Address: Vanilla/Environment/Vein/Item/VeinPrefab_Bronz
     m_ReadOnly: 0
     m_SerializedLabels: []
     FlaggedDuringContentUpdateRestriction: 0
@@ -1040,6 +1055,11 @@ MonoBehaviour:
     m_ReadOnly: 0
     m_SerializedLabels: []
     FlaggedDuringContentUpdateRestriction: 0
+  - m_GUID: 748a5d3a11124487b94c9f886e929dc7
+    m_Address: Vanilla/Environment/Vein/Item/VeinPrefab_Tree
+    m_ReadOnly: 0
+    m_SerializedLabels: []
+    FlaggedDuringContentUpdateRestriction: 0
   - m_GUID: 74c661b69539b4646b58bacbc3365a30
     m_Address: Vanilla/Block/PipeStraightWindow
     m_ReadOnly: 0
@@ -1132,6 +1152,11 @@ MonoBehaviour:
     FlaggedDuringContentUpdateRestriction: 0
   - m_GUID: 7ca897a22f2fc4b68b93d719a1c29e63
     m_Address: Vanilla/Environment/Vein/Item/Tree
+    m_ReadOnly: 0
+    m_SerializedLabels: []
+    FlaggedDuringContentUpdateRestriction: 0
+  - m_GUID: 7cf40dd9ee7c343cdbe4920821c3a812
+    m_Address: Vanilla/Environment/Vein/Item/VeinPrefab_Clay
     m_ReadOnly: 0
     m_SerializedLabels: []
     FlaggedDuringContentUpdateRestriction: 0
@@ -2167,6 +2192,11 @@ MonoBehaviour:
     FlaggedDuringContentUpdateRestriction: 0
   - m_GUID: e039e23dd6ec87742ac59a0964a66fa0
     m_Address: Vanilla/Block/iron furnace with bellows
+    m_ReadOnly: 0
+    m_SerializedLabels: []
+    FlaggedDuringContentUpdateRestriction: 0
+  - m_GUID: e1ac52bd224134096b414e2a37f5a747
+    m_Address: Vanilla/Environment/Vein/Item/VeinPrefab_Coal
     m_ReadOnly: 0
     m_SerializedLabels: []
     FlaggedDuringContentUpdateRestriction: 0

--- a/moorestech_client/Assets/AddressableAssetsData/AssetGroups/Vanilla Asset Group.asset
+++ b/moorestech_client/Assets/AddressableAssetsData/AssetGroups/Vanilla Asset Group.asset
@@ -330,6 +330,11 @@ MonoBehaviour:
     m_ReadOnly: 0
     m_SerializedLabels: []
     FlaggedDuringContentUpdateRestriction: 0
+  - m_GUID: 1f9e7411df63240d994142b1ccb1b971
+    m_Address: Vanilla/Environment/Vein/Item/VeinPrefab_Stone
+    m_ReadOnly: 0
+    m_SerializedLabels: []
+    FlaggedDuringContentUpdateRestriction: 0
   - m_GUID: 20610057e121e458dab7f6e14c754787
     m_Address: Vanilla/Environment/Rock/Mountains/Stone1
     m_ReadOnly: 0

--- a/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefabBase.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefabBase.prefab
@@ -1,0 +1,599 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7777184945603898279
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3411773016607635121}
+  - component: {fileID: 6210964166733236183}
+  m_Layer: 0
+  m_Name: VeinPrefabBase
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3411773016607635121
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7777184945603898279}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 766.9, y: 78.56, z: 849.4}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5148302405645803904}
+  - {fileID: 2539337192159425586}
+  - {fileID: 151013987900853770}
+  - {fileID: 4192479114256082799}
+  - {fileID: 7005847663050398316}
+  - {fileID: 4916749688045990703}
+  - {fileID: 5330711295270609747}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!205 &6210964166733236183
+LODGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7777184945603898279}
+  serializedVersion: 2
+  m_LocalReferencePoint: {x: -0.09312862, y: 0.19197348, z: -0.097022176}
+  m_Size: 2.2191339
+  m_FadeMode: 0
+  m_AnimateCrossFading: 0
+  m_LastLODIsBillboard: 0
+  m_LODs:
+  - screenRelativeHeight: 0.04005259
+    fadeTransitionWidth: 0
+    renderers:
+    - renderer: {fileID: 7572237721331722063}
+    - renderer: {fileID: 962088534504469245}
+    - renderer: {fileID: 3206296545162348741}
+    - renderer: {fileID: 1461737345332978080}
+    - renderer: {fileID: 5719090494191590563}
+    - renderer: {fileID: 7664073366109337056}
+  m_Enabled: 1
+--- !u!1001 &569530455632631772
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 3411773016607635121}
+    m_Modifications:
+    - target: {fileID: 773887420266620193, guid: e198fab53f70a25478a00348862a707e, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 75b6be70f9d9c432a99d976c7acb824c, type: 2}
+    - target: {fileID: 1333541091171930621, guid: e198fab53f70a25478a00348862a707e, type: 3}
+      propertyPath: m_Name
+      value: Rock08
+      objectReference: {fileID: 0}
+    - target: {fileID: 2655691487863792622, guid: e198fab53f70a25478a00348862a707e, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.76134
+      objectReference: {fileID: 0}
+    - target: {fileID: 2655691487863792622, guid: e198fab53f70a25478a00348862a707e, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.76134
+      objectReference: {fileID: 0}
+    - target: {fileID: 2655691487863792622, guid: e198fab53f70a25478a00348862a707e, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.76134
+      objectReference: {fileID: 0}
+    - target: {fileID: 2655691487863792622, guid: e198fab53f70a25478a00348862a707e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.666
+      objectReference: {fileID: 0}
+    - target: {fileID: 2655691487863792622, guid: e198fab53f70a25478a00348862a707e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.192
+      objectReference: {fileID: 0}
+    - target: {fileID: 2655691487863792622, guid: e198fab53f70a25478a00348862a707e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.743
+      objectReference: {fileID: 0}
+    - target: {fileID: 2655691487863792622, guid: e198fab53f70a25478a00348862a707e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.22991109
+      objectReference: {fileID: 0}
+    - target: {fileID: 2655691487863792622, guid: e198fab53f70a25478a00348862a707e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.57398456
+      objectReference: {fileID: 0}
+    - target: {fileID: 2655691487863792622, guid: e198fab53f70a25478a00348862a707e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.3836172
+      objectReference: {fileID: 0}
+    - target: {fileID: 2655691487863792622, guid: e198fab53f70a25478a00348862a707e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.685945
+      objectReference: {fileID: 0}
+    - target: {fileID: 2655691487863792622, guid: e198fab53f70a25478a00348862a707e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -15.21
+      objectReference: {fileID: 0}
+    - target: {fileID: 2655691487863792622, guid: e198fab53f70a25478a00348862a707e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 87.223
+      objectReference: {fileID: 0}
+    - target: {fileID: 2655691487863792622, guid: e198fab53f70a25478a00348862a707e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -231.557
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: -3476315560463321058, guid: e198fab53f70a25478a00348862a707e, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e198fab53f70a25478a00348862a707e, type: 3}
+--- !u!23 &962088534504469245 stripped
+MeshRenderer:
+  m_CorrespondingSourceObject: {fileID: 773887420266620193, guid: e198fab53f70a25478a00348862a707e, type: 3}
+  m_PrefabInstance: {fileID: 569530455632631772}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &2539337192159425586 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2655691487863792622, guid: e198fab53f70a25478a00348862a707e, type: 3}
+  m_PrefabInstance: {fileID: 569530455632631772}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1395774777788972230
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 3411773016607635121}
+    m_Modifications:
+    - target: {fileID: 511136142808128870, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 75b6be70f9d9c432a99d976c7acb824c, type: 2}
+    - target: {fileID: 2245956535012501946, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_Name
+      value: Rock11_3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.242
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.34500122
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.174
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.56350994
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.58783835
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.52302516
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.25168896
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -67.787
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -230.941
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -61.188
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: -7290580861758732654, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+--- !u!23 &1461737345332978080 stripped
+MeshRenderer:
+  m_CorrespondingSourceObject: {fileID: 511136142808128870, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+  m_PrefabInstance: {fileID: 1395774777788972230}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &4192479114256082799 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+  m_PrefabInstance: {fileID: 1395774777788972230}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3128002988955129251
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 3411773016607635121}
+    m_Modifications:
+    - target: {fileID: 511136142808128870, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 75b6be70f9d9c432a99d976c7acb824c, type: 2}
+    - target: {fileID: 2245956535012501946, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_Name
+      value: Rock11
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.744
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.247
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.663
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7641847
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.64499754
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -80.331
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: -7290580861758732654, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+--- !u!4 &151013987900853770 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+  m_PrefabInstance: {fileID: 3128002988955129251}
+  m_PrefabAsset: {fileID: 0}
+--- !u!23 &3206296545162348741 stripped
+MeshRenderer:
+  m_CorrespondingSourceObject: {fileID: 511136142808128870, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+  m_PrefabInstance: {fileID: 3128002988955129251}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5208871594242032069
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 3411773016607635121}
+    m_Modifications:
+    - target: {fileID: 511136142808128870, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 75b6be70f9d9c432a99d976c7acb824c, type: 2}
+    - target: {fileID: 2245956535012501946, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_Name
+      value: Rock11_2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.994
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.311
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.204
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7641847
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.64499754
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -80.331
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: -7290580861758732654, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+--- !u!23 &5719090494191590563 stripped
+MeshRenderer:
+  m_CorrespondingSourceObject: {fileID: 511136142808128870, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+  m_PrefabInstance: {fileID: 5208871594242032069}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &7005847663050398316 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+  m_PrefabInstance: {fileID: 5208871594242032069}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7875574756857849990
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 3411773016607635121}
+    m_Modifications:
+    - target: {fileID: 511136142808128870, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 75b6be70f9d9c432a99d976c7acb824c, type: 2}
+    - target: {fileID: 2245956535012501946, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_Name
+      value: Rock11_1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.175
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.299
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.397
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.8020042
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.47677222
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.024305075
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.3590081
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 51.462
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 29.136
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -297.492
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: -7290580861758732654, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+--- !u!4 &4916749688045990703 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+  m_PrefabInstance: {fileID: 7875574756857849990}
+  m_PrefabAsset: {fileID: 0}
+--- !u!23 &7664073366109337056 stripped
+MeshRenderer:
+  m_CorrespondingSourceObject: {fileID: 511136142808128870, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+  m_PrefabInstance: {fileID: 7875574756857849990}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7976107150263536010
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 3411773016607635121}
+    m_Modifications:
+    - target: {fileID: 2831267316483566297, guid: 9e31d6d9401ccb84999ae6527f00513a, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.1457817
+      objectReference: {fileID: 0}
+    - target: {fileID: 2831267316483566297, guid: 9e31d6d9401ccb84999ae6527f00513a, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.1457817
+      objectReference: {fileID: 0}
+    - target: {fileID: 2831267316483566297, guid: 9e31d6d9401ccb84999ae6527f00513a, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.18040484
+      objectReference: {fileID: 0}
+    - target: {fileID: 2831267316483566297, guid: 9e31d6d9401ccb84999ae6527f00513a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.0020141602
+      objectReference: {fileID: 0}
+    - target: {fileID: 2831267316483566297, guid: 9e31d6d9401ccb84999ae6527f00513a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.058998108
+      objectReference: {fileID: 0}
+    - target: {fileID: 2831267316483566297, guid: 9e31d6d9401ccb84999ae6527f00513a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.013000488
+      objectReference: {fileID: 0}
+    - target: {fileID: 2831267316483566297, guid: 9e31d6d9401ccb84999ae6527f00513a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2831267316483566297, guid: 9e31d6d9401ccb84999ae6527f00513a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2831267316483566297, guid: 9e31d6d9401ccb84999ae6527f00513a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2831267316483566297, guid: 9e31d6d9401ccb84999ae6527f00513a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2831267316483566297, guid: 9e31d6d9401ccb84999ae6527f00513a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2831267316483566297, guid: 9e31d6d9401ccb84999ae6527f00513a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2831267316483566297, guid: 9e31d6d9401ccb84999ae6527f00513a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3170954371187699811, guid: 9e31d6d9401ccb84999ae6527f00513a, type: 3}
+      propertyPath: m_Name
+      value: Vein_based_Cliff02f
+      objectReference: {fileID: 0}
+    - target: {fileID: 3963592371525046710, guid: 9e31d6d9401ccb84999ae6527f00513a, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: ead07fa83dae04c43883e5ef46b18f74, type: 2}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9e31d6d9401ccb84999ae6527f00513a, type: 3}
+--- !u!4 &5330711295270609747 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2831267316483566297, guid: 9e31d6d9401ccb84999ae6527f00513a, type: 3}
+  m_PrefabInstance: {fileID: 7976107150263536010}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8682579036271281213
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 3411773016607635121}
+    m_Modifications:
+    - target: {fileID: 673182297715660718, guid: 7f16ab3e3a7705b44a369f388e2a0472, type: 3}
+      propertyPath: m_Name
+      value: Rock12
+      objectReference: {fileID: 0}
+    - target: {fileID: 1255177971916759922, guid: 7f16ab3e3a7705b44a369f388e2a0472, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 75b6be70f9d9c432a99d976c7acb824c, type: 2}
+    - target: {fileID: 4543224253754549693, guid: 7f16ab3e3a7705b44a369f388e2a0472, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.80556
+      objectReference: {fileID: 0}
+    - target: {fileID: 4543224253754549693, guid: 7f16ab3e3a7705b44a369f388e2a0472, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.80556
+      objectReference: {fileID: 0}
+    - target: {fileID: 4543224253754549693, guid: 7f16ab3e3a7705b44a369f388e2a0472, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.80556
+      objectReference: {fileID: 0}
+    - target: {fileID: 4543224253754549693, guid: 7f16ab3e3a7705b44a369f388e2a0472, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.719
+      objectReference: {fileID: 0}
+    - target: {fileID: 4543224253754549693, guid: 7f16ab3e3a7705b44a369f388e2a0472, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.168
+      objectReference: {fileID: 0}
+    - target: {fileID: 4543224253754549693, guid: 7f16ab3e3a7705b44a369f388e2a0472, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.522
+      objectReference: {fileID: 0}
+    - target: {fileID: 4543224253754549693, guid: 7f16ab3e3a7705b44a369f388e2a0472, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.44267753
+      objectReference: {fileID: 0}
+    - target: {fileID: 4543224253754549693, guid: 7f16ab3e3a7705b44a369f388e2a0472, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.03131084
+      objectReference: {fileID: 0}
+    - target: {fileID: 4543224253754549693, guid: 7f16ab3e3a7705b44a369f388e2a0472, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.53210443
+      objectReference: {fileID: 0}
+    - target: {fileID: 4543224253754549693, guid: 7f16ab3e3a7705b44a369f388e2a0472, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.7210556
+      objectReference: {fileID: 0}
+    - target: {fileID: 4543224253754549693, guid: 7f16ab3e3a7705b44a369f388e2a0472, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -52.662
+      objectReference: {fileID: 0}
+    - target: {fileID: 4543224253754549693, guid: 7f16ab3e3a7705b44a369f388e2a0472, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 44.611
+      objectReference: {fileID: 0}
+    - target: {fileID: 4543224253754549693, guid: 7f16ab3e3a7705b44a369f388e2a0472, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -266.048
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 8951066691353222406, guid: 7f16ab3e3a7705b44a369f388e2a0472, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7f16ab3e3a7705b44a369f388e2a0472, type: 3}
+--- !u!4 &5148302405645803904 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4543224253754549693, guid: 7f16ab3e3a7705b44a369f388e2a0472, type: 3}
+  m_PrefabInstance: {fileID: 8682579036271281213}
+  m_PrefabAsset: {fileID: 0}
+--- !u!23 &7572237721331722063 stripped
+MeshRenderer:
+  m_CorrespondingSourceObject: {fileID: 1255177971916759922, guid: 7f16ab3e3a7705b44a369f388e2a0472, type: 3}
+  m_PrefabInstance: {fileID: 8682579036271281213}
+  m_PrefabAsset: {fileID: 0}

--- a/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefabBase.prefab.meta
+++ b/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefabBase.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d18aa0284baff47518ed573eeea77043
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefab_Bronz.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefab_Bronz.prefab
@@ -1,0 +1,87 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5324710704204527812
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 962088534504469245, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: f966803060b3d4829b0f54c5c113a6de, type: 2}
+    - target: {fileID: 1461737345332978080, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: f966803060b3d4829b0f54c5c113a6de, type: 2}
+    - target: {fileID: 3206296545162348741, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: f966803060b3d4829b0f54c5c113a6de, type: 2}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.029364672
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.5403311
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.2145963
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5719090494191590563, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: f966803060b3d4829b0f54c5c113a6de, type: 2}
+    - target: {fileID: 6463036493255120956, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: e43e512e49cc1407288e64731c6323f9, type: 2}
+    - target: {fileID: 7572237721331722063, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: f966803060b3d4829b0f54c5c113a6de, type: 2}
+    - target: {fileID: 7664073366109337056, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: f966803060b3d4829b0f54c5c113a6de, type: 2}
+    - target: {fileID: 7777184945603898279, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_Name
+      value: VeinPrefab_Bronz
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d18aa0284baff47518ed573eeea77043, type: 3}

--- a/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefab_Bronz.prefab.meta
+++ b/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefab_Bronz.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 45bd1c42410764c4baff0d3becb83757
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefab_Clay.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefab_Clay.prefab
@@ -1,0 +1,87 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5324710704204527812
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 962088534504469245, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 034c74eb7928f453595deb0722b26890, type: 2}
+    - target: {fileID: 1461737345332978080, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 034c74eb7928f453595deb0722b26890, type: 2}
+    - target: {fileID: 3206296545162348741, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 034c74eb7928f453595deb0722b26890, type: 2}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.029364672
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.5403311
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.2145963
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5719090494191590563, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 034c74eb7928f453595deb0722b26890, type: 2}
+    - target: {fileID: 6463036493255120956, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: e2686011a12a246b191d741eda51d10b, type: 2}
+    - target: {fileID: 7572237721331722063, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 034c74eb7928f453595deb0722b26890, type: 2}
+    - target: {fileID: 7664073366109337056, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 034c74eb7928f453595deb0722b26890, type: 2}
+    - target: {fileID: 7777184945603898279, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_Name
+      value: VeinPrefab_Clay
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d18aa0284baff47518ed573eeea77043, type: 3}

--- a/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefab_Clay.prefab.meta
+++ b/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefab_Clay.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7cf40dd9ee7c343cdbe4920821c3a812
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefab_Coal.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefab_Coal.prefab
@@ -1,0 +1,87 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5324710704204527812
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 962088534504469245, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 65a119b264eb647318863c1113f79400, type: 2}
+    - target: {fileID: 1461737345332978080, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 65a119b264eb647318863c1113f79400, type: 2}
+    - target: {fileID: 3206296545162348741, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 65a119b264eb647318863c1113f79400, type: 2}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.029364672
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.5403311
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.2145963
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5719090494191590563, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 65a119b264eb647318863c1113f79400, type: 2}
+    - target: {fileID: 6463036493255120956, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 109950d2510824e87bf3777d5619a1b3, type: 2}
+    - target: {fileID: 7572237721331722063, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 65a119b264eb647318863c1113f79400, type: 2}
+    - target: {fileID: 7664073366109337056, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 65a119b264eb647318863c1113f79400, type: 2}
+    - target: {fileID: 7777184945603898279, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_Name
+      value: VeinPrefab_Coal
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d18aa0284baff47518ed573eeea77043, type: 3}

--- a/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefab_Coal.prefab.meta
+++ b/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefab_Coal.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e1ac52bd224134096b414e2a37f5a747
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefab_Copper.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefab_Copper.prefab
@@ -1,0 +1,87 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5324710704204527812
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 962088534504469245, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 08f903dfa8ece42ba98a4d0c25f52552, type: 2}
+    - target: {fileID: 1461737345332978080, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 08f903dfa8ece42ba98a4d0c25f52552, type: 2}
+    - target: {fileID: 3206296545162348741, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 08f903dfa8ece42ba98a4d0c25f52552, type: 2}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.029364672
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.5403311
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.2145963
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5719090494191590563, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 08f903dfa8ece42ba98a4d0c25f52552, type: 2}
+    - target: {fileID: 6463036493255120956, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 515c58d44c2094053a770d359aa0410e, type: 2}
+    - target: {fileID: 7572237721331722063, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 08f903dfa8ece42ba98a4d0c25f52552, type: 2}
+    - target: {fileID: 7664073366109337056, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 08f903dfa8ece42ba98a4d0c25f52552, type: 2}
+    - target: {fileID: 7777184945603898279, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_Name
+      value: VeinPrefab_Copper
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d18aa0284baff47518ed573eeea77043, type: 3}

--- a/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefab_Copper.prefab.meta
+++ b/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefab_Copper.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 19d78660b83304b7393b0f7aebc2fb03
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefab_Iron.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefab_Iron.prefab
@@ -1,0 +1,87 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5324710704204527812
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 962088534504469245, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 6f4510534f256454191aa193cc000b6f, type: 2}
+    - target: {fileID: 1461737345332978080, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 6f4510534f256454191aa193cc000b6f, type: 2}
+    - target: {fileID: 3206296545162348741, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 6f4510534f256454191aa193cc000b6f, type: 2}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.029364672
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.5403311
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.2145963
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5719090494191590563, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 6f4510534f256454191aa193cc000b6f, type: 2}
+    - target: {fileID: 6463036493255120956, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 3ea02327f5489407d960fa776b809f6a, type: 2}
+    - target: {fileID: 7572237721331722063, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 6f4510534f256454191aa193cc000b6f, type: 2}
+    - target: {fileID: 7664073366109337056, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 6f4510534f256454191aa193cc000b6f, type: 2}
+    - target: {fileID: 7777184945603898279, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_Name
+      value: VeinPrefab_Iron
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d18aa0284baff47518ed573eeea77043, type: 3}

--- a/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefab_Iron.prefab.meta
+++ b/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefab_Iron.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1df27d00e9d6b46ea8535b047020338c
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefab_Stone.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefab_Stone.prefab
@@ -1,0 +1,59 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5324710704204527812
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.029364672
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.5403311
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.2145963
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7777184945603898279, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_Name
+      value: VeinPrefabBase_1 Variant
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d18aa0284baff47518ed573eeea77043, type: 3}

--- a/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefab_Stone.prefab.meta
+++ b/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefab_Stone.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1f9e7411df63240d994142b1ccb1b971
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefab_Tree.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefab_Tree.prefab
@@ -1,0 +1,87 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &3955900045675839602
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 962088534504469245, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 1005b563f250042e1a563e73df231266, type: 2}
+    - target: {fileID: 1461737345332978080, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 1005b563f250042e1a563e73df231266, type: 2}
+    - target: {fileID: 3206296545162348741, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 1005b563f250042e1a563e73df231266, type: 2}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 750.7832
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.54033196
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -249.28122
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3411773016607635121, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5719090494191590563, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 1005b563f250042e1a563e73df231266, type: 2}
+    - target: {fileID: 6463036493255120956, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 74bff1e3e37d0476ca445d48336f4692, type: 2}
+    - target: {fileID: 7572237721331722063, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 1005b563f250042e1a563e73df231266, type: 2}
+    - target: {fileID: 7664073366109337056, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 1005b563f250042e1a563e73df231266, type: 2}
+    - target: {fileID: 7777184945603898279, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: m_Name
+      value: VeinPrefab_Tree
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d18aa0284baff47518ed573eeea77043, type: 3}

--- a/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefab_Tree.prefab.meta
+++ b/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefab_Tree.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 748a5d3a11124487b94c9f886e929dc7
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- `VeinPrefabBase.prefab`（鉱脈の見た目用マップオブジェクト）をベースに、資源種別ごとのマテリアルバリアントprefabを追加
  - `VeinPrefab_Tree`（木材）/ `VeinPrefab_Bronz`（ブロンズ）/ `VeinPrefab_Iron`（鉄）/ `VeinPrefab_Copper`（銅）/ `VeinPrefab_Clay`（粘土）/ `VeinPrefab_Coal`（石炭）
- Rockメッシュ（小さい鉱石粒）のアルベドのみ複製し、資源ごとのトーンカーブ/色調補正を適用
- ベースCliffメッシュは低〜中彩度のトーンに抑え、鉱石粒（Rock）が視覚的に目立つよう配色（石炭のみベースCliffごと黒系に統一）
- 参照テクスチャ・マテリアルは非公開アセットリポジトリ（PersonalAssets/moorestech-client-private）側で管理、GUID参照はAddressablesグループへ反映済み

## Test plan
- [x] Unity Editor上でシーンにインスタンス化し、各バリアントの見た目をScene Viewで目視確認
- [x] 色調補正の数値検証（HSVの彩度・色相シフトをUnity C#で算出しログ出力、無彩色→有彩色への変化を確認）
- [ ] 実プレイでの採掘対象としての見た目確認（未実施）

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01AW5onx7wcGCFqsRsCTN637