### PR TITLE
fix(client): mapObjectのHPバー位置を原点に戻す

### DIFF
--- a/moorestech_client/Assets/AddressableResources/Environment/Plant/MesaDesert/Brittlebush_1.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Plant/MesaDesert/Brittlebush_1.prefab
@@ -306,7 +306,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.2907307
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Plant/MesaDesert/Brittlebush_2.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Plant/MesaDesert/Brittlebush_2.prefab
@@ -306,7 +306,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.296145
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Plant/MesaDesert/Brittlebush_3.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Plant/MesaDesert/Brittlebush_3.prefab
@@ -306,7 +306,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.3631127
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Plant/MesaDesert/Brittlebush_4.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Plant/MesaDesert/Brittlebush_4.prefab
@@ -306,7 +306,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.3601532
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Plant/MesaDesert/DryGrass1.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Plant/MesaDesert/DryGrass1.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.6024904
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Plant/MesaDesert/DryGrass2.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Plant/MesaDesert/DryGrass2.prefab
@@ -306,7 +306,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.62390924
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Plant/MesaDesert/DryGrass3.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Plant/MesaDesert/DryGrass3.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.7495744
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Plant/MesaDesert/DryGrass4.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Plant/MesaDesert/DryGrass4.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.83493865
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Plant/MesaDesert/Peanut1.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Plant/MesaDesert/Peanut1.prefab
@@ -306,7 +306,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.69770044
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Plant/MesaDesert/Peanut2.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Plant/MesaDesert/Peanut2.prefab
@@ -306,7 +306,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.68621755
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Plant/MesaDesert/Peanut3.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Plant/MesaDesert/Peanut3.prefab
@@ -306,7 +306,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.7031042
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Plant/MesaDesert/WildflowersYellow1.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Plant/MesaDesert/WildflowersYellow1.prefab
@@ -306,7 +306,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.79267097
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Plant/MesaDesert/WildflowersYellow2.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Plant/MesaDesert/WildflowersYellow2.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.90165436
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Plant/MesaDesert/WildflowersYellow3.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Plant/MesaDesert/WildflowersYellow3.prefab
@@ -306,7 +306,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.7937974
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Plant/MesaDesert/WildflowersYellow4.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Plant/MesaDesert/WildflowersYellow4.prefab
@@ -306,7 +306,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.8023968
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Prop/MesaDesert/CowSkull.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Prop/MesaDesert/CowSkull.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.6438399
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/BigMesa_0.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/BigMesa_0.prefab
@@ -326,7 +326,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 28.80798
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/BigMesa_1.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/BigMesa_1.prefab
@@ -326,7 +326,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 31.153503
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/BigMesa_2.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/BigMesa_2.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 30.44773
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/BigMesa_3.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/BigMesa_3.prefab
@@ -326,7 +326,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 36.803814
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/BigMesa_4.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/BigMesa_4.prefab
@@ -326,7 +326,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 39.74705
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/BigMesa_5.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/BigMesa_5.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 41.66067
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/Boulders_0.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/Boulders_0.prefab
@@ -326,7 +326,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 4.262713
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/Boulders_1.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/Boulders_1.prefab
@@ -326,7 +326,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 5.2938037
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/Boulders_2.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/Boulders_2.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 4.24337
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/Boulders_3.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/Boulders_3.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 7.486059
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/Boulders_4.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/Boulders_4.prefab
@@ -326,7 +326,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 6.008898
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/Boulders_5.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/Boulders_5.prefab
@@ -326,7 +326,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3.72101
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/RubbleDense_1.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/RubbleDense_1.prefab
@@ -318,7 +318,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.531654
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/RubbleDense_2.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/RubbleDense_2.prefab
@@ -318,7 +318,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.1890168
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/RubbleDense_3.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/RubbleDense_3.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.3237605
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/RubbleSparse_1.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/RubbleSparse_1.prefab
@@ -318,7 +318,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.0217401
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/RubbleSparse_2.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/RubbleSparse_2.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.0628008
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/RubbleSparse_3.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/RubbleSparse_3.prefab
@@ -318,7 +318,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.0282755
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/StratMesaSharp_0.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/StratMesaSharp_0.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3.568495
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/StratMesaSharp_1.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/StratMesaSharp_1.prefab
@@ -326,7 +326,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3.6262777
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/StratMesaSharp_2.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/StratMesaSharp_2.prefab
@@ -326,7 +326,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.1277542
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/StratMesaSharp_3.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/StratMesaSharp_3.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.4421203
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/StratMesaSharp_4.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/StratMesaSharp_4.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 4.8729854
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/StrateCliff_0.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/StrateCliff_0.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.8953009
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/StrateCliff_1.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/StrateCliff_1.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.6104128
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/StrateCliff_2.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/StrateCliff_2.prefab
@@ -326,7 +326,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.7249876
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/Strate_0.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/Strate_0.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 10.529767
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/Strate_1.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/Strate_1.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 10.37638
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/Strate_2.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/Strate_2.prefab
@@ -326,7 +326,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 10.647367
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/Strate_3.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/Strate_3.prefab
@@ -326,7 +326,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 10.551127
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/Strate_4.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/Strate_4.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 10.506485
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/Strate_5.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/Strate_5.prefab
@@ -326,7 +326,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 10.494804
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/ThinMesa_0.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/ThinMesa_0.prefab
@@ -326,7 +326,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 21.424147
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/ThinMesa_1.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/ThinMesa_1.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 28.742882
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/ThinMesa_2.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/ThinMesa_2.prefab
@@ -326,7 +326,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 27.99524
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/ThinMesa_3.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/ThinMesa_3.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 35.222008
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/ThinMesa_4.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/ThinMesa_4.prefab
@@ -326,7 +326,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 27.852312
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/ThinMesa_5.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/MesaDesert/ThinMesa_5.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 30.570818
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Mountains/Boulder1.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Mountains/Boulder1.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.74982756
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Mountains/Boulder2.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Mountains/Boulder2.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.96920973
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Mountains/Boulder3.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Mountains/Boulder3.prefab
@@ -318,7 +318,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.92707366
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Mountains/Stone1.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Mountains/Stone1.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.0044357
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Mountains/Stone1b.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Mountains/Stone1b.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.0044357
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Mountains/Stone2.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Mountains/Stone2.prefab
@@ -318,7 +318,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.2510014
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Mountains/Stone2b.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Mountains/Stone2b.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.2510014
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Mountains/Stone3.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Mountains/Stone3.prefab
@@ -318,7 +318,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.2513908
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Mountains/Stone3b.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Mountains/Stone3b.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.2513908
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Mountains/Stone4.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Mountains/Stone4.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.5073484
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Mountains/Stone4b.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Mountains/Stone4b.prefab
@@ -318,7 +318,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.5073484
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Mountains/Stone5.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Mountains/Stone5.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.9983201
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/DesertBoulder_0.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/DesertBoulder_0.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 13.322142
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/DesertBoulder_1.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/DesertBoulder_1.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 11.806694
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/DesertBoulder_2.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/DesertBoulder_2.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 12.972263
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/DesertBoulder_3.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/DesertBoulder_3.prefab
@@ -322,7 +322,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 10.769698
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/DesertBoulder_4.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/DesertBoulder_4.prefab
@@ -322,7 +322,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 13.27721
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/DesertBoulder_5.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/DesertBoulder_5.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 16.645136
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/DesertBoulder_6.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/DesertBoulder_6.prefab
@@ -322,7 +322,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 11.2343855
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/DesertBoulder_7.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/DesertBoulder_7.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 10.991709
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/DesertBoulder_8.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/DesertBoulder_8.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3.7380123
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/DesertBoulder_9.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/DesertBoulder_9.prefab
@@ -322,7 +322,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 12.596089
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/DesertRock_1.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/DesertRock_1.prefab
@@ -318,7 +318,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.0432783
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/DesertRock_2.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/DesertRock_2.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.1164488
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/DesertRock_3.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/DesertRock_3.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.0203152
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/DesertRock_4.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/DesertRock_4.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.1151682
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/DesertRock_5.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/DesertRock_5.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.3126401
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/DesertRock_6.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/DesertRock_6.prefab
@@ -318,7 +318,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.0429003
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/DesertRock_7.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/DesertRock_7.prefab
@@ -318,7 +318,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.0182414
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/DesertRock_8.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/DesertRock_8.prefab
@@ -318,7 +318,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.66171134
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/DesertRock_9.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/DesertRock_9.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.1027021
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/RubbleSparse_1.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/RubbleSparse_1.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.11676
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/RubbleSparse_2.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/RubbleSparse_2.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.1656575
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/RubbleSparse_3.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Oasis/RubbleSparse_3.prefab
@@ -318,7 +318,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.1742783
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Redwood/BigBoulders_0.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Redwood/BigBoulders_0.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3.301939
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Redwood/BigBoulders_1.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Redwood/BigBoulders_1.prefab
@@ -326,7 +326,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3.347218
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Redwood/BigBoulders_2.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Redwood/BigBoulders_2.prefab
@@ -326,7 +326,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3.3970575
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Redwood/BigBoulders_3.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Redwood/BigBoulders_3.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3.386078
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Redwood/BigBoulders_4.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Redwood/BigBoulders_4.prefab
@@ -326,7 +326,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3.2785268
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Redwood/BigBoulders_5.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Redwood/BigBoulders_5.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3.3785224
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Redwood/Boulder_0.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Redwood/Boulder_0.prefab
@@ -322,7 +322,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.4020498
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Redwood/Boulder_1.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Redwood/Boulder_1.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.5194955
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Redwood/Boulder_2.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Redwood/Boulder_2.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.645989
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Redwood/Boulder_3.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Redwood/Boulder_3.prefab
@@ -322,7 +322,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3.5438342
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Redwood/Boulder_4.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Redwood/Boulder_4.prefab
@@ -322,7 +322,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.9942603
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Rock/Redwood/Boulder_5.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Rock/Redwood/Boulder_5.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.691998
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Base/BirchTree01.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Base/BirchTree01.prefab
@@ -315,7 +315,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 7.286149
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Base/BirchTree02.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Base/BirchTree02.prefab
@@ -315,7 +315,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 8.380435
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Base/PineTree01.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Base/PineTree01.prefab
@@ -208,7 +208,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 6.7397213
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Base/PineTree02.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Base/PineTree02.prefab
@@ -208,7 +208,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 8.590255
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Jungle/Banana1.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Jungle/Banana1.prefab
@@ -208,7 +208,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 6.406355
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Jungle/Banana2.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Jungle/Banana2.prefab
@@ -319,7 +319,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 7.792817
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Jungle/Kapokier1.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Jungle/Kapokier1.prefab
@@ -323,7 +323,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 16.082933
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Jungle/Kapokier2.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Jungle/Kapokier2.prefab
@@ -208,7 +208,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 16.268986
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Jungle/Musa1.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Jungle/Musa1.prefab
@@ -314,7 +314,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.1965156
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Jungle/Tropica1.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Jungle/Tropica1.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.3701665
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Jungle/Tropica2.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Jungle/Tropica2.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.7774254
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Cacactus1.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Cacactus1.prefab
@@ -322,7 +322,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.1522225
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Cacactus2.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Cacactus2.prefab
@@ -208,7 +208,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.3271393
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Cacactus3.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Cacactus3.prefab
@@ -323,7 +323,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.5339652
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Cacactus4.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Cacactus4.prefab
@@ -208,7 +208,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.5743997
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Grocactus1.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Grocactus1.prefab
@@ -323,7 +323,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.9668279
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Grocactus2.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Grocactus2.prefab
@@ -323,7 +323,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.3512492
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Grocactus3.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Grocactus3.prefab
@@ -208,7 +208,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3.8818362
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Grocactus4.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Grocactus4.prefab
@@ -323,7 +323,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 4.568729
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Grocactus5.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Grocactus5.prefab
@@ -323,7 +323,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 4.908082
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Grocactus6.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Grocactus6.prefab
@@ -208,7 +208,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 5.4506474
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Grocactus7.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Grocactus7.prefab
@@ -323,7 +323,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 6.0295243
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Grocactus8.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Grocactus8.prefab
@@ -323,7 +323,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 7.0686893
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Opuntia1.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Opuntia1.prefab
@@ -318,7 +318,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.0235131
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Opuntia2.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Opuntia2.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.2024527
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Opuntia3.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Opuntia3.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.4820875
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Opuntia4.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Opuntia4.prefab
@@ -318,7 +318,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.5970095
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Saguaro1.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Saguaro1.prefab
@@ -208,7 +208,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 4.3415976
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Saguaro2.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Saguaro2.prefab
@@ -208,7 +208,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 5.7147956
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Saguaro3.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Saguaro3.prefab
@@ -323,7 +323,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 6.22684
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Saguaro4.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Saguaro4.prefab
@@ -208,7 +208,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 7.573768
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Saguaro5.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Saguaro5.prefab
@@ -323,7 +323,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 11.044061
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Senita1.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Senita1.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.5982678
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Senita2.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Senita2.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.7846884
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Senita3.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Senita3.prefab
@@ -322,7 +322,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.0314062
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Senita4.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Senita4.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.2617538
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Senita5.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Senita5.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.7667146
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Senita6.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Senita6.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3.1829157
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Senita7.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Senita7.prefab
@@ -322,7 +322,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3.1127203
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Senita8.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/MesaDesert/Senita8.prefab
@@ -322,7 +322,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3.137372
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Mountains/Bush1.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Mountains/Bush1.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.2630534
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Mountains/Bush3.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Mountains/Bush3.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.792614
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Mountains/Fir1.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Mountains/Fir1.prefab
@@ -208,7 +208,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 9.070507
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Mountains/Fir3.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Mountains/Fir3.prefab
@@ -323,7 +323,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 13.226804
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Mountains/Fir5.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Mountains/Fir5.prefab
@@ -323,7 +323,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 22.609112
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Mountains/Pine1.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Mountains/Pine1.prefab
@@ -208,7 +208,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 6.311666
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Mountains/Pine3.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Mountains/Pine3.prefab
@@ -323,7 +323,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 9.419361
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Mountains/Spruce1.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Mountains/Spruce1.prefab
@@ -323,7 +323,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 9.079456
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Mountains/Spruce4.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Mountains/Spruce4.prefab
@@ -323,7 +323,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 16.87923
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Oasis/Olivebush1.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Oasis/Olivebush1.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.9640931
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Oasis/Olivebush2.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Oasis/Olivebush2.prefab
@@ -322,7 +322,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.9487743
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Oasis/Olivebush3.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Oasis/Olivebush3.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3.083528
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Redwood/RedFir1.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Redwood/RedFir1.prefab
@@ -323,7 +323,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.551992
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Redwood/RedFir2.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Redwood/RedFir2.prefab
@@ -208,7 +208,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 4.3953257
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Redwood/RedFir3.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Redwood/RedFir3.prefab
@@ -323,7 +323,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 5.560416
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Redwood/RedFir4.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Redwood/RedFir4.prefab
@@ -323,7 +323,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 7.9690094
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Redwood/RedFir5.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Redwood/RedFir5.prefab
@@ -323,7 +323,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 9.718924
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Redwood/RedFir6.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Redwood/RedFir6.prefab
@@ -208,7 +208,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 11.143166
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Redwood/RedFir7.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Redwood/RedFir7.prefab
@@ -208,7 +208,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 9.711178
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Redwood/RedFir8.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Redwood/RedFir8.prefab
@@ -323,7 +323,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 9.7317295
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Redwood/RedPine1.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Redwood/RedPine1.prefab
@@ -208,7 +208,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 6.7055182
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Redwood/RedPine2.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Redwood/RedPine2.prefab
@@ -323,7 +323,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 8.371933
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Redwood/RedPine3.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Redwood/RedPine3.prefab
@@ -208,7 +208,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 10.1291485
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Redwood/RedPine4.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Redwood/RedPine4.prefab
@@ -208,7 +208,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 12.377923
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Redwood/RedPine5.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Redwood/RedPine5.prefab
@@ -208,7 +208,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 12.969018
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Redwood/Sequoia1.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Redwood/Sequoia1.prefab
@@ -348,7 +348,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 33.38151
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Redwood/Sequoia2.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Redwood/Sequoia2.prefab
@@ -348,7 +348,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 35.93479
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Redwood/Sequoia3.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Redwood/Sequoia3.prefab
@@ -348,7 +348,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 38.287193
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Redwood/Sequoia4.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Redwood/Sequoia4.prefab
@@ -348,7 +348,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 41.028114
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Redwood/Sequoia5.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Redwood/Sequoia5.prefab
@@ -348,7 +348,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 45.20369
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Savanna/Acacia1.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Savanna/Acacia1.prefab
@@ -208,7 +208,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 6.7590365
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Savanna/Acacia2.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Savanna/Acacia2.prefab
@@ -208,7 +208,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 8.611967
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Savanna/Acacia3.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Savanna/Acacia3.prefab
@@ -323,7 +323,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 7.8338804
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Savanna/Acacia4.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Savanna/Acacia4.prefab
@@ -208,7 +208,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 9.8897295
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Savanna/Acacia5.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Savanna/Acacia5.prefab
@@ -208,7 +208,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 10.818372
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Savanna/Acacia6.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Savanna/Acacia6.prefab
@@ -208,7 +208,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 9.708001
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Savanna/Acacia7.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Savanna/Acacia7.prefab
@@ -208,7 +208,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 11.823083
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Savanna/Acacia8.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Savanna/Acacia8.prefab
@@ -208,7 +208,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 14.071832
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Savanna/Baobab1.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Savanna/Baobab1.prefab
@@ -323,7 +323,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 11.425482
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Savanna/Baobab2.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Savanna/Baobab2.prefab
@@ -323,7 +323,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 13.409926
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Savanna/Baobab3.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Savanna/Baobab3.prefab
@@ -208,7 +208,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 13.601564
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Savanna/Baobab4.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Savanna/Baobab4.prefab
@@ -323,7 +323,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 13.141079
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Savanna/Baobab5.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Savanna/Baobab5.prefab
@@ -323,7 +323,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 10.401707
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Savanna/Baobab6.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Savanna/Baobab6.prefab
@@ -323,7 +323,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 11.367333
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Savanna/Baobab7.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Savanna/Baobab7.prefab
@@ -208,7 +208,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 9.862207
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Savanna/Baobab8.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Savanna/Baobab8.prefab
@@ -323,7 +323,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 12.299706
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Savanna/Bush1.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Savanna/Bush1.prefab
@@ -207,7 +207,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.2739272
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Savanna/Bush2.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Savanna/Bush2.prefab
@@ -322,7 +322,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.5330217
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z

--- a/moorestech_client/Assets/AddressableResources/Environment/Tree/Savanna/Bush3.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Tree/Savanna/Bush3.prefab
@@ -322,7 +322,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.9253418
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5938972570524110259, guid: 8cf9677c0dc7f460faa78f3b80aabde7, type: 3}
       propertyPath: m_LocalPosition.z


### PR DESCRIPTION
## 症状

直近追加した pure nature 系 mapObject の HP バーが極端に高い位置にあり、実質表示されていなかった。

## 原因

`WrapperPrefabFactory.CreateHpBar` が HP バーを `localBounds.max.y + HpBarHeightMargin` に置いている。この `localBounds` は見た目の外接をルートローカル空間で取ったものなので、元アセットのメッシュが大きい種ほど値が跳ね上がる。実測で Sequoia5 が y=45.20、BigMesa_5 が y=41.66 と、カメラの画角外まで持ち上がっていた。

手作りの旧 prefab（`Clay.prefab` / `BirchTree small1.prefab`）は HP バーが 0,0,0 に置かれており、自動生成分だけが浮いている状態だった。

## 変更

自動生成ラッパー prefab **189 件**の `MapObjectHpBar` インスタンスの `localPosition` を `0,0,0` に揃えた。y の元値のレンジは 0.60〜45.20。

編集は手書きではなく `uloop execute-dynamic-code` 経由（`PrefabUtility.LoadPrefabContents` → `SaveAsPrefabAsset`）で行い、Unity 自身にシリアライズさせている。diff は 189 ファイル × 1 行（`m_LocalPosition.y` のみ）。

## 検証

- `Client.Tests.Map.*` EditMode 8/8 pass（`MapObjectAddressableLoadTest` / `MapObjectHpBarScaleTest`）

## 残課題（このPRの対象外）

- **生成器側は未修正。** `WrapperPrefabFactory.cs:110` は依然として `localBounds.max.y + 0.5` を書き込むので、ラッパー prefab を再生成すると同じ位置に戻る。prefab 更新のみという依頼スコープに従い .cs には触れていない。別途対応が必要。
- `Bush.prefab`（手作りの旧 prefab）は HP バーが 0.1 程度のわずかなズレしか無く今回の症状に該当しないため対象外。Unity 再保存でルート名 `Bush01`→`Bush` の副作用が出たこともあり revert した。
- `Rock/MesaDesert/StratMesaSharp_0.prefab` は import が壊れており（元 FBX 未 import → Prefab Variant の親欠落）、一度 FBX を強制 import してから修正した。再現性のある環境依存の壊れ方なので注意。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pHR45munFG7mg6d5RGKqN