### PR TITLE
feat(webui): チュートリアルのドラッグガイド低速・大型化とkeyControlヒントの赤文字化

### DIFF
--- a/.agents/skills/webui-design/SKILL.md
+++ b/.agents/skills/webui-design/SKILL.md
@@ -447,7 +447,7 @@ description: |
 
 - `tutorial.presentation` の kind `keyControl`（tutorialGuid / keyName / uiState）を `KeyControlHintHud` が描く。表示は `ui_state.current` の `state` が `uiState` と一致する間だけで、blockingスキット中は出さない（ユーザー裁定 2026-08-20）。
 - 配置は常時表示HUD族の `.viewportOverlay` 内・画面下中央で、ホットバーの床（`--hotbar-floor-offset`）から `--tutorial-key-hint-hotbar-gap` だけ上に置き、採掘ゲージと重ねない。複数は `--tutorial-key-hint-gap` で縦積み。床位置の計算式（`--hotbar-floor-offset` + 各HUD固有のgap）は採掘プログレスバー（§8.18）と共有する。
-- 様式は §7 のキー操作ヒント（`<kbd>{keyName}</kbd>` + `t(challengeTutorial.<guid>.text)`）。実装は `LocalizedShortcutHint`（`shared/i18n`）を `layout="prefix"` で再利用する（kbdを常に先頭へ置く様式を型で表明し、`layout="inline"` の文言中マーカー差し込みと識別可能にする）。文字様式はInventoryScreenChrome/ResearchScreenChromeのkeyHintsと共有する `keyHintText` クラス（§7）、kbdとの間隔・縦積み間隔は `--tutorial-key-hint-*` 固定長トークン。面・枠・光彩・アニメーションは持たず `pointer-events: none`。
+- 様式は §7 のキー操作ヒント（`<kbd>{keyName}</kbd>` + `t(challengeTutorial.<guid>.text)`）。実装は `LocalizedShortcutHint`（`shared/i18n`）を `layout="prefix"` で再利用する（kbdを常に先頭へ置く様式を型で表明し、`layout="inline"` の文言中マーカー差し込みと識別可能にする）。文字様式はInventoryScreenChrome/ResearchScreenChromeのkeyHintsと共有する `keyHintText` クラス（§7）、kbdとの間隔・縦積み間隔は `--tutorial-key-hint-*` 固定長トークン。**文字色だけは `--tutorial-key-hint-color`（共通の赤 `--text-insufficient` を参照）で上書きする**: 面を持たずワールド上に浮くため白文字では埋もれる（ユーザー裁定 2026-08-22）。新しい色相は増やさない。面・枠・光彩・アニメーションは持たず `pointer-events: none`。
 
 ## 9. やらないことリスト（再掲・明示）
 

--- a/moorestech_web/webui/src/app/tokens.css
+++ b/moorestech_web/webui/src/app/tokens.css
@@ -227,8 +227,8 @@
   --world-pin-edge-margin: 40px;
   /* D&D説明のドラッグガイド矢印の寸法と1周期の長さ（webui-design §8.17） */
   /* Size and one-cycle duration of the D&D drag guide arrow (webui-design §8.17) */
-  --tutorial-drag-guide-size: 28px;
-  --tutorial-drag-guide-duration: 1600ms;
+  --tutorial-drag-guide-size: 56px;
+  --tutorial-drag-guide-duration: 3200ms;
   /* 枠線ハイライトの文言ラベルの間隔（webui-design §8.17） */
   /* Gap for an outline highlight's text label (webui-design §8.17) */
   --tutorial-highlight-label-gap: 4px;
@@ -241,6 +241,9 @@
   --tutorial-key-hint-hotbar-gap: 72px;
   --tutorial-key-hint-gap: 6px;
   --tutorial-key-hint-kbd-gap: 10px;
+  /* keyControlヒントはワールド上に面無しで浮くため白では埋もれる。共通の赤で文字色を立てる（webui-design §8.19） */
+  /* The keyControl hint floats faceless over the world and drowns in white, so it uses the shared red (webui-design §8.19) */
+  --tutorial-key-hint-color: var(--text-insufficient);
   /* ドラッグガイド矢印を世界背景から分離する最小限の影（world-pin矢印と同族） */
   /* Minimal shadow separating the drag guide arrow from the world background, same family as the world-pin arrow */
   --tutorial-drag-guide-shadow: rgb(0 0 0 / 65%);

--- a/moorestech_web/webui/src/features/tutorial/keyControlHint.module.css
+++ b/moorestech_web/webui/src/features/tutorial/keyControlHint.module.css
@@ -13,8 +13,13 @@
   z-index: var(--z-stage-overlay-panel);
 }
 
-/* 文字様式は共有の keyHintText が持ち、ここはkbdとの間隔だけを決める（§7） */
-/* The shared keyHintText class owns the text style; this rule only sets the gap to the kbd (§7) */
+/* 文字様式は共有の keyHintText が持ち、ここはkbdとの間隔と視認性用の文字色だけを決める（§7・§8.19） */
+/* The shared keyHintText class owns the text style; this rule only sets the kbd gap and the legibility color (§7, §8.19) */
+.hint,
+.hint kbd {
+  color: var(--tutorial-key-hint-color);
+}
+
 .hint {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## 概要
序盤チュートリアルの見づらさ・速さの調整（ユーザー依頼 2026-08-22）。

## 変更
- **ドラッグガイド矢印**（`--tutorial-drag-guide-*`）: 周期 1600ms→3200ms（速度半分）、寸法 28px→56px（2倍）
- **keyControlヒントHUD**（「Tab インベントリを開く」）: 面無しでワールド上に浮くため白文字では埋もれる。`--tutorial-key-hint-color`（共通の赤 `--text-insufficient` 参照）で文字色とkbd色のみ上書き。新しい色相は追加しない
- `webui-design` §8.19 に文字色例外を追記

## 検証
- `vitest run src/features/tutorial` 18件緑、`eslint src/features/tutorial` 0件

## 関連
- Beads: moorestech-tlv0.1 / moorestech-tlv0.2（epic moorestech-tlv0）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPoRaxeHGNUST3G6VyDggC
