### PR TITLE
moorestech_client_private のpinをマージ済みterrainアセットへ更新

### DIFF
--- a/.moorestech-external-revisions.json
+++ b/.moorestech-external-revisions.json
@@ -8,7 +8,7 @@
         {
             "key": "moorestech_client_private",
             "relativePath": "moorestech_client/Assets/PersonalAssets/moorestech-client-private",
-            "commitHash": "40cdf1ad0d5d6b8526e08a6e78b75bdd9f3b5f5b"
+            "commitHash": "34f269ec595245d87105e9d8c4c09eba533bb5f6"
         }
     ]
 }


### PR DESCRIPTION
## 概要

`.moorestech-external-revisions.json` の `moorestech_client_private` のpinを
`40cdf1a` → `34f269e` に更新する。差分はこの1行のみ。

## 参照先

[moorestech-client-private#3](https://github.com/moorestech/moorestech-client-private/pull/3)（master にマージ済み・`34f269e`）

- `BK/PureNature*` の全バイオームアセット（11.4GB / 14コミットに分割してpush）
- `VeinPrefab_*` テクスチャ10枚を `Texture2D .asset`（1.06GB）から PNG（118MB）へ変換し、参照する `.mat` を張り替え
- `SpaceShip/landing pod.prefab` に convex MeshCollider を4つ追加
- 100MB超のため未追跡にしたもの: `GeneratedTerrains/`（再生成物）、`Savanna_Terrain.asset`

Git LFSは使用していない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148JjERxaDFx7NQSGPCAq3Q