### PR TITLE
feat(client): 破壊モード中もミドルクリックで設置モードへ遷移（スポイト）

### DIFF
--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/UIState/State/DeleteObjectState.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/UIState/State/DeleteObjectState.cs
@@ -1,8 +1,10 @@
 using Client.Game.InGame.Train.RailGraph;
+using Client.Game.InGame.BlockSystem.PlaceSystem;
 using Client.Game.InGame.BlockSystem.PlaceSystem.Undo;
 using Client.Game.InGame.UI.KeyControl;
 using Client.Game.InGame.UI.UIState.State.CameraPolicy;
 using Client.Game.InGame.UI.UIState.State.DragDelete;
+using Client.Game.InGame.UI.UIState.State.PlacementPick;
 using Client.Game.InGame.UI.UIState.UIObject;
 using Client.Input;
 using UnityEngine;
@@ -13,16 +15,18 @@ namespace Client.Game.InGame.UI.UIState.State
     {
         private readonly DeleteBarObject _deleteBarObject;
         private readonly UiStateCameraPolicyService _cameraPolicyService;
+        private readonly PlacementTargetPickService _placementTargetPickService;
 
         private readonly DeleteObjectService _deleteObjectService;
         private readonly BuildUndoService _buildUndoService;
 
-        public DeleteObjectState(DeleteBarObject deleteBarObject, RailGraphClientCache cache, UiStateCameraPolicyService cameraPolicyService, BuildOperationHistory buildOperationHistory, BuildUndoService buildUndoService)
+        public DeleteObjectState(DeleteBarObject deleteBarObject, RailGraphClientCache cache, UiStateCameraPolicyService cameraPolicyService, BuildOperationHistory buildOperationHistory, BuildUndoService buildUndoService, PlacementTargetPickService placementTargetPickService)
         {
             _deleteBarObject = deleteBarObject;
             _cameraPolicyService = cameraPolicyService;
             _deleteObjectService = new DeleteObjectService(buildOperationHistory);
             _buildUndoService = buildUndoService;
+            _placementTargetPickService = placementTargetPickService;
             deleteBarObject.gameObject.SetActive(false);
         }
 
@@ -33,7 +37,7 @@ namespace Client.Game.InGame.UI.UIState.State
             _cameraPolicyService.EnterBuildMode();
 
             _deleteBarObject.gameObject.SetActive(!WebUiScreenGate.IsWebUiMode);
-            KeyControlDescription.Instance.SetText("ドラッグ: まとめて選択\n離す: まとめて削除\nV: 視点切替\nESC: 選択キャンセル\nG: 破壊モード終了\nB: 設置モード\nTab: インベントリ\nCtrl+Z: 元に戻す");
+            KeyControlDescription.Instance.SetText("ドラッグ: まとめて選択\n離す: まとめて削除\nV: 視点切替\nESC: 選択キャンセル\nG: 破壊モード終了\nB: 設置モード\nミドルクリック: 設置物をスポイト\nTab: インベントリ\nCtrl+Z: 元に戻す");
         }
 
         public UITransitContext GetNextUpdate()
@@ -73,6 +77,12 @@ namespace Client.Game.InGame.UI.UIState.State
                 {
                     return new UITransitContext(UIStateEnum.GameScreen);
                 }
+
+                // ミドルクリックで設置物をスポイトし設置モードへ移る
+                // Middle-click eyedrops a placed object and switches to placement mode
+                if (_placementTargetPickService.TryPickTargetUnderCursor(out var pickedTarget))
+                    return new UITransitContext(UIStateEnum.PlaceBlock, UITransitContextContainer.Create(new PlacementSelection(pickedTarget, PlacementOrigin.NonHotbar)));
+
                 return null;
             }
 

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/UIState/State/PlaceBlockState.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/UIState/State/PlaceBlockState.cs
@@ -62,8 +62,8 @@ namespace Client.Game.InGame.UI.UIState.State
             // Take the placement target and its origin as one pair from the transition payload and hand them to the owner (falls back to Empty when absent)
             if (context.TryGetContext<PlacementSelection>(out var selection)) _placeSystemStateController.SetTarget(selection.Target, selection.Origin);
 
-            // 対象未選択でも滞在中は範囲表示を出す。遷移元(BuildMenuState/GameScreenState)が必ずtargetを載せる
-            // Show the range view for the whole stay even without a target; both entries (BuildMenuState/GameScreenState) always carry one
+            // 対象未選択でも滞在中は範囲表示を出す。遷移元(BuildMenu/GameScreen/DeleteObject)が必ずtargetを載せる
+            // Show the range view for the whole stay even without a target; every entry (BuildMenu/GameScreen/DeleteObject) carries one
             _mapVeinRangeView.Show(true);
 
             // 視点別カーソル/回転ポリシーを適用

--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/UIState/State/PlacementPick/PlacementTargetPickService.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/UIState/State/PlacementPick/PlacementTargetPickService.cs
@@ -28,6 +28,9 @@ namespace Client.Game.InGame.UI.UIState.State.PlacementPick
             //TODO InputSystem対応
             if (!HybridInput.GetMouseButtonDown(2)) return false;
             if (UiPointerHitTest.IsPointerOverAnyUi()) return false;
+            // 左ドラッグ中はスポイトしない（遷移先でGetKeyUpが拾われ意図せず設置されるのを防ぐ）
+            // Skip picking during a left-drag (the release would be consumed as a place click in the next state)
+            if (HybridInput.GetMouseButton(0)) return false;
 
             // 電線→列車→ブロックの順に解決する（ワイヤー優先は電線ツールの切断判定と整合）
             // Resolve wire, then train car, then block (wire priority matches the wire tool's disconnect check)

--- a/moorestech_client/Assets/Scripts/Client.Tests/UIState/UIStateCameraInteractionTest.cs
+++ b/moorestech_client/Assets/Scripts/Client.Tests/UIState/UIStateCameraInteractionTest.cs
@@ -81,7 +81,7 @@ namespace Client.Tests.UIState
             // 履歴はサービスと共有する（記録先とpop元が別インスタンスになる罠の防止）
             // Share the history with the service (avoids the trap of recording into a different instance than the one popped)
             var buildOperationHistory = new BuildOperationHistory();
-            var state = new DeleteObjectState(deleteObject, null, CreateCameraPolicy(applier), buildOperationHistory, new BuildUndoService(buildOperationHistory, null));
+            var state = new DeleteObjectState(deleteObject, null, CreateCameraPolicy(applier), buildOperationHistory, new BuildUndoService(buildOperationHistory, null), new PlacementTargetPickService(null));
             state.OnEnter(new UITransitContext(UIStateEnum.DeleteBar));
             CollectionAssert.AreEqual(new[] { "Mode:PointerFree" }, applier.Calls);
 

--- a/moorestech_client/Assets/Scripts/Client.Tests/UIState/UIStateFocusRestorationTest.cs
+++ b/moorestech_client/Assets/Scripts/Client.Tests/UIState/UIStateFocusRestorationTest.cs
@@ -108,7 +108,7 @@ namespace Client.Tests.UIState
             // 履歴はサービスと共有する（記録先とpop元が別インスタンスになる罠の防止）
             // Share the history with the service (avoids the trap of recording into a different instance than the one popped)
             var buildOperationHistory = new BuildOperationHistory();
-            return new DeleteObjectState(deleteObject, null, CreateCameraPolicy(applier, viewModeController), buildOperationHistory, new BuildUndoService(buildOperationHistory, null));
+            return new DeleteObjectState(deleteObject, null, CreateCameraPolicy(applier, viewModeController), buildOperationHistory, new BuildUndoService(buildOperationHistory, null), new PlacementTargetPickService(null));
         }
     }
 }


### PR DESCRIPTION
## Summary
- `DeleteObjectState`（破壊モード）にも `GameScreenState` と同様のミドルクリック・スポイト遷移を追加。設置物をミドルクリックすると `PlacementTargetPickService.TryPickTargetUnderCursor` でピックし、`UIStateEnum.PlaceBlock` へ遷移する。
- 判定は既存の G/B/Tab/ESC 遷移判定の直後に追加。DIは `MainGameStarter.cs` に既存の `PlacementTargetPickService` Singleton登録をそのまま利用。
- `OnEnter` の `KeyControlDescription` 表示に「ミドルクリック: 設置物をスポイト」を追記（`GameScreenState`/`PlaceBlockState` の文言と統一）。
- `UIStateCameraInteractionTest` / `UIStateFocusRestorationTest` の `DeleteObjectState` コンストラクタ呼び出しを更新（`new PlacementTargetPickService(null)` を追加）。

## Test plan
- [x] `uloop compile --project-path ./moorestech_client` → Success, ErrorCount 0, WarningCount 0
- [x] `uloop run-tests --project-path ./moorestech_client --test-mode EditMode --filter-type regex --filter-value "UIStateCameraInteractionTest|UIStateFocusRestorationTest"` → 10 tests, Passed 10 / Failed 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G9wWd7tVaHzfe623VYaNwz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added middle-click eyedropper support while in delete mode.
  * Selecting a placed object with the middle mouse button now switches to placement mode using that object’s type.

* **Bug Fixes**
  * Updated delete-mode controls to clearly describe the new middle-click interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->