### PR TITLE
fix(ugui-retirement): 退役uGUIのgrabアイテムスロットがWebモードで見えてしまうのを止める

### DIFF
--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Main/PlayerInventoryViewController.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/UI/Inventory/Main/PlayerInventoryViewController.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using Client.Game.InGame.Context;
 using Client.Game.InGame.UI.Inventory.Common;
 using Client.Game.InGame.UI.UIState;
-using Core.Master;
 using UniRx;
 using UnityEngine;
 using UnityEngine.UI;
@@ -20,7 +19,6 @@ namespace Client.Game.InGame.UI.Inventory.Main
     {
         [SerializeField] private GameObject mainInventoryObject;
         [SerializeField] private PlayerInventoryMainSlotsView mainSlotsView;
-        [SerializeField] private ItemSlotView grabInventorySlotView;
 
         public Transform SubInventoryParent => subInventoryParent.transform;
         [SerializeField] private Transform subInventoryParent;
@@ -38,8 +36,6 @@ namespace Client.Game.InGame.UI.Inventory.Main
         // クリック/ドラッグ操作の解釈を担う非MonoBehaviourハンドラ
         // Non-MonoBehaviour handler that interprets click/drag gestures
         private PlayerInventorySlotInteraction _interaction;
-
-        private bool IsGrabItem => _playerInventory.GrabInventory.Id != ItemMaster.EmptyItemId;
 
         private void Awake()
         {
@@ -107,12 +103,6 @@ namespace Client.Game.InGame.UI.Inventory.Main
                 else
                     _subInventory.SubInventorySlotObjects[i - mainSlotsView.SlotViews.Count].SetItem(itemView, item.Count);
             }
-
-            // 掴んでいるアイテムの表示を最後に同期する
-            // Synchronize the grabbed-item view last
-            grabInventorySlotView.SetActive(IsGrabItem);
-            var grabItemView = ClientContext.ItemImageContainer.GetItemView(_playerInventory.GrabInventory.Id);
-            grabInventorySlotView.SetItem(grabItemView, _playerInventory.GrabInventory.Count);
         }
     }
 }


### PR DESCRIPTION
## 症状

Web UI でアイテムを掴むと、退役済み uGUI の grab アイテムスロットがカーソル追従で画面に出てしまう。

## 原因

`PlayerInventoryViewController.SetActive()` は `mainInventoryObject` / `subInventoryParent` を `WebUiScreenGate.IsWebUiMode` でゲートしているが、**grab スロットだけがゲートの外**にいた。`InventoryViewUpdate()`（毎フレーム）が無条件に

```csharp
grabInventorySlotView.SetActive(IsGrabItem);
```

を叩くため、`IsWebUiMode` が恒久 `true` の現在も、Web 側で掴んだ瞬間に `InventoryItems.prefab` の `GrabItem/PlayerGrabbedItem`（`UICursorFollowControl` 配下）が active になって表示される。uGUI 廃止 Phase 1 のゲート漏れ。

## 対応

ゲートを足すのではなく、grab スロットの描画同期ごと削除した。

- grab スロットは**外部参照ゼロの Tier A リーフ**（`grabInventorySlotView` の参照は本ファイル内の3箇所のみ）
- 掴みアイテムの表示主権は既に Web UI 側にある（`InventoryTopic` が `Grab = ToDto(_controller.GrabInventory)` を配信）。`GrabInventory` 自体はサーバ同期・split drag・WebUiHost の Actions が使い続けるので無傷
- prefab の `PlayerGrabbedItem` は `m_IsActive: 0`。scene / `MainGameUI.prefab` 側に active 上書きは無く、これを active にしていたのは削除したこの1行だけ → **コード削除だけで恒久的に非表示**になる（prefab 変更は不要）

`ProgressBarView` の同種ゲート漏れは「論理状態が ProgressTopic のデータ源として生きている」ためゲート追加で対処されているが、こちらはデータ源としての役割が無いので Phase 2 の削除方向に寄せた。

## 検証

- `uloop compile`: Success（0 errors / 0 warnings）
- `WebUiGateAuditTest` / `WebUiScreenGateTest`: 4/4 pass
  - `PlayerInventoryViewController.cs` は `WebUiGateClassification` の `GatedRoot` 分類のままで、`SetActive()` 側にゲート参照が残っているため `GatedRootsContainGateToken` は緑
- `LocalPlayerInventoryControllerSwapMoveTest`: 5/6 pass。落ちる1件は**本 PR と無関係の既存欠陥**（変更を stash して master 相当で単体実行しても同一の NRE で落ちることを確認済み）。`FakeSubInventory` ctor が `CreateController()` より先に `ServerContext.ItemStackFactory` を触るための実行順依存。別途 bd に起票済み（moorestech-trnj）

closes moorestech-lccj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed unused inventory UI synchronization logic.
  * Simplified internal inventory view handling without changing user-visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->