### PR TITLE
レシピカタログ見出しの日本語未訳を訳し、流体・車両名を補ったmasterへpinを進める

### DIFF
--- a/.moorestech-external-revisions.json
+++ b/.moorestech-external-revisions.json
@@ -3,7 +3,7 @@
         {
             "key": "moorestech_master",
             "relativePath": "../moorestech_master",
-            "commitHash": "9c5d187d9d93a28af7a40bd22d3b8a48904a06b0"
+            "commitHash": "6e0134551dc66ce9761ea27a2dcef7ec7af3ba6e"
         },
         {
             "key": "moorestech_client_private",

--- a/Localization/localization.csv
+++ b/Localization/localization.csv
@@ -116,7 +116,7 @@ ui.notification.unknownMessage,Unknown notification: {messageId},Unknown notific
 ui.pauseMenu.title,Pause Menu,Pause Menu,ポーズメニュー
 ui.pauseMenu.disconnected,Disconnected from server,Disconnected from server,サーバーから切断されました
 ui.settings.language,Language,Language,言語
-ui.recipe.catalogTitle,CRAFT RECIPE,CRAFT RECIPE,CRAFT RECIPE
+ui.recipe.catalogTitle,CRAFT RECIPE,CRAFT RECIPE,クラフトレシピ
 ui.recipe.selectItemHint,Select an item from the list on the right,Select an item from the list on the right,右のリストからアイテムを選択してください
 ui.recipe.materialTooltip,{itemName}\nOwned: {ownedCount}\nRequired: {requiredCount}\nClick to view recipes for this item,{itemName}\nOwned: {ownedCount}\nRequired: {requiredCount}\nClick to view recipes for this item,{itemName}\n所持数: {ownedCount}\n必要数: {requiredCount}\nクリックでこのアイテムのレシピを確認
 ui.recipe.itemCountSummary,{ownedCount}/{requiredCount},{ownedCount}/{requiredCount},{ownedCount}/{requiredCount}

--- a/moorestech_client/Assets/Scripts/Client.Localization/_CompileRequester.cs
+++ b/moorestech_client/Assets/Scripts/Client.Localization/_CompileRequester.cs
@@ -5,5 +5,5 @@ public class LocalizationCompileRequester
 {
 // CSV更新時はこの印もcommit
 // Commit this marker with CSV changes
-    private const string dummyText = "7B-81-BB-E7-7E-20-AD-4F-5E-7B-37-0F-76-1C-01-A5";
+    private const string dummyText = "46-13-2C-51-95-7E-C5-18-BC-99-EE-52-B8-AD-2F-76";
 }

--- a/moorestech_server/Assets/Scripts/Core.Master/_CompileRequester.cs
+++ b/moorestech_server/Assets/Scripts/Core.Master/_CompileRequester.cs
@@ -5,5 +5,5 @@ public class CompileRequester
 {
 // スキーマ更新時はこの印もcommit
 // Commit this marker with schema changes
-    private const string dummyText = "E4-62-AF-50-C2-AB-70-AD-58-20-FD-26-E3-FF-EF-A5";
+    private const string dummyText = "4C-04-3A-8D-6A-4E-42-64-8B-D9-54-CC-84-51-01-8A";
 }


### PR DESCRIPTION
## 概要

翻訳漏れの棚卸しで見つかった未訳を修正する。データ本体の修正は master repo 側 PR（moorestech/moorestech_master#36）にあり、本PRはバニラ辞書1件の修正とpin更新。

## 変更

- `Localization/localization.csv` の `ui.recipe.catalogTitle` が japanese 列も `CRAFT RECIPE` のままだったため「クラフトレシピ」に訳す（レシピ一覧パネル `ItemListPanel` の見出し）
- pin を moorestech_master#36 のコミットへ更新する。同PRの内容:
  - `fluid.*.name` 9件・`trainCar.*.name` 3件の辞書行を追加（辞書行が存在せず、英語プレイ時に日本語原文へフォールバックしていた）
  - character 3件の japanese 列をローマ字から `ヨリ`/`エレノ`/`クルア` へ
  - masterから削除済みのチャレンジ3件と `uiDragGuide` チュートリアル2件の死にキー8行を削除

## 棚卸しの結果（この修正で漏れ0）

master GUID から導出される全キー（item/block/research/challenge/character/buildMenu/connectTool/fluid/trainCar 等）と辞書を突き合わせ、欠落0・死にキー0・english列の日本語残り0を確認。スキット45文言も英訳欠落0。Web UI 側は `no-jsx-visible-literal` の disable が0件で、`t()` を通さない文字列は辞書ロード失敗時用の `dictionaryIndependentText.ts` のみ。

## 検証

- `uloop compile`: 0 errors
- `uloop run-tests --filter-value "Client\.Tests\.Localization\..*"`: 107/107 passed
- webui `npm run gen:i18n` で生成物に差分が出ないこと（キー集合は不変）を確認
- webui i18nテスト 98/98 passed

## 積み残し

同じ漏れをCIで機械検知する完全性テストを実装したが、出荷masterの `map.json` が現スキーマとズレていて `MasterHolder.Load` 自体が落ちるため、本PRからは切り出した（別issueで追跡）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012kgcYmGWbgriRBJhqzz64J