### PR TITLE
fix(webui): チュートリアル枠線の撤去をrAF非依存にしゴースト残留を止める

### DIFF
--- a/moorestech_web/webui/e2e/tests/system/tutorial.spec.ts
+++ b/moorestech_web/webui/e2e/tests/system/tutorial.spec.ts
@@ -45,3 +45,30 @@ test("keyControl hint renders a kbd and text above the hotbar while uiState matc
   await expect(hint.locator("kbd")).toHaveText("Tab");
   await expect(hint).toContainText("インベントリを開く");
 });
+
+// 枠線の撤去がフレーム到来に依存すると、CEF(外部BeginFrame駆動)ではフレーム間隔ぶんゴーストが残る
+// If the outline's teardown waits for a frame, CEF (driven by external BeginFrame) shows a ghost for that whole gap
+test("outline never outlives its anchor even when no frame arrives", async ({ page }) => {
+  await setUiState(page, "PlayerInventory");
+  await page.goto("/");
+  await setTopicScenario(page, "tutorialRecipeItem");
+
+  const grid = page.getByTestId("item-list-grid");
+  const outline = page.locator('[data-testid="tutorial-overlay"] [data-kind="outline"]');
+  await expect(grid).toBeVisible();
+  await expect(outline).toBeVisible();
+
+  // rAFを止めて「次の描画が来ない」状況を作る。React本体はMessageChannel駆動なので進み続ける
+  // Stop rAF to model "no next frame"; React itself is MessageChannel-driven and keeps advancing
+  await page.evaluate(() => {
+    window.requestAnimationFrame = (() => 1) as typeof window.requestAnimationFrame;
+  });
+  // 差し替え時点で予約済みだった本物のrAFを消化しきってから閉じる。残っていると偶然そちらが撤去してしまう
+  // Let the real rAF already queued at swap time drain first; otherwise it may do the teardown by luck
+  await page.waitForTimeout(200);
+
+  await setUiState(page, "GameScreen");
+
+  await expect(grid).toHaveCount(0);
+  await expect(outline).toHaveCount(0);
+});

--- a/moorestech_web/webui/src/shared/tutorialAnchor/anchorRegistry.ts
+++ b/moorestech_web/webui/src/shared/tutorialAnchor/anchorRegistry.ts
@@ -1,9 +1,14 @@
 import { resolveTutorialAnchor, type ResolvedAnchor } from "./resolveAnchor";
 import { tutorialAnchorSelector } from "./tutorialAnchor";
 
+// 追従(位置更新)はrAFへ集約するが、撤去(アンカーのDOM離脱)だけは同期で流す
+// Tracking (position updates) coalesces into rAF, while teardown (an anchor leaving the DOM) is pushed synchronously
 export class TutorialAnchorRegistry {
   private readonly listeners = new Map<string, Set<(value: ResolvedAnchor) => void>>();
-  private readonly mutation = new MutationObserver(() => this.markAllDirty());
+  // 直近の解決で見えていた要素。離脱判定に使うだけなので矩形もスタイルも持たない
+  // Elements seen at the last resolve; references only, so detecting departure needs no layout read
+  private readonly tracked = new Map<string, HTMLElement[]>();
+  private readonly mutation = new MutationObserver(() => this.onMutation());
   private readonly resize = new ResizeObserver(() => this.markAllDirty());
   private readonly intersection = new IntersectionObserver(() => this.markAllDirty());
   private frame = 0;
@@ -23,7 +28,9 @@ export class TutorialAnchorRegistry {
     this.markAllDirty();
     return () => {
       set.delete(listener);
-      if (set.size === 0) this.listeners.delete(anchorId);
+      if (set.size !== 0) return;
+      this.listeners.delete(anchorId);
+      this.tracked.delete(anchorId);
     };
   }
 
@@ -32,11 +39,28 @@ export class TutorialAnchorRegistry {
     this.resize.disconnect();
     this.intersection.disconnect();
     cancelAnimationFrame(this.frame);
+    this.tracked.clear();
     document.removeEventListener("scroll", this.markAllDirty, true);
     window.removeEventListener("resize", this.markAllDirty);
     visualViewport?.removeEventListener("resize", this.markAllDirty);
     visualViewport?.removeEventListener("scroll", this.markAllDirty);
   }
+
+  // 撤去をrAFに載せるとアンカー無き枠線が次の描画まで残る。CEFは外部BeginFrame駆動で自力の描画を起こせず、その空きがゴーストの寿命になる
+  // Deferring teardown to rAF leaves an anchorless outline until the next paint; CEF cannot self-schedule one, so that gap becomes the ghost's lifetime
+  private readonly onMutation = () => {
+    for (const [anchorId, listeners] of this.listeners) {
+      const elements = this.tracked.get(anchorId);
+      if (!elements || elements.length === 0) continue;
+      if (elements.every((element) => element.isConnected)) continue;
+      // ノードの差し替えは撤去ではないので次の解決へ委ね、真の消滅だけを即座に落とす
+      // A node swap is not a teardown, so leave it to the next resolve and drop only a true disappearance
+      if (document.querySelector(tutorialAnchorSelector(anchorId)) !== null) continue;
+      this.tracked.set(anchorId, []);
+      for (const listener of listeners) listener({ status: "not-found", reason: "missing" });
+    }
+    this.markAllDirty();
+  };
 
   private readonly markAllDirty = () => {
     if (this.frame !== 0) return;
@@ -45,10 +69,12 @@ export class TutorialAnchorRegistry {
       this.resize.disconnect();
       this.intersection.disconnect();
       for (const [anchorId, listeners] of this.listeners) {
-        for (const element of document.querySelectorAll<HTMLElement>(tutorialAnchorSelector(anchorId))) {
+        const elements = [...document.querySelectorAll<HTMLElement>(tutorialAnchorSelector(anchorId))];
+        for (const element of elements) {
           this.resize.observe(element);
           this.intersection.observe(element);
         }
+        this.tracked.set(anchorId, elements);
         const value = resolveTutorialAnchor(anchorId);
         for (const listener of listeners) listener(value);
       }


### PR DESCRIPTION
## 症状

アイテムをハイライト中に tab でインベントリを閉じると、インベントリは即座に消えるのに **ハイライト枠だけが数秒間「何もないところ」に残る**。

## 原因

**枠線の撤去だけが `requestAnimationFrame` に依存していた。**

- インベントリの消滅: `ui_state` トピック → React 再描画。**rAF 不要**（タスク駆動）
- ハイライトの消滅: `TutorialAnchorRegistry.markAllDirty()` 経由。**rAF が来るまで `resolved` が `ready` のまま残る**

`anchorRegistry.ts` で MutationObserver / ResizeObserver / IntersectionObserver / scroll / resize の**全経路が単一の rAF コアレスへ集約**されており、「アンカーが DOM から消えた」を同期的に反映する道が無かった。よって枠線の撤去は必ずインベントリの消滅より後になり、残留時間 = **次にページが描画されるまでの時間**そのものになる。

ゲームで数秒になるのは、CEF が外部 BeginFrame 駆動（`CefUnityBrowserSample.OnEarlyUpdateLast` が毎 Unity フレーム `SendExternalBeginFrame`）で、**ページの rAF 周期 = Unity のフレーム発行周期**だから。ページは自力でフレームを起こせないので、フレームの空きがそのままゴーストの寿命として見える。

### 切り分けの実測（webui e2e / mock-host / 実アンカー `recipe.item-<itemId>`）

| 条件 | インベントリ消滅 | 枠線消滅 |
| --- | --- | --- |
| prod ビルド | 12ms | 15ms |
| Vite dev + StrictMode（Editorと同構成） | 15ms | 17ms |
| CPU 20倍スロットル | 176ms | 184ms |
| **rAF を握り潰す** | 消える | **3秒後も残存** |

rAF を止めた時だけ症状が完全一致した。負荷では再現しない。

## 変更

直近の解決で見えていた要素を `tracked` へ保持し、MutationObserver で**離脱を同期検知**する。

- 追跡中の要素が `isConnected === false` になったアンカーだけを見る
- 再照会して**まだ見つかる**（React のノード差し替え）→ 次の解決へ委ねる
- **見つからない**（真の消滅）→ その場で `missing` を購読者へ流す
- 幾何・可視性の再解決は従来どおり rAF 経路に残す（追従は今までどおり）
- `querySelector` は DOM ツリー照会でレイアウトを強制しないため、追従経路の負荷は変えない

撤去経路が共通なので、`itemViewHighLight`（`recipe.item-*`）・`uiHighLight`（`recipe.craft-button` 等）・`dragGuide` が同時に直る。

## 検証

- 回帰テストを追加: **「フレームが来なくても枠線はアンカーより長く生き残らない」**。rAF を握り潰した状態でインベントリを閉じる。**修正前に落ち・修正後に通る**ことを両方確認済み
- `tutorialHighlightClip.spec.ts`（ADR 0024 のクリップ検査）緑 = 追従経路は無傷
- webui unit 753件 / 105ファイル 緑、`eslint`・`tsc -b`・e2e typecheck 緑
- e2e 全体の既存失敗13件は **master でも同一**（stash して baseline 取得済み）で本変更とは無関係
- `.cs` の変更が無いため Unity コンパイルゲートは対象外

## スコープ外

- `display:none` / `visibility:hidden` / `zero-area` などレイアウト起因の可視性変化は従来どおり rAF 経路（本件はアンマウントによる DOM 離脱で、moorestech の各パネルは非表示ではなくアンマウントする）
- `duplicate-anchor` 判定も rAF 経路のまま
- CefUnity 側（外部 BeginFrame の周期）には触らない

bead: `moorestech-e0vx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xe6qKLzMBaAZnRgyhsnjP6