### PR TITLE
fix(vein): Rock11マテリアル反映と鉱脈生成範囲修正

### DIFF
--- a/.moorestech-external-revisions.json
+++ b/.moorestech-external-revisions.json
@@ -3,7 +3,7 @@
         {
             "key": "moorestech_master",
             "relativePath": "../moorestech_master",
-            "commitHash": "ab9e8bc4826bc42cad712910504a2acedec6e8ef"
+            "commitHash": "00dda1f85fec85d37d07f60b6598f12dded48487"
         },
         {
             "key": "moorestech_client_private",

--- a/moorestech_client/Assets/AddressableAssetsData/AssetGroups/Vanilla Asset Group.asset
+++ b/moorestech_client/Assets/AddressableAssetsData/AssetGroups/Vanilla Asset Group.asset
@@ -2025,6 +2025,11 @@ MonoBehaviour:
     m_ReadOnly: 0
     m_SerializedLabels: []
     FlaggedDuringContentUpdateRestriction: 0
+  - m_GUID: d18aa0284baff47518ed573eeea77043
+    m_Address: Vanilla/Environment/Vein/Item/VeinPrefabBase
+    m_ReadOnly: 0
+    m_SerializedLabels: []
+    FlaggedDuringContentUpdateRestriction: 0
   - m_GUID: d1962ee19d1234898b4c3faa248625cb
     m_Address: Vanilla/Environment/Rock/MesaDesert/Strate_4
     m_ReadOnly: 0

--- a/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefabBase.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefabBase.prefab
@@ -34,7 +34,9 @@ Transform:
   - {fileID: 2539337192159425586}
   - {fileID: 151013987900853770}
   - {fileID: 4192479114256082799}
+  - {fileID: 3062689465513776766}
   - {fileID: 7005847663050398316}
+  - {fileID: 534699207371323184}
   - {fileID: 4916749688045990703}
   - {fileID: 5330711295270609747}
   m_Father: {fileID: 0}
@@ -63,6 +65,73 @@ LODGroup:
     - renderer: {fileID: 5719090494191590563}
     - renderer: {fileID: 7664073366109337056}
   m_Enabled: 1
+--- !u!1001 &283937465418534359
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 3411773016607635121}
+    m_Modifications:
+    - target: {fileID: 511136142808128870, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 75b6be70f9d9c432a99d976c7acb824c, type: 2}
+    - target: {fileID: 2245956535012501946, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_Name
+      value: Rock11_4
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.282
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.274
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.996
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.00087702426
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.123419635
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.69212216
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.7111495
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 79.798
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -446.288
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 103.694
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: -7290580861758732654, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+--- !u!4 &3062689465513776766 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+  m_PrefabInstance: {fileID: 283937465418534359}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &569530455632631772
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -97,7 +166,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2655691487863792622, guid: e198fab53f70a25478a00348862a707e, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.192
+      value: -0.406
       objectReference: {fileID: 0}
     - target: {fileID: 2655691487863792622, guid: e198fab53f70a25478a00348862a707e, type: 3}
       propertyPath: m_LocalPosition.z
@@ -165,15 +234,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.242
+      value: 0.605
       objectReference: {fileID: 0}
     - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.34500122
+      value: -0.25299877
       objectReference: {fileID: 0}
     - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.174
+      value: -0.765
       objectReference: {fileID: 0}
     - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
       propertyPath: m_LocalRotation.w
@@ -237,15 +306,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.744
+      value: 0.581
       objectReference: {fileID: 0}
     - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.247
+      value: -0.199
       objectReference: {fileID: 0}
     - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.663
+      value: 0.248
       objectReference: {fileID: 0}
     - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
       propertyPath: m_LocalRotation.w
@@ -291,6 +360,73 @@ MeshRenderer:
   m_CorrespondingSourceObject: {fileID: 511136142808128870, guid: e27902ea3559a414bb814a35631790fd, type: 3}
   m_PrefabInstance: {fileID: 3128002988955129251}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3322467204950731929
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 3411773016607635121}
+    m_Modifications:
+    - target: {fileID: 511136142808128870, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 75b6be70f9d9c432a99d976c7acb824c, type: 2}
+    - target: {fileID: 2245956535012501946, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_Name
+      value: Rock11_5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.184
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.386
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.937
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7641847
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.64499754
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -80.331
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: -7290580861758732654, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+--- !u!4 &534699207371323184 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
+  m_PrefabInstance: {fileID: 3322467204950731929}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &5208871594242032069
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -309,15 +445,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.994
+      value: -1.005
       objectReference: {fileID: 0}
     - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.311
+      value: -0.287
       objectReference: {fileID: 0}
     - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.204
+      value: 0.56
       objectReference: {fileID: 0}
     - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
       propertyPath: m_LocalRotation.w
@@ -381,15 +517,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.175
+      value: -0.386
       objectReference: {fileID: 0}
     - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.299
+      value: -0.299
       objectReference: {fileID: 0}
     - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.397
+      value: -0.312
       objectReference: {fileID: 0}
     - target: {fileID: 2985996818815769513, guid: e27902ea3559a414bb814a35631790fd, type: 3}
       propertyPath: m_LocalRotation.w
@@ -445,7 +581,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 2831267316483566297, guid: 9e31d6d9401ccb84999ae6527f00513a, type: 3}
       propertyPath: m_LocalScale.x
-      value: 0.1457817
+      value: 0.2
       objectReference: {fileID: 0}
     - target: {fileID: 2831267316483566297, guid: 9e31d6d9401ccb84999ae6527f00513a, type: 3}
       propertyPath: m_LocalScale.y
@@ -453,19 +589,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2831267316483566297, guid: 9e31d6d9401ccb84999ae6527f00513a, type: 3}
       propertyPath: m_LocalScale.z
-      value: 0.18040484
+      value: 0.2445429
       objectReference: {fileID: 0}
     - target: {fileID: 2831267316483566297, guid: 9e31d6d9401ccb84999ae6527f00513a, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.0020141602
+      value: -0.0556
       objectReference: {fileID: 0}
     - target: {fileID: 2831267316483566297, guid: 9e31d6d9401ccb84999ae6527f00513a, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.058998108
+      value: -0.657
       objectReference: {fileID: 0}
     - target: {fileID: 2831267316483566297, guid: 9e31d6d9401ccb84999ae6527f00513a, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.013000488
+      value: 0.0424
       objectReference: {fileID: 0}
     - target: {fileID: 2831267316483566297, guid: 9e31d6d9401ccb84999ae6527f00513a, type: 3}
       propertyPath: m_LocalRotation.w
@@ -543,15 +679,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4543224253754549693, guid: 7f16ab3e3a7705b44a369f388e2a0472, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.719
+      value: -1.11
       objectReference: {fileID: 0}
     - target: {fileID: 4543224253754549693, guid: 7f16ab3e3a7705b44a369f388e2a0472, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.168
+      value: -0.43
       objectReference: {fileID: 0}
     - target: {fileID: 4543224253754549693, guid: 7f16ab3e3a7705b44a369f388e2a0472, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.522
+      value: -0.801
       objectReference: {fileID: 0}
     - target: {fileID: 4543224253754549693, guid: 7f16ab3e3a7705b44a369f388e2a0472, type: 3}
       propertyPath: m_LocalRotation.w

--- a/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefab_Bronze.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefab_Bronze.prefab
@@ -8,11 +8,19 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 353343471043694769, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: f966803060b3d4829b0f54c5c113a6de, type: 2}
     - target: {fileID: 962088534504469245, guid: d18aa0284baff47518ed573eeea77043, type: 3}
       propertyPath: 'm_Materials.Array.data[0]'
       value: 
       objectReference: {fileID: 2100000, guid: f966803060b3d4829b0f54c5c113a6de, type: 2}
     - target: {fileID: 1461737345332978080, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: f966803060b3d4829b0f54c5c113a6de, type: 2}
+    - target: {fileID: 2957789412811354623, guid: d18aa0284baff47518ed573eeea77043, type: 3}
       propertyPath: 'm_Materials.Array.data[0]'
       value: 
       objectReference: {fileID: 2100000, guid: f966803060b3d4829b0f54c5c113a6de, type: 2}
@@ -78,7 +86,7 @@ PrefabInstance:
       objectReference: {fileID: 2100000, guid: f966803060b3d4829b0f54c5c113a6de, type: 2}
     - target: {fileID: 7777184945603898279, guid: d18aa0284baff47518ed573eeea77043, type: 3}
       propertyPath: m_Name
-      value: VeinPrefab_Bronz
+      value: VeinPrefab_Bronze
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefab_Clay.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefab_Clay.prefab
@@ -8,11 +8,19 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 353343471043694769, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 034c74eb7928f453595deb0722b26890, type: 2}
     - target: {fileID: 962088534504469245, guid: d18aa0284baff47518ed573eeea77043, type: 3}
       propertyPath: 'm_Materials.Array.data[0]'
       value: 
       objectReference: {fileID: 2100000, guid: 034c74eb7928f453595deb0722b26890, type: 2}
     - target: {fileID: 1461737345332978080, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 034c74eb7928f453595deb0722b26890, type: 2}
+    - target: {fileID: 2957789412811354623, guid: d18aa0284baff47518ed573eeea77043, type: 3}
       propertyPath: 'm_Materials.Array.data[0]'
       value: 
       objectReference: {fileID: 2100000, guid: 034c74eb7928f453595deb0722b26890, type: 2}

--- a/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefab_Coal.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefab_Coal.prefab
@@ -8,11 +8,19 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 353343471043694769, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 65a119b264eb647318863c1113f79400, type: 2}
     - target: {fileID: 962088534504469245, guid: d18aa0284baff47518ed573eeea77043, type: 3}
       propertyPath: 'm_Materials.Array.data[0]'
       value: 
       objectReference: {fileID: 2100000, guid: 65a119b264eb647318863c1113f79400, type: 2}
     - target: {fileID: 1461737345332978080, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 65a119b264eb647318863c1113f79400, type: 2}
+    - target: {fileID: 2957789412811354623, guid: d18aa0284baff47518ed573eeea77043, type: 3}
       propertyPath: 'm_Materials.Array.data[0]'
       value: 
       objectReference: {fileID: 2100000, guid: 65a119b264eb647318863c1113f79400, type: 2}

--- a/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefab_Copper.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefab_Copper.prefab
@@ -8,11 +8,19 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 353343471043694769, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 08f903dfa8ece42ba98a4d0c25f52552, type: 2}
     - target: {fileID: 962088534504469245, guid: d18aa0284baff47518ed573eeea77043, type: 3}
       propertyPath: 'm_Materials.Array.data[0]'
       value: 
       objectReference: {fileID: 2100000, guid: 08f903dfa8ece42ba98a4d0c25f52552, type: 2}
     - target: {fileID: 1461737345332978080, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 08f903dfa8ece42ba98a4d0c25f52552, type: 2}
+    - target: {fileID: 2957789412811354623, guid: d18aa0284baff47518ed573eeea77043, type: 3}
       propertyPath: 'm_Materials.Array.data[0]'
       value: 
       objectReference: {fileID: 2100000, guid: 08f903dfa8ece42ba98a4d0c25f52552, type: 2}

--- a/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefab_Iron.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefab_Iron.prefab
@@ -8,11 +8,19 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 353343471043694769, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 6f4510534f256454191aa193cc000b6f, type: 2}
     - target: {fileID: 962088534504469245, guid: d18aa0284baff47518ed573eeea77043, type: 3}
       propertyPath: 'm_Materials.Array.data[0]'
       value: 
       objectReference: {fileID: 2100000, guid: 6f4510534f256454191aa193cc000b6f, type: 2}
     - target: {fileID: 1461737345332978080, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 6f4510534f256454191aa193cc000b6f, type: 2}
+    - target: {fileID: 2957789412811354623, guid: d18aa0284baff47518ed573eeea77043, type: 3}
       propertyPath: 'm_Materials.Array.data[0]'
       value: 
       objectReference: {fileID: 2100000, guid: 6f4510534f256454191aa193cc000b6f, type: 2}

--- a/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefab_Tree.prefab
+++ b/moorestech_client/Assets/AddressableResources/Environment/Vein/Item/VeinPrefab_Tree.prefab
@@ -8,11 +8,19 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 353343471043694769, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 1005b563f250042e1a563e73df231266, type: 2}
     - target: {fileID: 962088534504469245, guid: d18aa0284baff47518ed573eeea77043, type: 3}
       propertyPath: 'm_Materials.Array.data[0]'
       value: 
       objectReference: {fileID: 2100000, guid: 1005b563f250042e1a563e73df231266, type: 2}
     - target: {fileID: 1461737345332978080, guid: d18aa0284baff47518ed573eeea77043, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 1005b563f250042e1a563e73df231266, type: 2}
+    - target: {fileID: 2957789412811354623, guid: d18aa0284baff47518ed573eeea77043, type: 3}
       propertyPath: 'm_Materials.Array.data[0]'
       value: 
       objectReference: {fileID: 2100000, guid: 1005b563f250042e1a563e73df231266, type: 2}

--- a/moorestech_server/Assets/Scripts/Core.Master/_CompileRequester.cs
+++ b/moorestech_server/Assets/Scripts/Core.Master/_CompileRequester.cs
@@ -5,5 +5,5 @@ public class CompileRequester
 {
 // スキーマ更新時はこの印もcommit
 // Commit this marker with schema changes
-    private const string dummyText = "82-8E-2B-77-70-A4-25-A0-B0-D6-36-11-9B-81-37-99";
+    private const string dummyText = "2A-14-D1-24-C4-D6-17-45-64-6C-F3-5B-84-AE-6F-14";
 }

--- a/moorestech_server/Assets/Scripts/Game.MapGeneration/Pipeline/Stages/Vein/VeinAabbBuilder.cs
+++ b/moorestech_server/Assets/Scripts/Game.MapGeneration/Pipeline/Stages/Vein/VeinAabbBuilder.cs
@@ -6,9 +6,9 @@ namespace Game.MapGeneration.Pipeline.Stages
     // Builds a fixed-size AABB centred on the point (ADR-0023).
     public static class VeinAabbBuilder
     {
-        // 中心から各軸へ張り出す量。inclusive なので Max-Min = 2・実体は1辺3セル。
-        // The per-axis reach from the centre; inclusive bounds make Max-Min = 2 while the body covers three cells per edge.
-        static readonly Vector3Int Extent = new(1, 1, 1);
+        // 中心から各軸へ張り出す量。XZは3セル、Yは中心1セルのみの3x1x3。
+        // The per-axis reach from the centre; XZ span three cells while Y stays a single centre cell, giving 3x1x3.
+        static readonly Vector3Int Extent = new(1, 0, 1);
 
         public static PlacedVein Build(string veinGuid, Vector3 worldPosition)
         {

--- a/moorestech_server/Assets/Scripts/Tests/UnitTest/Game/MapGeneration/MapGenerationPipelineTest.cs
+++ b/moorestech_server/Assets/Scripts/Tests/UnitTest/Game/MapGeneration/MapGenerationPipelineTest.cs
@@ -54,12 +54,12 @@ namespace Tests.UnitTest.Game.MapGeneration
             Assert.That(output.ItemVeins, Is.Not.Empty);
             Assert.That(output.FluidVeins, Is.Not.Empty);
 
-            // 変換後も鉱脈は Max-Min = 2 の固定AABB
-            // After the transform, every vein keeps a fixed AABB whose Max-Min is 2
+            // 変換後も鉱脈は 3x1x3 の固定AABB
+            // After the transform, every vein keeps a fixed 3x1x3 AABB
             foreach (var vein in output.ItemVeins)
-                Assert.That(vein.Max - vein.Min, Is.EqualTo(new Vector3Int(2, 2, 2)));
+                Assert.That(vein.Max - vein.Min, Is.EqualTo(new Vector3Int(2, 0, 2)));
             foreach (var vein in output.FluidVeins)
-                Assert.That(vein.Max - vein.Min, Is.EqualTo(new Vector3Int(2, 2, 2)));
+                Assert.That(vein.Max - vein.Min, Is.EqualTo(new Vector3Int(2, 0, 2)));
         }
 
         [Test]

--- a/moorestech_server/Assets/Scripts/Tests/UnitTest/Game/MapGeneration/Vein/VeinAabbBuilderTest.cs
+++ b/moorestech_server/Assets/Scripts/Tests/UnitTest/Game/MapGeneration/Vein/VeinAabbBuilderTest.cs
@@ -14,8 +14,8 @@ namespace Tests.UnitTest.Game.MapGeneration
             var vein = VeinAabbBuilder.Build("11111111-1111-1111-1111-111111111111", new Vector3(10f, 20f, 30f));
 
             Assert.That(vein.VeinGuid, Is.EqualTo("11111111-1111-1111-1111-111111111111"));
-            Assert.That(vein.Min, Is.EqualTo(new Vector3Int(9, 19, 29)));
-            Assert.That(vein.Max, Is.EqualTo(new Vector3Int(11, 21, 31)));
+            Assert.That(vein.Min, Is.EqualTo(new Vector3Int(9, 20, 29)));
+            Assert.That(vein.Max, Is.EqualTo(new Vector3Int(11, 20, 31)));
         }
 
         [Test]
@@ -23,8 +23,8 @@ namespace Tests.UnitTest.Game.MapGeneration
         {
             var vein = VeinAabbBuilder.Build("11111111-1111-1111-1111-111111111111", new Vector3(10.4f, 19.6f, -0.4f));
 
-            Assert.That(vein.Min, Is.EqualTo(new Vector3Int(9, 19, -1)));
-            Assert.That(vein.Max, Is.EqualTo(new Vector3Int(11, 21, 1)));
+            Assert.That(vein.Min, Is.EqualTo(new Vector3Int(9, 20, -1)));
+            Assert.That(vein.Max, Is.EqualTo(new Vector3Int(11, 20, 1)));
         }
     }
 }


### PR DESCRIPTION
## Summary
- VeinPrefabBaseへのRock11_*追加でIron/Copper/Coal/ClayのRock11_4・Rock11_5がベースのRocks_no_glassのままだった問題を、各鉱脈のRockマテリアルへ反映
- 鉱脈のAABB生成範囲を修正（VeinAabbBuilder）し、関連ユニットテストを更新
- 上記変更に整合するmoorestech_masterのピンを更新（対応先: moorestech_master PR #33、既にorigin/masterへマージ済み）
- スキーマ再生成マーカー(_CompileRequester.cs)を更新

## Test plan
- [x] moorestech_masterの参照コミットがorigin/masterへマージ済みであることを確認
- [ ] `uloop compile --project-path ./moorestech_client` でコンパイル確認
- [ ] MapGenerationPipelineTest / VeinAabbBuilderTest の該当テストを実行

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected vein map generation bounds to cover a 3×1×3 area, keeping the vertical position fixed.
  * Updated item and fluid vein placement to use the corrected bounds around rounded coordinates.

* **Tests**
  * Added coverage confirming the revised vein dimensions and placement behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->