### PR TITLE
fix: GameDataBundlerの必須ローカライズパスをmod構成へ合わせる

### DIFF
--- a/moorestech_client/Assets/Scripts/Editor/Build/GameDataBundler.cs
+++ b/moorestech_client/Assets/Scripts/Editor/Build/GameDataBundler.cs
@@ -21,8 +21,8 @@ namespace Client.Editor.Build
             // The source of truth is ../moorestech_master/server_v8 beside this repository
             var sourceDirectory = Path.GetFullPath(Path.Combine(Application.dataPath, "..", "..", "..", "moorestech_master", "server_v8"));
 
-            // 必須構成（config/map/mods）が欠けた成果物を出さない
-            // Never ship an artifact missing the required config/map/mods layout
+            // 必須構成（map/mods）が欠けた成果物を出さない
+            // Never ship an artifact missing the required map/mods layout
             var missingPath = FindMissingRequiredPath();
             if (missingPath != string.Empty)
             {
@@ -47,12 +47,16 @@ namespace Client.Editor.Build
                 var modsDirectory = Path.Combine(sourceDirectory, "mods");
                 if (!Directory.Exists(modsDirectory)) return modsDirectory;
 
-                // ランタイムのLocalize.csが読むのはconfig/localization.csvの1点だけ
-                // Localize.cs at runtime reads exactly one file: config/localization.csv
-                var localizationCsv = Path.Combine(sourceDirectory, "config", "localization.csv");
-                if (!File.Exists(localizationCsv)) return localizationCsv;
+                // ランタイムはmodごとのlocalization/localization.csvをマージするので1件も無ければ欠損
+                // At runtime each mod's localization/localization.csv is merged, so zero files means missing
+                var modDirectories = Directory.GetDirectories(modsDirectory);
+                var anyLocalizationCsvPath = Path.Combine(modsDirectory, "*", "localization", "localization.csv");
+                foreach (var modDirectory in modDirectories)
+                {
+                    if (File.Exists(Path.Combine(modDirectory, "localization", "localization.csv"))) return string.Empty;
+                }
 
-                return string.Empty;
+                return anyLocalizationCsvPath;
             }
 
             #endregion


### PR DESCRIPTION
## 問題
Releaseフルビルドが `BuildFailedException: required game data is missing: .../server_v8/config/localization.csv` で失敗する。

## 原因
ローカライズはmod単位（`mods/<modId>/localization/localization.csv` を `ModLocalizationMerger` がマージ）へ移行済みで、`moorestech_master/server_v8` に `config/` は存在しない。`GameDataBundler` の必須判定だけが旧契約のまま取り残されていた。

## 変更
- 必須判定を「mods配下のいずれかに `localization/localization.csv` があること」へ差し替え
- 事実と逆になっていたコメント（「Localize.csが読むのはconfig/localization.csvの1点だけ」「必須構成（config/map/mods）」）を修正

## テスト
未実施（ユーザー指示によりコード修正のみ）。Releaseフルビルドでの同梱確認は bd moorestech-cxcv 側で行う。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7ue2QFLhBghyvCsoGfr8g