### PR TITLE
docs: PR #1254の独立レビュー裁定を記録

### DIFF
--- a/.decisions/2026-08-24-PR1254独立レビュー17件は全推奨案を採用し手動適用する.md
+++ b/.decisions/2026-08-24-PR1254独立レビュー17件は全推奨案を採用し手動適用する.md
@@ -1,0 +1,7 @@
+決定: PR #1254 の独立レビュー非suppressed指摘 F01〜F17 は、すべて推奨案Aを採用し、Codexが変更適用・検証・push・完了ラベル付与まで手動で行う。
+
+棄却案: 各指摘の非推奨案B〜C、および通常の無人apply起動とpollerによるラベル遷移に任せる運用。
+
+理由: 指摘内容は全件推奨案でよく、通常経路でClaudeを起動する使用量を節約しつつ同じ裁定結果を反映するため。
+
+リンク: https://review.moores.tech/pr/1254 / https://github.com/moorestech/moorestech/pull/1254 / bd moorestech-4z88.4


### PR DESCRIPTION
PR #1254 の独立レビュー F01〜F17 をすべて推奨案Aで採用し、Codexが手動適用するユーザー裁定を `.decisions/` に記録します。

実装適用先: #1254 / `99c2dd3d5`
Beads: `moorestech-4z88.4`