### PR TITLE
スキット中のみSSAOを切る（SkitCamera専用Rendererを追加）

### DIFF
--- a/moorestech_client/Assets/Asset/Common/URPSettings/URP Data - Skit.asset
+++ b/moorestech_client/Assets/Asset/Common/URPSettings/URP Data - Skit.asset
@@ -1,0 +1,144 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: de640fe3d0db1804a85f9fc8f5cadab6, type: 3}
+  m_Name: URP Data - Skit
+  m_EditorClassIdentifier: 
+  debugShaders:
+    debugReplacementPS: {fileID: 4800000, guid: cf852408f2e174538bcd9b7fda1c5ae7, type: 3}
+    hdrDebugViewPS: {fileID: 4800000, guid: 573620ae32aec764abd4d728906d2587, type: 3}
+    probeVolumeSamplingDebugComputeShader: {fileID: 7200000, guid: 53626a513ea68ce47b59dc1299fe3959, type: 3}
+  probeVolumeResources:
+    probeVolumeDebugShader: {fileID: 0}
+    probeVolumeFragmentationDebugShader: {fileID: 0}
+    probeVolumeOffsetDebugShader: {fileID: 0}
+    probeVolumeSamplingDebugShader: {fileID: 0}
+    probeSamplingDebugMesh: {fileID: 0}
+    probeSamplingDebugTexture: {fileID: 0}
+    probeVolumeBlendStatesCS: {fileID: 0}
+  m_RendererFeatures:
+  - {fileID: 9176458359454757473}
+  m_RendererFeatureMap: 59896c27dc4ee90761f2764b4254597f
+  m_UseNativeRenderPass: 0
+  xrSystemData: {fileID: 11400000, guid: 60e1133243b97e347b653163a8c01b64, type: 2}
+  postProcessData: {fileID: 11400000, guid: 41439944d30ece34e96484bdb6645b55, type: 2}
+  m_AssetVersion: 3
+  m_PrepassLayerMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_OpaqueLayerMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_TransparentLayerMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_DefaultStencilState:
+    overrideStencilState: 0
+    stencilReference: 0
+    stencilCompareFunction: 8
+    passOperation: 2
+    failOperation: 0
+    zFailOperation: 0
+  m_ShadowTransparentReceive: 1
+  m_RenderingMode: 0
+  m_DepthPrimingMode: 0
+  m_CopyDepthMode: 1
+  m_DepthAttachmentFormat: 0
+  m_DepthTextureFormat: 0
+  m_AccurateGbufferNormals: 0
+  m_IntermediateTextureMode: 1
+--- !u!114 &6462834283191547274
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 495e0fa855ec80545a45c2e7717114c8, type: 3}
+  m_Name: ScreenSpaceOutlines
+  m_EditorClassIdentifier: 
+  m_Active: 1
+  renderPassEvent: 300
+  outlinesLayerMask:
+    m_Bits: 0
+  outlinesOccluderLayerMask:
+    m_Bits: 0
+  outlineSettings:
+    outlineColor:
+      r: 0
+      g: 0
+      b: 0
+      a: 1
+    outlineScale: 1
+    depthThreshold: 1.5
+    robertsCrossMultiplier: 100
+    normalThreshold: 0.4
+    steepAngleThreshold: 0.2
+    steepAngleMultiplier: 25
+  viewSpaceNormalsTextureSettings:
+    colorFormat: 0
+    depthBufferBits: 16
+    filterMode: 0
+    backgroundColor:
+      r: 0
+      g: 0
+      b: 0
+      a: 1
+    perObjectData: 0
+    enableDynamicBatching: 0
+    enableInstancing: 0
+--- !u!114 &9176458359454757473
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6b3d386ba5cd94485973aee1479b272e, type: 3}
+  m_Name: OutlinePass
+  m_EditorClassIdentifier: 
+  m_Active: 1
+  settings:
+    passTag: OutlinePass
+    Event: 300
+    filterSettings:
+      RenderQueueType: 0
+      LayerMask:
+        serializedVersion: 2
+        m_Bits: 4294967295
+      PassNames:
+      - OutlineStencil
+      - FillOutlineStencil
+      - Outline
+    overrideMaterial: {fileID: 0}
+    overrideMaterialPassIndex: 0
+    overrideShader: {fileID: 0}
+    overrideShaderPassIndex: 0
+    overrideMode: 1
+    overrideDepthState: 0
+    depthCompareFunction: 4
+    enableWrite: 1
+    stencilSettings:
+      overrideStencilState: 0
+      stencilReference: 0
+      stencilCompareFunction: 8
+      passOperation: 0
+      failOperation: 0
+      zFailOperation: 0
+    cameraSettings:
+      overrideCamera: 0
+      restoreCamera: 1
+      offset: {x: 0, y: 0, z: 0, w: 0}
+      cameraFieldOfView: 60

--- a/moorestech_client/Assets/Asset/Common/URPSettings/URP Data - Skit.asset.meta
+++ b/moorestech_client/Assets/Asset/Common/URPSettings/URP Data - Skit.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cf3fffc199be4461bac6a74c42b96d7b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/moorestech_client/Assets/Asset/Common/URPSettings/UniversalRP-HighQuality.asset
+++ b/moorestech_client/Assets/Asset/Common/URPSettings/UniversalRP-HighQuality.asset
@@ -18,6 +18,7 @@ MonoBehaviour:
   m_RendererData: {fileID: 0}
   m_RendererDataList:
   - {fileID: 11400000, guid: d2b832e00cc582b42ac56766b73decdc, type: 2}
+  - {fileID: 11400000, guid: cf3fffc199be4461bac6a74c42b96d7b, type: 2}
   m_DefaultRendererIndex: 0
   m_RequireDepthTexture: 1
   m_RequireOpaqueTexture: 1

--- a/moorestech_client/Assets/Asset/Common/URPSettings/UniversalRP-LowQuality.asset
+++ b/moorestech_client/Assets/Asset/Common/URPSettings/UniversalRP-LowQuality.asset
@@ -18,6 +18,7 @@ MonoBehaviour:
   m_RendererData: {fileID: 0}
   m_RendererDataList:
   - {fileID: 11400000, guid: d2b832e00cc582b42ac56766b73decdc, type: 2}
+  - {fileID: 11400000, guid: cf3fffc199be4461bac6a74c42b96d7b, type: 2}
   m_DefaultRendererIndex: 0
   m_RequireDepthTexture: 0
   m_RequireOpaqueTexture: 0

--- a/moorestech_client/Assets/Asset/Common/URPSettings/UniversalRP-MediumQuality.asset
+++ b/moorestech_client/Assets/Asset/Common/URPSettings/UniversalRP-MediumQuality.asset
@@ -18,6 +18,7 @@ MonoBehaviour:
   m_RendererData: {fileID: 0}
   m_RendererDataList:
   - {fileID: 11400000, guid: d2b832e00cc582b42ac56766b73decdc, type: 2}
+  - {fileID: 11400000, guid: cf3fffc199be4461bac6a74c42b96d7b, type: 2}
   m_DefaultRendererIndex: 0
   m_RequireDepthTexture: 0
   m_RequireOpaqueTexture: 0

--- a/moorestech_client/Assets/Asset/Common/URPSettings/UniversalRP-UltraLowQuality.asset
+++ b/moorestech_client/Assets/Asset/Common/URPSettings/UniversalRP-UltraLowQuality.asset
@@ -18,6 +18,7 @@ MonoBehaviour:
   m_RendererData: {fileID: 0}
   m_RendererDataList:
   - {fileID: 11400000, guid: d2b832e00cc582b42ac56766b73decdc, type: 2}
+  - {fileID: 11400000, guid: cf3fffc199be4461bac6a74c42b96d7b, type: 2}
   m_DefaultRendererIndex: 0
   m_RequireDepthTexture: 0
   m_RequireOpaqueTexture: 0

--- a/moorestech_client/Assets/Asset/Skit/SkitManager.prefab
+++ b/moorestech_client/Assets/Asset/Skit/SkitManager.prefab
@@ -180,7 +180,7 @@ MonoBehaviour:
   m_RequiresOpaqueTextureOption: 2
   m_CameraType: 0
   m_Cameras: []
-  m_RendererIndex: -1
+  m_RendererIndex: 1
   m_VolumeLayerMask:
     serializedVersion: 2
     m_Bits: 1
@@ -199,7 +199,6 @@ MonoBehaviour:
   m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
   m_RequiresDepthTexture: 0
   m_RequiresColorTexture: 0
-  m_Version: 2
   m_TaaSettings:
     m_Quality: 3
     m_FrameInfluence: 0.1
@@ -207,6 +206,7 @@ MonoBehaviour:
     m_MipBias: 0
     m_VarianceClampScale: 0.9
     m_ContrastAdaptiveSharpening: 0
+  m_Version: 2
 --- !u!114 &366237098242407697
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## 何を

スキット再生中だけ SSAO（Screen Space Ambient Occlusion）を無効にする。通常のゲームプレイ描画は変更なし。

## どうやって

案A（カメラ単位のRenderer差し替え・ランタイムコード無し）。

- `Assets/Asset/Common/URPSettings/URP Data - Skit.asset` を新規追加
  - 既存 `URP Data` の複製から `ScreenSpaceAmbientOcclusion` Renderer Feature のみ除去（`m_RendererFeatureMap` の該当エントリも削除）
  - アウトライン（`OutlinePass`）はそのまま残す
- `UniversalRP-{High,Medium,Low,UltraLow}Quality.asset` の Renderer List へ **すべて index 1** で登録
  - 品質切替でインデックスがズレると別Rendererを引くため、4本で番号を揃えている
- `SkitManager.prefab` の `SkitCamera` の `m_RendererIndex` を `-1`（default）→ `1`

`SkitCamera` は `CameraManager` が enable/disable で排他切り替えする単独のベースカメラなので、Renderer の差し替えが通常カメラへ波及しない。

## 検証

- `uloop compile`: エラー0・警告0
- アセット編集はすべて `uloop execute-dynamic-code`（Unity経由）で実施。テキスト直編集なし
- 差分確認: 4本のURPアセットが index 1 で新Rendererを持つこと、Skit側Rendererの feature が `OutlinePass` のみになっていること
- 実プレイでの見た目確認は未実施（アセットのみの変更のためテスト新設もなし）

## メモ

- `URP Data` 側の設定（アウトライン等）を今後変更する場合、Skit用Rendererも手当てが必要（複製ゆえの保守コスト）
- 元の `URP Data` には feature list に載っていない `ScreenSpaceOutlines` サブアセットが残っており、複製にもそのまま入っている（master 由来。今回は触っていない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019MfZ2xN1cX8bYwXbadUkdN